### PR TITLE
Support a flag configured to passthrough to env var

### DIFF
--- a/packages/api/internal/cfg/model.go
+++ b/packages/api/internal/cfg/model.go
@@ -66,8 +66,6 @@ type Config struct {
 
 	DefaultKernelVersion string `env:"DEFAULT_KERNEL_VERSION"`
 
-	DefaultPersistentVolumeType string `env:"DEFAULT_PERSISTENT_VOLUME_TYPE"`
-
 	// SandboxStorageBackend selects the sandbox storage implementation.
 	// "redis" uses Redis directly; "populate_redis" uses in-memory with Redis shadow writes.
 	SandboxStorageBackend string `env:"SANDBOX_STORAGE_BACKEND" envDefault:"memory"`

--- a/packages/api/internal/handlers/volume_create.go
+++ b/packages/api/internal/handlers/volume_create.go
@@ -65,7 +65,7 @@ func (a *APIStore) PostVolumes(c *gin.Context) {
 
 	ctx = featureflags.AddToContext(ctx, featureflags.VolumeContext(body.Name))
 
-	volumeType := a.getVolumeType(ctx)
+	volumeType := a.featureFlags.StringFlag(ctx, featureflags.DefaultPersistentVolumeType)
 	if volumeType == "" {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "No persistent volume type is configured")
 		telemetry.ReportCriticalError(ctx, "default persistent volume type is not configured", nil)
@@ -163,15 +163,6 @@ func (a *APIStore) PostVolumes(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, result)
-}
-
-func (a *APIStore) getVolumeType(ctx context.Context) string {
-	volumeType := a.featureFlags.StringFlag(ctx, featureflags.DefaultPersistentVolumeType)
-	if volumeType == "" {
-		volumeType = a.config.DefaultPersistentVolumeType
-	}
-
-	return volumeType
 }
 
 var validVolumeNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)

