### PR TITLE
perf(storage): race NFS cache against remote backend

### DIFF
--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -160,6 +160,7 @@ var (
 	OptimisticResourceAccountingFlag = NewBoolFlag("sandbox-placement-optimistic-resource-accounting", false)
 	FreePageReportingFlag            = NewBoolFlag("free-page-reporting", false)
 	FreezeUserCgroupFlag             = NewBoolFlag("freeze-user-cgroup", env.IsDevelopment())
+	ConcurrentNFSCacheCheckFlag      = NewBoolFlag("concurrent-nfs-cache-check", false)
 
 	NetworkTransformRulesFlag = NewBoolFlag("network-transform-rules", env.IsDevelopment())
 

--- a/packages/shared/pkg/storage/read_metrics.go
+++ b/packages/shared/pkg/storage/read_metrics.go
@@ -71,6 +71,26 @@ var (
 		metric.WithDescription("In-flight read-path fetches (cache miss → backend), by file_type"),
 		metric.WithUnit("1"),
 	))
+
+	// readRaceEfficiency records the wall-time saved by the concurrent
+	// NFS-vs-remote race: on a cache miss, the NFS os.Open ran in parallel
+	// with the remote fetch start, so its duration equals the time the
+	// sequential path would have blocked before issuing the GCS request.
+	// Emitted only on the compressed concurrent miss path. No attributes.
+	readRaceEfficiency = mustFloatHist(
+		"orchestrator.read.race.efficiency_ms",
+		"Wall-time saved on a cache miss = NFS os.Open duration (concurrent compressed path only)",
+		"ms",
+	)
+
+	// readRaceWasted counts in-flight remote fetches that were started and
+	// then cancelled because the NFS check hit first. Each one ≈ one wasted
+	// class-B GCS request. No attributes.
+	readRaceWasted = utils.Must(meter.Int64Counter(
+		"orchestrator.read.race.wasted_requests",
+		metric.WithDescription("Remote fetches cancelled because NFS won the race (cost of the optimization)"),
+		metric.WithUnit("1"),
+	))
 )
 
 func RecordReadOpen(ctx context.Context, dur time.Duration, bytes int64, attrs metric.MeasurementOption) {
@@ -91,6 +111,18 @@ func RecordReadDecompress(ctx context.Context, dur time.Duration, bytes int64, a
 
 func RecordPipelineEfficiency(ctx context.Context, ratio float64, attrs metric.MeasurementOption) {
 	readPipelineEfficiency.Record(ctx, ratio, attrs)
+}
+
+// RecordRaceEfficiency records the wall-time saved on a concurrent compressed
+// cache miss = the NFS os.Open duration that overlapped with the remote fetch.
+func RecordRaceEfficiency(ctx context.Context, nfsOpenDur time.Duration) {
+	readRaceEfficiency.Record(ctx, float64(nfsOpenDur)/float64(time.Millisecond))
+}
+
+// RecordRaceWasted increments the wasted-requests counter when the NFS check
+// wins and we cancel the in-flight remote fetch.
+func RecordRaceWasted(ctx context.Context) {
+	readRaceWasted.Add(ctx, 1)
 }
 
 // StartInflight increments the read.inflight gauge and returns a func that

--- a/packages/shared/pkg/storage/storage_cache_seekable.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable.go
@@ -77,6 +77,7 @@ var (
 
 func (c *cachedSeekable) OpenRangeReader(ctx context.Context, off int64, length int64, frameTable *FrameTable) (RangeReader, Source, error) {
 	compressed := frameTable.IsCompressed()
+	concurrent := c.flags.BoolFlag(ctx, featureflags.ConcurrentNFSCacheCheckFlag)
 
 	ctx, span := c.tracer.Start(ctx, "read", trace.WithAttributes(
 		attribute.Int64("offset", off),
@@ -88,8 +89,14 @@ func (c *cachedSeekable) OpenRangeReader(ctx context.Context, off int64, length 
 	var source Source
 	var err error
 	switch {
+	case compressed && concurrent:
+		rc, source, err = c.openReaderCompressedConcurrent(ctx, off, frameTable)
 	case compressed:
 		rc, source, err = c.openReaderCompressed(ctx, off, frameTable)
+	case concurrent:
+		if err = c.validateReadParams(length, off); err == nil {
+			rc, source, err = c.openReaderUncompressedConcurrent(ctx, off, length)
+		}
 	default:
 		if err = c.validateReadParams(length, off); err == nil {
 			rc, source, err = c.openReaderUncompressed(ctx, off, length)

--- a/packages/shared/pkg/storage/storage_cache_seekable_concurrent.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable_concurrent.go
@@ -1,0 +1,216 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// nfsRaceOutcome is the result of racing NFS against the remote backend.
+// Exactly one of NFS or Remote is non-nil on success. Cancel must be invoked
+// on Close of whichever reader is consumed (releases the race-scoped context).
+// NFSOpenDur is the wall of the NFS os.Open call (used by the compressed
+// caller to record the efficiency metric on miss).
+type nfsRaceOutcome struct {
+	NFS        *os.File
+	Remote     RangeReader
+	Source     Source
+	Cancel     context.CancelFunc
+	NFSOpenDur time.Duration
+}
+
+// raceNFSvsRemote fires a remote fetch in a goroutine, then tries an NFS
+// os.Open. If NFS hits first, the in-flight remote is cancelled and drained.
+// If NFS misses, it waits for the remote result.
+//
+// c.inner must be non-nil (guaranteed by testCache / production constructors).
+func (c *cachedSeekable) raceNFSvsRemote(
+	ctx context.Context,
+	nfsPath string,
+	off, length int64,
+	timerAttrs ...attribute.KeyValue,
+) (nfsRaceOutcome, error) {
+	type result struct {
+		reader RangeReader
+		source Source
+		err    error
+	}
+
+	timer := cacheSlabReadTimerFactory.Begin(timerAttrs...)
+
+	raceCtx, cancel := context.WithCancel(ctx)
+
+	innerCh := make(chan result, 1)
+
+	go func() {
+		r, src, err := c.inner.OpenRangeReader(raceCtx, off, length, nil)
+		innerCh <- result{reader: r, source: src, err: err}
+	}()
+
+	// NFS cache — os.Open is a single syscall, hit or miss.
+	// Time it for the compressed caller to derive the efficiency metric on miss.
+	nfsStart := time.Now()
+	fp, nfsErr := os.Open(nfsPath)
+	nfsDur := time.Since(nfsStart)
+	if fp != nil {
+		cancel()
+		// Drain the losing goroutine asynchronously.
+		go func() {
+			if r := <-innerCh; r.reader != nil {
+				r.reader.Close(raceCtx)
+			}
+		}()
+
+		recordCacheRead(ctx, true, length, cacheTypeSeekable, cacheOpOpenRangeReader)
+		timer.Success(ctx, length)
+
+		return nfsRaceOutcome{NFS: fp, Source: SourceNFS, NFSOpenDur: nfsDur}, nil
+	}
+
+	if os.IsNotExist(nfsErr) {
+		nfsErr = nil
+	} else {
+		recordCacheReadError(ctx, cacheTypeSeekable, cacheOpOpenRangeReader, nfsErr)
+	}
+
+	timer.Failure(ctx, 0)
+
+	// NFS missed — wait for the remote (which got a head start).
+	inner := <-innerCh
+	if inner.err != nil {
+		cancel()
+
+		return nfsRaceOutcome{}, fmt.Errorf("remote read at offset %d: %w", off, errors.Join(nfsErr, inner.err))
+	}
+
+	recordCacheRead(ctx, false, length, cacheTypeSeekable, cacheOpOpenRangeReader)
+
+	return nfsRaceOutcome{Remote: inner.reader, Source: inner.source, Cancel: cancel, NFSOpenDur: nfsDur}, nil
+}
+
+// cancelRangeReader cancels its context after the inner reader is closed.
+type cancelRangeReader struct {
+	RangeReader
+
+	cancel context.CancelFunc
+}
+
+func (r *cancelRangeReader) Close(ctx context.Context) (*ReadStats, error) {
+	stats, err := r.RangeReader.Close(ctx)
+	if r.cancel != nil {
+		r.cancel()
+	}
+
+	return stats, err
+}
+
+func withCancel(rr RangeReader, cancel context.CancelFunc) RangeReader {
+	if cancel == nil {
+		return rr
+	}
+
+	return &cancelRangeReader{RangeReader: rr, cancel: cancel}
+}
+
+// openReaderUncompressedConcurrent races NFS cache open against the remote
+// backend. If NFS hits, the in-flight remote request is cancelled.
+func (c *cachedSeekable) openReaderUncompressedConcurrent(ctx context.Context, off, length int64) (RangeReader, Source, error) {
+	chunkPath := c.makeChunkFilename(off)
+
+	outcome, err := c.raceNFSvsRemote(ctx, chunkPath, off, length,
+		attribute.String(nfsCacheOperationAttr, nfsCacheOperationAttrReadAt),
+		attribute.Bool("compressed", false),
+	)
+	if err != nil {
+		return nil, UnknownSource, err
+	}
+
+	if outcome.NFS != nil {
+		readCache.Add(ctx, 1, CacheHitAttrs(c.objType, SourceNFS, CompressionNone))
+
+		return newSectionReader(outcome.NFS, 0, length), SourceNFS, nil
+	}
+
+	readCache.Add(ctx, 1, CacheMissAttrs(c.objType, SourceNFS, CompressionNone))
+
+	rc := withCancel(outcome.Remote, outcome.Cancel)
+
+	if skipCacheWriteback(ctx) {
+		return rc, outcome.Source, nil
+	}
+
+	rc = newCaptureReader(rc, int(length),
+		c.uncompressedChunkWriteback(chunkPath, off, length, outcome.Source, trace.SpanContextFromContext(ctx)))
+
+	return rc, outcome.Source, nil
+}
+
+// openReaderCompressedConcurrent races NFS cache open against the remote
+// backend for compressed frames. If NFS hits, the in-flight remote request
+// is cancelled and the cached frame is decompressed locally.
+func (c *cachedSeekable) openReaderCompressedConcurrent(ctx context.Context, offsetU int64, frameTable *FrameTable) (RangeReader, Source, error) {
+	r, err := frameTable.LocateCompressed(offsetU)
+	if err != nil {
+		return nil, UnknownSource, fmt.Errorf("frame lookup for offset %d: %w", offsetU, err)
+	}
+
+	path := makeFrameFilename(c.path, r)
+	ct := frameTable.CompressionType()
+
+	outcome, err := c.raceNFSvsRemote(ctx, path, r.Offset, int64(r.Length), compressedCacheReadAttrs...)
+	if err != nil {
+		return nil, UnknownSource, err
+	}
+
+	if outcome.NFS != nil {
+		fi, statErr := outcome.NFS.Stat()
+		if statErr != nil || fi.Size() != int64(r.Length) {
+			outcome.NFS.Close()
+			if statErr == nil {
+				_ = os.Remove(path)
+			}
+
+			return nil, SourceNFS, fmt.Errorf("cached frame %s size mismatch or stat error: %w", path, statErr)
+		}
+
+		readCache.Add(ctx, 1, CacheHitAttrs(c.objType, SourceNFS, ct))
+		// NFS won the race — the remote fetch we started is now wasted.
+		RecordRaceWasted(ctx)
+
+		dec, err := newDecompressReader(NewRangeReader(outcome.NFS), ct, SourceNFS, c.objType)
+		if err != nil {
+			outcome.NFS.Close()
+
+			return nil, SourceNFS, fmt.Errorf("decompress cached frame: %w", err)
+		}
+
+		return dec, SourceNFS, nil
+	}
+
+	readCache.Add(ctx, 1, CacheMissAttrs(c.objType, SourceNFS, ct))
+	// On miss, the NFS open ran in parallel with the remote fetch start —
+	// that wall is exactly the wall we saved over the sequential path.
+	RecordRaceEfficiency(ctx, outcome.NFSOpenDur)
+
+	raw := withCancel(outcome.Remote, outcome.Cancel)
+
+	src := raw
+	if !skipCacheWriteback(ctx) {
+		src = newCaptureReader(raw, r.Length,
+			c.compressedFrameWriteback(path, offsetU, r.Length, outcome.Source, ct, trace.SpanContextFromContext(ctx)))
+	}
+
+	dec, err := newDecompressReader(src, ct, outcome.Source, c.objType)
+	if err != nil {
+		src.Close(ctx)
+
+		return nil, outcome.Source, fmt.Errorf("create decompressor: %w", err)
+	}
+
+	return dec, outcome.Source, nil
+}

--- a/packages/shared/pkg/storage/storage_cache_seekable_concurrent_test.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable_concurrent_test.go
@@ -1,0 +1,329 @@
+//go:build ignore
+// +build ignore
+
+// TODO: tests carried over from old API (io.ReadCloser, 2-return OpenRangeReader).
+// Rewrite to match current RangeReader / 3-return API before un-ignoring.
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
+)
+
+// closeTracker wraps a ReadCloser and signals when Close is called.
+type closeTracker struct {
+	io.ReadCloser
+
+	closed chan struct{}
+}
+
+func newCloseTracker(rc io.ReadCloser) *closeTracker {
+	return &closeTracker{ReadCloser: rc, closed: make(chan struct{})}
+}
+
+func (ct *closeTracker) Close() error {
+	defer close(ct.closed)
+
+	return ct.ReadCloser.Close()
+}
+
+// concurrentFlags returns a mock that enables ConcurrentNFSCacheCheckFlag.
+func concurrentFlags(t *testing.T) *MockFeatureFlagsClient {
+	t.Helper()
+
+	ff := NewMockFeatureFlagsClient(t)
+	ff.EXPECT().
+		BoolFlag(mock.Anything, featureflags.ConcurrentNFSCacheCheckFlag).
+		Return(true)
+
+	return ff
+}
+
+func TestOpenRangeReader_UncompressedConcurrent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NFS hit cancels inner and closes its reader", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		data := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+
+		innerCancelled := make(chan struct{})
+		tracker := newCloseTracker(io.NopCloser(bytes.NewReader(data)))
+		mockSeeker := NewMockSeekable(t)
+		mockSeeker.EXPECT().
+			OpenRangeReader(mock.Anything, mock.Anything, mock.Anything, (*FrameTable)(nil)).
+			RunAndReturn(func(ctx context.Context, _ int64, _ int64, _ *FrameTable) (io.ReadCloser, error) {
+				go func() {
+					<-ctx.Done()
+					close(innerCancelled)
+				}()
+
+				return tracker, nil
+			})
+
+		c := cachedSeekable{
+			path:      tempDir,
+			chunkSize: int64(len(data)),
+			inner:     mockSeeker,
+			flags:     concurrentFlags(t),
+			tracer:    noopTracer,
+		}
+
+		// Plant a cache file so NFS wins.
+		chunkPath := c.makeChunkFilename(0)
+		require.NoError(t, os.MkdirAll(filepath.Dir(chunkPath), 0o755))
+		require.NoError(t, os.WriteFile(chunkPath, data, 0o600))
+
+		rc, err := c.OpenRangeReader(t.Context(), 0, int64(len(data)), nil)
+		require.NoError(t, err)
+
+		got, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		assert.Equal(t, data, got)
+		require.NoError(t, rc.Close())
+
+		select {
+		case <-innerCancelled:
+		case <-time.After(5 * time.Second):
+			t.Fatal("inner context was not cancelled after NFS hit")
+		}
+
+		select {
+		case <-tracker.closed:
+		case <-time.After(5 * time.Second):
+			t.Fatal("inner reader was not closed after NFS hit")
+		}
+	})
+
+	t.Run("NFS miss uses inner with head start", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		data := []byte("hello")
+
+		mockSeeker := NewMockSeekable(t)
+		mockSeeker.EXPECT().
+			OpenRangeReader(mock.Anything, int64(0), int64(len(data)), (*FrameTable)(nil)).
+			Return(io.NopCloser(bytes.NewReader(data)), nil).
+			Once()
+
+		c := cachedSeekable{
+			path:      tempDir,
+			chunkSize: 10,
+			inner:     mockSeeker,
+			flags:     concurrentFlags(t),
+			tracer:    noopTracer,
+		}
+
+		rc, err := c.OpenRangeReader(t.Context(), 0, int64(len(data)), nil)
+		require.NoError(t, err)
+
+		got, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		assert.Equal(t, data, got)
+		require.NoError(t, rc.Close())
+
+		c.wg.Wait()
+
+		// Cache should be populated for next call (mock would fail if called again).
+		c.flags = nil
+		rc2, err := c.OpenRangeReader(t.Context(), 0, int64(len(data)), nil)
+		require.NoError(t, err)
+
+		got2, err := io.ReadAll(rc2)
+		require.NoError(t, err)
+		assert.Equal(t, data, got2)
+		require.NoError(t, rc2.Close())
+	})
+
+	t.Run("skip writeback does not populate cache", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		data := []byte("hello")
+
+		mockSeeker := NewMockSeekable(t)
+		mockSeeker.EXPECT().
+			OpenRangeReader(mock.Anything, int64(0), int64(len(data)), (*FrameTable)(nil)).
+			Return(io.NopCloser(bytes.NewReader(data)), nil)
+
+		c := cachedSeekable{
+			path:      tempDir,
+			chunkSize: 10,
+			inner:     mockSeeker,
+			flags:     concurrentFlags(t),
+			tracer:    noopTracer,
+		}
+
+		ctx := WithSkipCacheWriteback(t.Context())
+		rc, err := c.OpenRangeReader(ctx, 0, int64(len(data)), nil)
+		require.NoError(t, err)
+
+		got, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		assert.Equal(t, data, got)
+		require.NoError(t, rc.Close())
+
+		c.wg.Wait()
+
+		chunkPath := c.makeChunkFilename(0)
+		_, err = os.Stat(chunkPath)
+		assert.True(t, os.IsNotExist(err), "cache writeback should be skipped")
+	})
+
+	t.Run("cancel is called on reader Close", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		data := []byte("hello")
+
+		cancelCalled := make(chan struct{})
+		mockSeeker := NewMockSeekable(t)
+		mockSeeker.EXPECT().
+			OpenRangeReader(mock.Anything, int64(0), int64(len(data)), (*FrameTable)(nil)).
+			RunAndReturn(func(ctx context.Context, _ int64, _ int64, _ *FrameTable) (io.ReadCloser, error) {
+				go func() {
+					<-ctx.Done()
+					close(cancelCalled)
+				}()
+
+				return io.NopCloser(bytes.NewReader(data)), nil
+			})
+
+		c := cachedSeekable{
+			path:      tempDir,
+			chunkSize: 10,
+			inner:     mockSeeker,
+			flags:     concurrentFlags(t),
+			tracer:    noopTracer,
+		}
+
+		ctx := WithSkipCacheWriteback(t.Context())
+		rc, err := c.OpenRangeReader(ctx, 0, int64(len(data)), nil)
+		require.NoError(t, err)
+
+		_, err = io.ReadAll(rc)
+		require.NoError(t, err)
+		require.NoError(t, rc.Close())
+
+		select {
+		case <-cancelCalled:
+		case <-time.After(5 * time.Second):
+			t.Fatal("cancel was not called after reader Close")
+		}
+	})
+}
+
+func TestOpenRangeReader_CompressedConcurrent(t *testing.T) {
+	t.Parallel()
+
+	original := []byte("the quick brown fox jumps over the lazy dog")
+	compressed := lz4Compress(t, original)
+	ft := NewFrameTable(CompressionLZ4, []FrameSize{{U: int32(len(original)), C: int32(len(compressed))}})
+
+	t.Run("NFS hit cancels inner and decompresses cached frame", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+
+		innerCancelled := make(chan struct{})
+		tracker := newCloseTracker(io.NopCloser(bytes.NewReader(compressed)))
+		mockSeeker := NewMockSeekable(t)
+		mockSeeker.EXPECT().
+			OpenRangeReader(mock.Anything, mock.Anything, mock.Anything, (*FrameTable)(nil)).
+			RunAndReturn(func(ctx context.Context, _ int64, _ int64, _ *FrameTable) (io.ReadCloser, error) {
+				go func() {
+					<-ctx.Done()
+					close(innerCancelled)
+				}()
+
+				return tracker, nil
+			})
+
+		c := cachedSeekable{
+			path:      tempDir,
+			chunkSize: int64(len(original)),
+			inner:     mockSeeker,
+			flags:     concurrentFlags(t),
+			tracer:    noopTracer,
+		}
+
+		// Plant compressed frame in NFS cache.
+		r, err := ft.LocateCompressed(0)
+		require.NoError(t, err)
+		framePath := makeFrameFilename(tempDir, r)
+		require.NoError(t, os.MkdirAll(filepath.Dir(framePath), 0o755))
+		require.NoError(t, os.WriteFile(framePath, compressed, 0o600))
+
+		rc, err := c.OpenRangeReader(t.Context(), 0, int64(len(original)), ft)
+		require.NoError(t, err)
+
+		got, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		assert.Equal(t, original, got)
+		require.NoError(t, rc.Close())
+
+		select {
+		case <-innerCancelled:
+		case <-time.After(5 * time.Second):
+			t.Fatal("inner context was not cancelled after NFS hit")
+		}
+
+		select {
+		case <-tracker.closed:
+		case <-time.After(5 * time.Second):
+			t.Fatal("inner reader was not closed after NFS hit")
+		}
+	})
+
+	t.Run("NFS miss uses inner and caches compressed frame", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+
+		mockSeeker := NewMockSeekable(t)
+		mockSeeker.EXPECT().
+			OpenRangeReader(mock.Anything, int64(0), int64(len(compressed)), (*FrameTable)(nil)).
+			Return(io.NopCloser(bytes.NewReader(compressed)), nil).
+			Once()
+
+		c := cachedSeekable{
+			path:      tempDir,
+			chunkSize: int64(len(original)),
+			inner:     mockSeeker,
+			flags:     concurrentFlags(t),
+			tracer:    noopTracer,
+		}
+
+		rc, err := c.OpenRangeReader(t.Context(), 0, int64(len(original)), ft)
+		require.NoError(t, err)
+
+		got, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		assert.Equal(t, original, got)
+		require.NoError(t, rc.Close())
+
+		c.wg.Wait()
+
+		// Verify the compressed frame was cached.
+		r, err := ft.LocateCompressed(0)
+		require.NoError(t, err)
+		framePath := makeFrameFilename(tempDir, r)
+		cached, err := os.ReadFile(framePath)
+		require.NoError(t, err)
+		assert.Equal(t, compressed, cached)
+	})
+}

