### PR TITLE
Disable stack traces

### DIFF
--- a/packages/api/internal/auth/middleware.go
+++ b/packages/api/internal/auth/middleware.go
@@ -80,7 +80,7 @@ func (a *commonAuthenticator[T]) Authenticate(ctx context.Context, input *openap
 	headerKey, err := a.getHeaderKeysFromRequest(input.RequestValidationInput.Request)
 	if err != nil {
 		err = fmt.Errorf("%s: %w", a.errorMessage, err)
-		trace.SpanFromContext(ctx).RecordError(err, trace.WithStackTrace(true))
+		trace.SpanFromContext(ctx).RecordError(err)
 
 		return err
 	}

--- a/packages/shared/pkg/logger/logger.go
+++ b/packages/shared/pkg/logger/logger.go
@@ -41,7 +41,7 @@ func NewLogger(_ context.Context, loggerConfig LoggerConfig) (Logger, error) {
 
 	// Console logging configuration
 	config := zap.Config{
-		DisableStacktrace: true,
+		DisableStacktrace: loggerConfig.DisableStacktrace,
 		// Takes stacktraces more liberally
 		Development: true,
 		Sampling:    nil,

--- a/packages/shared/pkg/logger/logger.go
+++ b/packages/shared/pkg/logger/logger.go
@@ -41,7 +41,7 @@ func NewLogger(_ context.Context, loggerConfig LoggerConfig) (Logger, error) {
 
 	// Console logging configuration
 	config := zap.Config{
-		DisableStacktrace: loggerConfig.DisableStacktrace,
+		DisableStacktrace: true,
 		// Takes stacktraces more liberally
 		Development: true,
 		Sampling:    nil,

--- a/packages/shared/pkg/logger/sandbox/logger.go
+++ b/packages/shared/pkg/logger/sandbox/logger.go
@@ -43,7 +43,7 @@ func NewLogger(ctx context.Context, loggerProvider log.LoggerProvider, config Sa
 		ServiceName:       config.ServiceName,
 		IsInternal:        config.IsInternal,
 		IsDebug:           true,
-		DisableStacktrace: !config.IsInternal,
+		DisableStacktrace: true,
 		InitialFields: []zap.Field{
 			zap.String("logger", config.ServiceName),
 		},

--- a/packages/shared/pkg/telemetry/tracing.go
+++ b/packages/shared/pkg/telemetry/tracing.go
@@ -84,7 +84,6 @@ func ReportCriticalError(ctx context.Context, message string, err error, attrs .
 	errorAttrs := append(attrs, attribute.String("error.message", message))
 
 	span.RecordError(fmt.Errorf("%s: %w", message, err),
-		trace.WithStackTrace(true),
 		trace.WithAttributes(
 			errorAttrs...,
 		),
@@ -100,7 +99,6 @@ func ReportError(ctx context.Context, message string, err error, attrs ...attrib
 	logger.L().With(attributesToZapFields(attrs...)...).Warn(ctx, message, zap.Stringp("debug_id", debugID), zap.Error(err))
 
 	span.RecordError(fmt.Errorf("%s: %w", message, err),
-		trace.WithStackTrace(true),
 		trace.WithAttributes(
 			attrs...,
 		),


### PR DESCRIPTION
These extra logs provide very little value, but take up a lot of physical and visual space