### PR TITLE
add AddCallerSkip(1) so we aren't having the logger log itself

### DIFF
--- a/packages/shared/pkg/logger/grpc.go
+++ b/packages/shared/pkg/logger/grpc.go
@@ -61,7 +61,7 @@ func GRPCLogger(l Logger) logging.Logger {
 		}
 		f = f[:fieldsCount]
 
-		logger := l.WithOptions(zap.AddCallerSkip(1)).With(f...)
+		logger := l.WithOptions(zap.WithCaller(false)).With(f...)
 
 		methodFullName := fmt.Sprintf("%s/%s/%s",
 			methodFullNameMap["grpc.service"],

--- a/packages/shared/pkg/logger/logger.go
+++ b/packages/shared/pkg/logger/logger.go
@@ -117,7 +117,7 @@ func NewTracedLogger(innerLogger *zap.Logger) Logger {
 }
 
 func L() *TracedLogger {
-	return &TracedLogger{innerLogger: withTraceLoggerOptions(zap.L())} //nolint:forbidigo // zap.L is used to get the global logger
+	return &TracedLogger{innerLogger: zap.L()} //nolint:forbidigo // zap.L is used to get the global logger
 }
 
 func NewNopLogger() *TracedLogger {

--- a/packages/shared/pkg/logger/logger.go
+++ b/packages/shared/pkg/logger/logger.go
@@ -101,20 +101,27 @@ type TracedLogger struct {
 	innerLogger *zap.Logger
 }
 
+func withTraceLoggerOptions(innerLogger *zap.Logger) *zap.Logger {
+	return innerLogger.WithOptions(
+		zap.AddCaller(),
+		zap.AddCallerSkip(1),
+	)
+}
+
 func NewTracedLoggerFromCore(core zapcore.Core) Logger {
-	return &TracedLogger{innerLogger: zap.New(core)} //nolint:forbidigo // zap.New is used to create a new logger from a core
+	return &TracedLogger{innerLogger: withTraceLoggerOptions(zap.New(core))} //nolint:forbidigo // zap.New is used to create a new logger from a core
 }
 
 func NewTracedLogger(innerLogger *zap.Logger) Logger {
-	return &TracedLogger{innerLogger: innerLogger}
+	return &TracedLogger{innerLogger: withTraceLoggerOptions(innerLogger)}
 }
 
 func L() *TracedLogger {
-	return &TracedLogger{innerLogger: zap.L()} //nolint:forbidigo // zap.L is used to get the global logger
+	return &TracedLogger{innerLogger: withTraceLoggerOptions(zap.L())} //nolint:forbidigo // zap.L is used to get the global logger
 }
 
 func NewNopLogger() *TracedLogger {
-	return &TracedLogger{innerLogger: zap.NewNop()} //nolint:forbidigo // zap.NewNop is used to create a new nop logger
+	return &TracedLogger{innerLogger: withTraceLoggerOptions(zap.NewNop())} //nolint:forbidigo // zap.NewNop is used to create a new nop logger
 }
 
 func NewDevelopmentLogger() (Logger, error) {

--- a/packages/shared/pkg/logger/logger_test.go
+++ b/packages/shared/pkg/logger/logger_test.go
@@ -12,7 +12,7 @@ func TestTracedLoggerCallerSkipsWrapper(t *testing.T) {
 	t.Parallel()
 
 	core, logs := observer.New(zap.InfoLevel)
-	logger := NewTracedLogger(zap.New(core))
+	logger := NewTracedLogger(zap.New(core)) //nolint:forbidigo // test needs a raw zap.Logger with observable core
 
 	logger.Warn(t.Context(), "wrapper skip test")
 
@@ -34,7 +34,7 @@ func TestLAfterReplaceGlobalsCallerIsCorrect(t *testing.T) {
 	t.Parallel()
 
 	core, logs := observer.New(zap.InfoLevel)
-	logger := NewTracedLogger(zap.New(core))
+	logger := NewTracedLogger(zap.New(core)) //nolint:forbidigo // test needs a raw zap.Logger with observable core
 
 	undo := ReplaceGlobals(t.Context(), logger)
 	defer undo()

--- a/packages/shared/pkg/logger/logger_test.go
+++ b/packages/shared/pkg/logger/logger_test.go
@@ -1,0 +1,58 @@
+package logger
+
+import (
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestTracedLoggerCallerSkipsWrapper(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zap.InfoLevel)
+	logger := NewTracedLogger(zap.New(core))
+
+	logger.Warn(t.Context(), "wrapper skip test")
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+
+	entry := entries[0]
+	if got := filepath.Base(entry.Caller.File); got != "logger_test.go" {
+		t.Fatalf("expected caller file logger_test.go, got %q", entry.Caller.File)
+	}
+	if entry.Caller.Line == 0 {
+		t.Fatal("expected caller line to be set")
+	}
+}
+
+func TestLAfterReplaceGlobalsCallerIsCorrect(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zap.InfoLevel)
+	logger := NewTracedLogger(zap.New(core))
+
+	undo := ReplaceGlobals(t.Context(), logger)
+	defer undo()
+
+	// L() wraps zap.L() which already has AddCallerSkip(1) from ReplaceGlobals.
+	// This test verifies L() does not double-apply the skip.
+	L().Info(t.Context(), "global logger test")
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+
+	entry := entries[0]
+	if got := filepath.Base(entry.Caller.File); got != "logger_test.go" {
+		t.Fatalf("expected caller file logger_test.go, got %q (double AddCallerSkip?)", entry.Caller.File)
+	}
+	if entry.Caller.Line == 0 {
+		t.Fatal("expected caller line to be set")
+	}
+}


### PR DESCRIPTION
cleans up logs by logging the root location the log occured rather than the location of the logger

previous behavior for, e.g. `Cluster instances: Failed to synchronize` would show the lgger as the code logging:

```
code_file_path
/build/shared/pkg/logger/logger.go

code_function_name
github.com/e2b-dev/infra/packages/shared/pkg/logger.(*TracedLogger).Error

code_line_number
142

code_stacktrace
github.com/e2b-dev/infra/packages/shared/pkg/logger.(*TracedLogger).Error
	/build/shared/pkg/logger/logger.go:142
github.com/e2b-dev/infra/packages/shared/pkg/synchronization.(*Synchronize[...]).Start
	/build/shared/pkg/synchronization/synchronization.go:75

detected_level
error 
```

now, we get what actually called the logger

```
code_file_path
/build/shared/pkg/synchronization/synchronization.go

code_function_name
github.com/e2b-dev/infra/packages/shared/pkg/synchronization.(*Synchronize[...]).Start

code_line_number
75

code_stacktrace
github.com/e2b-dev/infra/packages/shared/pkg/synchronization.(*Synchronize[...]).Start
	/build/shared/pkg/synchronization/synchronization.go:75

detected_level
error
```





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only logging metadata (caller attribution) and adds tests, but it may affect downstream log parsing/alerting that depends on caller fields.
> 
> **Overview**
> Updates `TracedLogger` construction to always enable caller reporting with `zap.AddCallerSkip(1)` so logs point at the original call site instead of the wrapper, while `GRPCLogger` now disables caller emission to avoid incorrect gRPC middleware attribution; adds tests to ensure caller file/line are correct and that `L()` doesn’t double-apply caller skipping after `ReplaceGlobals`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9136c6df10c4b149887c3e410c1009382ee26c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->