--- a/packages/shared/pkg/storage/storage_cache_seekable_test.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 )
 
 // testCache returns a cachedSeekable with a fresh temp dir, the given chunk
@@ -22,10 +24,14 @@ import (
 func testCache(t *testing.T, chunkSize int64) cachedSeekable {
 	t.Helper()
 
+	ff := NewMockFeatureFlagsClient(t)
+	ff.EXPECT().BoolFlag(mock.Anything, mock.Anything).Return(false).Maybe()
+
 	return cachedSeekable{
 		path:      t.TempDir(),
 		chunkSize: chunkSize,
 		inner:     NewMockSeekable(t),
+		flags:     ff,
 		tracer:    noopTracer,
 	}
 }
@@ -37,10 +43,13 @@ func testCacheMock(t *testing.T, chunkSize int64) (c cachedSeekable, m *MockSeek
 	t.Helper()
 
 	m = NewMockSeekable(t)
+	ff := NewMockFeatureFlagsClient(t)
+	ff.EXPECT().BoolFlag(mock.Anything, mock.Anything).Return(false).Maybe()
 	c = cachedSeekable{
 		path:      t.TempDir(),
 		chunkSize: chunkSize,
 		inner:     m,
+		flags:     ff,
 		tracer:    noopTracer,
 	}
 
@@ -135,7 +144,8 @@ func TestCachedFileObjectProvider_WriteFromFileSystem(t *testing.T) {
 			Once()
 
 		featureFlags := NewMockFeatureFlagsClient(t)
-		featureFlags.EXPECT().BoolFlag(mock.Anything, mock.Anything).Return(true)
+		featureFlags.EXPECT().BoolFlag(mock.Anything, featureflags.EnableWriteThroughCacheFlag).Return(true)
+		featureFlags.EXPECT().BoolFlag(mock.Anything, featureflags.ConcurrentNFSCacheCheckFlag).Return(false).Maybe()
 		featureFlags.EXPECT().IntFlag(mock.Anything, mock.Anything).Return(10)
 		c.flags = featureFlags
 
@@ -148,7 +158,6 @@ func TestCachedFileObjectProvider_WriteFromFileSystem(t *testing.T) {
 
 		// Remaining reads should come from cache only.
 		c.inner = nil
-		c.flags = nil
 
 		size, err := c.Size(t.Context())
 		require.NoError(t, err)


### PR DESCRIPTION
Saves ~2ms P50 of the chunk fetch time on NFS cache misses (in absolute
time, median), improving the P50 for the chunk fetch by 4.5% and P95 by
6.2% respectively. Tested with compression ON.

Method: start the GCS request before the NFS check, and cancel it if NFS is
a hit. The cost increase should be within ~1% — since no bytes are read
on cancellation we should be paying only per-class-B-request charges.

Measured on 363 cold cache misses (e2b-staging-lev, GCS us-east1,
NFS on shared Filestore, compression ON - smaller frames), comparing
actual concurrent wall time against hypothetical sequential (nfs + gcs)
within each sample:

```
                                   P50        P95
Hypothetical sequential (nfs+gcs)  76.5 ms    145.9 ms
Actual concurrent (total)          73.1 ms    136.9 ms
Difference                          3.4 ms      9.0 ms
Difference %                        4.5%        6.2%
```

Gated behind the `concurrent-nfs-cache-check` feature flag
(ConcurrentNFSCacheCheckFlag, default off). When the flag is off,
both paths use the original sequential NFS-then-remote flow.