### PR TITLE
Change sandboxes local hostname to e2b

### DIFF
--- a/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
+++ b/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
@@ -198,7 +198,7 @@ ExecStart=
 ExecStart=-/sbin/agetty --noissue --autologin root %I 115200,38400,9600 vt102
 `
 
-	hostname := "e2b.local"
+	hostname := "e2b"
 
 	hosts := fmt.Sprintf(`127.0.0.1	localhost
 ::1	localhost ip6-localhost ip6-loopback


### PR DESCRIPTION
Change the sandboxes hostname from `e2b.local` to just `e2b`. This should prevent conflicts with mDNS resolver.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Changes the sandbox hostname from `e2b.local` to `e2b` in `packages/orchestrator/internal/template/build/core/rootfs/rootfs.go`, updating the generated `/etc/hosts`.
> 
> - **Rootfs template**:
>   - Update default hostname to `e2b` (from `e2b.local`) in `packages/orchestrator/internal/template/build/core/rootfs/rootfs.go`, which updates the generated `/etc/hosts` entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89bd4d377b1cd6c221726210d0957c1c1c90e399. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->