--- a/packages/shared/pkg/featureflags/client.go
+++ b/packages/shared/pkg/featureflags/client.go
@@ -3,6 +3,7 @@ package featureflags
 import (
 	"context"
 	"os"
+	"reflect"
 	"time"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
@@ -108,6 +109,7 @@ func (c *Client) StringFlag(ctx context.Context, flag StringFlag, contexts ...ld
 type typedFlag[T any] interface {
 	Key() string
 	Fallback() T
+	FallbackOnZero() bool
 }
 
 func getFlag[T any](
@@ -128,7 +130,16 @@ func getFlag[T any](
 		logger.L().Warn(ctx, "error evaluating flag", zap.Error(err), zap.String("flag", flag.Key()))
 	}
 
+	if flag.FallbackOnZero() && isZeroValue(value) {
+		return flag.Fallback()
+	}
+
 	return value
+}
+
+// isZeroValue returns true if the value is the zero value for its type.
+func isZeroValue[T any](v T) bool {
+	return reflect.ValueOf(&v).Elem().IsZero()
 }
 
 func (c *Client) Close(ctx context.Context) error {

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -3,6 +3,7 @@ package featureflags
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
@@ -34,8 +35,9 @@ const (
 // All flags must be defined here: https://app.launchdarkly.com/projects/default/flags/
 
 type JSONFlag struct {
-	name     string
-	fallback ldvalue.Value
+	name           string
+	fallback       ldvalue.Value
+	fallbackOnZero bool
 }
 
 func (f JSONFlag) Key() string {
@@ -48,6 +50,10 @@ func (f JSONFlag) String() string {
 
 func (f JSONFlag) Fallback() ldvalue.Value {
 	return f.fallback
+}
+
+func (f JSONFlag) FallbackOnZero() bool {
+	return f.fallbackOnZero
 }
 
 func newJSONFlag(name string, fallback ldvalue.Value) JSONFlag {
@@ -88,6 +94,10 @@ func (f BoolFlag) Fallback() bool {
 	return f.fallback
 }
 
+func (f BoolFlag) FallbackOnZero() bool {
+	return false
+}
+
 func newBoolFlag(name string, fallback bool) BoolFlag {
 	flag := BoolFlag{name: name, fallback: fallback}
 	builder := launchDarklyOfflineStore.Flag(flag.name).VariationForAll(fallback)
@@ -122,8 +132,9 @@ var (
 )
 
 type IntFlag struct {
-	name     string
-	fallback int
+	name           string
+	fallback       int
+	fallbackOnZero bool
 }
 
 func (f IntFlag) Key() string {
@@ -136,6 +147,10 @@ func (f IntFlag) String() string {
 
 func (f IntFlag) Fallback() int {
 	return f.fallback
+}
+
+func (f IntFlag) FallbackOnZero() bool {
+	return f.fallbackOnZero
 }
 
 func newIntFlag(name string, fallback int) IntFlag {
@@ -207,8 +222,9 @@ var (
 )
 
 type StringFlag struct {
-	name     string
-	fallback string
+	name                  string
+	fallback              string
+	fallbackOnEmptyString bool
 }
 
 func (f StringFlag) Key() string {
@@ -223,10 +239,21 @@ func (f StringFlag) Fallback() string {
 	return f.fallback
 }
 
+func (f StringFlag) FallbackOnZero() bool {
+	return f.fallbackOnEmptyString
+}
+
 func newStringFlag(name string, fallback string) StringFlag {
 	flag := StringFlag{name: name, fallback: fallback}
 	builder := launchDarklyOfflineStore.Flag(flag.name).ValueForAll(ldvalue.String(fallback))
 	launchDarklyOfflineStore.Update(builder)
+
+	return flag
+}
+
+func newStringFlagFallbackOnEmptyString(name string, fallback string) StringFlag {
+	flag := newStringFlag(name, fallback)
+	flag.fallbackOnEmptyString = true
 
 	return flag
 }
@@ -251,9 +278,9 @@ var FirecrackerVersionMap = map[string]string{
 
 // BuildIoEngine Sync is used by default as there seems to be a bad interaction between Async and a lot of io operations.
 var (
-	BuildFirecrackerVersion     = newStringFlag("build-firecracker-version", env.GetEnv("DEFAULT_FIRECRACKER_VERSION", DefaultFirecrackerVersion))
+	BuildFirecrackerVersion     = newStringFlagFallbackOnEmptyString("build-firecracker-version", env.GetEnv("DEFAULT_FIRECRACKER_VERSION", DefaultFirecrackerVersion))
 	BuildIoEngine               = newStringFlag("build-io-engine", "Sync")
-	DefaultPersistentVolumeType = newStringFlag("default-persistent-volume-type", "")
+	DefaultPersistentVolumeType = newStringFlagFallbackOnEmptyString("default-persistent-volume-type", os.Getenv("DEFAULT_PERSISTENT_VOLUME_TYPE"))
 	BuildNodeInfo               = newJSONFlag("preferred-build-node", ldvalue.Null())
 	FirecrackerVersions         = newJSONFlag("firecracker-versions", ldvalue.FromJSONMarshal(FirecrackerVersionMap))
 )


### PR DESCRIPTION
Previously, flags had 2 possibilities:
- if flag is configured in launchdarkly, use that value
- if flag is unconfigured in launchdarkly, use fallback value

Now flags can opt-in to a third possibility
- if flag is configured in launchdarkly and returns a default value (empty string, zero, etc), use the fallback value

This allows us to create flags that should return no value, and allow it to fallback to the local configuration.

A concrete example: 
- the env var `DEFAULT_PERSISTENT_VOLUME_TYPE` sets the default
- the launch darkly flag `default-persistent-volume-type` can be set to customize this default per team

If we don't want to customize some teams, but fall through for others, it currently takes extra code to support it. After this PR, our feature flag client supports it natively.

Old usage:

```golang
var volumeTypeFlag = newStringFlag("default-persistent-volume-type", "")

func getVolumeType() string {
	volumeType := client.StringFlag(volumeTypeFlag)

	// could be empty from launch darkly, could be empty b/c launchdarkly is offline or failed
	if volumeType == "" {  
    	return os.Getenv("DEFAULT_PERSISTENT_VOLUME_TYPE")
	}
	return volumeType
}
```

New usage:

```golang
var volumeTypeFlag = newStringFlagFallbackOnEmptyString(
	"default-persistent-volume-type", 
	os.Getenv("DEFAULT_PERSISTENT_VOLUME_TYPE"),
)

func getVolumeType() string {
	return client.StringFlag(volumeTypeFlag)
}
```