### PR TITLE
feat(api): add per-call timeouts for redis backend operations (ENG-4060)

### DIFF
--- a/packages/api/internal/sandbox/reservations/redis/reservation.go
+++ b/packages/api/internal/sandbox/reservations/redis/reservation.go
@@ -22,6 +22,11 @@ const (
 	// and cleaned up. This handles the case where an API instance crashes mid-creation.
 	// 90 seconds is well beyond any realistic sandbox creation time.
 	staleTTL = 90 * time.Second
+
+	// redisOpTimeout bounds a single Redis round trip. Each call site wraps its
+	// context with this timeout so a stuck Redis call cannot block callers
+	// indefinitely.
+	redisOpTimeout = 5 * time.Second
 )
 
 var _ sandbox.ReservationStorage = (*ReservationStorage)(nil)
@@ -45,10 +50,12 @@ func (s *ReservationStorage) Reserve(ctx context.Context, teamID uuid.UUID, sand
 	now := float64(time.Now().Unix())
 	staleCutoff := float64(time.Now().Add(-staleTTL).Unix())
 
-	result, err := reserveScript.Run(ctx, s.redisClient,
+	reserveCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	result, err := reserveScript.Run(reserveCtx, s.redisClient,
 		[]string{storageIndexKey, pendingSetKey, resultKeyStr},
 		sandboxID, limit, now, staleCutoff,
 	).Int()
+	cancel()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to run reserve script: %w", err)
 	}
@@ -76,7 +83,9 @@ func (s *ReservationStorage) Release(ctx context.Context, teamID uuid.UUID, sand
 	pendingSetKey := getPendingSetKey(teamIDStr)
 	resultKeyStr := getResultKey(teamIDStr, sandboxID)
 
-	err := releaseScript.Run(ctx, s.redisClient, []string{pendingSetKey, resultKeyStr}, sandboxID).Err()
+	releaseCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	err := releaseScript.Run(releaseCtx, s.redisClient, []string{pendingSetKey, resultKeyStr}, sandboxID).Err()
+	cancel()
 	if err != nil {
 		return fmt.Errorf("failed to run release script: %w", err)
 	}
@@ -100,16 +109,20 @@ func (s *ReservationStorage) createFinishStart(ctx context.Context, teamID uuid.
 			)
 
 			// Still try to remove from pending even if encoding fails
-			_ = s.redisClient.ZRem(context.WithoutCancel(ctx), pendingSetKey, sandboxID).Err()
+			zremCtx, zremCancel := context.WithTimeout(context.WithoutCancel(ctx), redisOpTimeout)
+			_ = s.redisClient.ZRem(zremCtx, pendingSetKey, sandboxID).Err()
+			zremCancel()
 
 			return
 		}
 
 		ttlSeconds := int(resultTTL.Seconds())
-		err := finishStartScript.Run(context.WithoutCancel(ctx), s.redisClient,
+		finishCtx, finishCancel := context.WithTimeout(context.WithoutCancel(ctx), redisOpTimeout)
+		err := finishStartScript.Run(finishCtx, s.redisClient,
 			[]string{pendingSetKey, resultKeyStr},
 			sandboxID, resultData, ttlSeconds,
 		).Err()
+		finishCancel()
 		if err != nil {
 			logger.L().Error(ctx, "failed to run finishStart script",
 				zap.Error(err),
@@ -129,7 +142,9 @@ func (s *ReservationStorage) createWaitForStart(teamID uuid.UUID, sandboxID stri
 
 		for {
 			// Check for result
-			data, err := s.redisClient.Get(ctx, resultKeyStr).Bytes()
+			getCtx, getCancel := context.WithTimeout(ctx, redisOpTimeout)
+			data, err := s.redisClient.Get(getCtx, resultKeyStr).Bytes()
+			getCancel()
 			if err == nil {
 				return decodeResult(data)
 			}
@@ -138,10 +153,14 @@ func (s *ReservationStorage) createWaitForStart(teamID uuid.UUID, sandboxID stri
 			}
 
 			// No result yet — check if still pending (ZSCORE returns nil if not a member)
-			err = s.redisClient.ZScore(ctx, pendingSetKey, sandboxID).Err()
+			zscoreCtx, zscoreCancel := context.WithTimeout(ctx, redisOpTimeout)
+			err = s.redisClient.ZScore(zscoreCtx, pendingSetKey, sandboxID).Err()
+			zscoreCancel()
 			if errors.Is(err, redis.Nil) {
 				// Not pending anymore, final check
-				data, err = s.redisClient.Get(ctx, resultKeyStr).Bytes()
+				finalGetCtx, finalGetCancel := context.WithTimeout(ctx, redisOpTimeout)
+				data, err = s.redisClient.Get(finalGetCtx, resultKeyStr).Bytes()
+				finalGetCancel()
 				if err == nil {
 					return decodeResult(data)
 				}

--- a/packages/api/internal/sandbox/storage/redis/items.go
+++ b/packages/api/internal/sandbox/storage/redis/items.go
@@ -22,11 +22,13 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandbox.Sandbox, error) {
 	nowMs := float64(now.UnixMilli())
 
 	// Fetch members whose score (EndTime in ms) is <= now, bounded to 256 per cycle.
-	expiredMembers, err := s.redisClient.ZRangeByScore(ctx, globalExpirationSet, &redis.ZRangeBy{
+	zrangeCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	expiredMembers, err := s.redisClient.ZRangeByScore(zrangeCtx, globalExpirationSet, &redis.ZRangeBy{
 		Min:   "-inf",
 		Max:   fmt.Sprintf("%v", nowMs),
 		Count: expiredItemsBatchSize,
 	}).Result()
+	cancel()
 	if err != nil {
 		return nil, fmt.Errorf("failed to query global expiration index: %w", err)
 	}
@@ -75,7 +77,9 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandbox.Sandbox, error) {
 		batches = append(batches, batchInfo{cmd: cmd, members: entry.members})
 	}
 
-	_, err = pipe.Exec(ctx)
+	pipeCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	_, err = pipe.Exec(pipeCtx)
+	cancel()
 	if err != nil {
 		return nil, fmt.Errorf("MGET pipeline failed: %w", err)
 	}
@@ -130,8 +134,11 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandbox.Sandbox, error) {
 
 	// Remove orphaned ZSET entries so the set doesn't grow unboundedly.
 	if len(staleMembers) > 0 {
-		if err := s.redisClient.ZRem(ctx, globalExpirationSet, staleMembers...).Err(); err != nil {
-			logger.L().Warn(ctx, "Failed to clean up stale expiration index entries", zap.Error(err), zap.Int("count", len(staleMembers)))
+		zremCtx, zremCancel := context.WithTimeout(ctx, redisOpTimeout)
+		zremErr := s.redisClient.ZRem(zremCtx, globalExpirationSet, staleMembers...).Err()
+		zremCancel()
+		if zremErr != nil {
+			logger.L().Warn(ctx, "Failed to clean up stale expiration index entries", zap.Error(zremErr), zap.Int("count", len(staleMembers)))
 		}
 	}
 

--- a/packages/api/internal/sandbox/storage/redis/main.go
+++ b/packages/api/internal/sandbox/storage/redis/main.go
@@ -20,6 +20,11 @@ const (
 	lockRetryJitter        = 0.25
 	pollInterval           = 1 * time.Second // fallback polling interval; PubSub is the primary notification mechanism
 
+	// redisOpTimeout bounds a single Redis round trip (GET/SET/ZADD/Lua/pipeline).
+	// Each call site wraps its context with this timeout so a stuck Redis call
+	// cannot block callers (e.g. holding a distributed lock) indefinitely.
+	redisOpTimeout = 5 * time.Second
+
 	// orphanGracePeriod is the minimum age a sandbox must have before it can be
 	// considered an orphan and killed. This prevents killing sandboxes that are
 	// still in the process of being created (store write happens before the VM starts).
@@ -109,7 +114,9 @@ func (s *Storage) Reconcile(ctx context.Context, sbxs []sandbox.Sandbox, nodeID 
 		batches = append(batches, batchInfo{cmd: cmd, candidates: candidates})
 	}
 
-	_, err := pipe.Exec(ctx)
+	pipeCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	_, err := pipe.Exec(pipeCtx)
+	cancel()
 	if err != nil {
 		// Pipeline error — skip entirely to avoid mass kills.
 		logger.L().Error(ctx, "Redis pipeline error during orphan sync, skipping",

--- a/packages/api/internal/sandbox/storage/redis/operations.go
+++ b/packages/api/internal/sandbox/storage/redis/operations.go
@@ -30,25 +30,33 @@ func (s *Storage) Add(ctx context.Context, sbx sandbox.Sandbox) error {
 
 	// Add to the index before adding to the cache, so there's no possibility of leaking
 	// Index by EndTime so ExpiredItems can use ZRANGEBYSCORE instead of scanning all sandboxes.
-	if err := s.redisClient.ZAdd(ctx, globalExpirationSet, redis.Z{
+	zaddCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	zaddErr := s.redisClient.ZAdd(zaddCtx, globalExpirationSet, redis.Z{
 		Score:  float64(sbx.EndTime.UnixMilli()),
 		Member: expirationMember(sbx.TeamID.String(), sbx.SandboxID),
-	}).Err(); err != nil {
-		return fmt.Errorf("failed to add sandbox to global expiration index: %w", err)
+	}).Err()
+	cancel()
+	if zaddErr != nil {
+		return fmt.Errorf("failed to add sandbox to global expiration index: %w", zaddErr)
 	}
 
 	// Execute Lua script for atomic SET + SADD
-	err = addSandboxScript.Run(ctx, s.redisClient, []string{key, teamKey}, data, sbx.SandboxID).Err()
+	scriptCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	err = addSandboxScript.Run(scriptCtx, s.redisClient, []string{key, teamKey}, data, sbx.SandboxID).Err()
+	cancel()
 	if err != nil {
 		return fmt.Errorf("failed to store sandbox in Redis: %w", err)
 	}
 
 	// We can't set the globalTeamsSet in Lua script as they can be in different shards
-	if err := s.redisClient.ZAdd(ctx, globalTeamsSet, redis.Z{
+	teamsCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	teamsErr := s.redisClient.ZAdd(teamsCtx, globalTeamsSet, redis.Z{
 		Score:  float64(time.Now().Unix()),
 		Member: sbx.TeamID.String(),
-	}).Err(); err != nil {
-		logger.L().Warn(ctx, "failed to add team to global teams index", zap.Error(err), logger.WithSandboxID(sbx.SandboxID))
+	}).Err()
+	cancel()
+	if teamsErr != nil {
+		logger.L().Warn(ctx, "failed to add team to global teams index", zap.Error(teamsErr), logger.WithSandboxID(sbx.SandboxID))
 	}
 
 	return nil
@@ -57,7 +65,9 @@ func (s *Storage) Add(ctx context.Context, sbx sandbox.Sandbox) error {
 // Get retrieves a sandbox from Redis
 func (s *Storage) Get(ctx context.Context, teamID uuid.UUID, sandboxID string) (sandbox.Sandbox, error) {
 	key := getSandboxKey(teamID.String(), sandboxID)
-	data, err := s.redisClient.Get(ctx, key).Bytes()
+	getCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	defer cancel()
+	data, err := s.redisClient.Get(getCtx, key).Bytes()
 	if errors.Is(err, redis.Nil) {
 		return sandbox.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandbox.ErrNotFound)
 	}
@@ -93,15 +103,20 @@ func (s *Storage) Remove(ctx context.Context, teamID uuid.UUID, sandboxID string
 	}()
 
 	// Execute Lua script for atomic DEL + SREM
-	err = removeSandboxScript.Run(ctx, s.redisClient, []string{key, teamKey}, sandboxID).Err()
+	scriptCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	err = removeSandboxScript.Run(scriptCtx, s.redisClient, []string{key, teamKey}, sandboxID).Err()
+	cancel()
 	if err != nil {
 		return fmt.Errorf("failed to remove sandbox from Redis: %w", err)
 	}
 
 	// Clean up from the global expiration index.
 	// Do it after the removal to prevent leaking expired sandboxes.
-	if err := s.redisClient.ZRem(ctx, globalExpirationSet, expirationMember(teamID.String(), sandboxID)).Err(); err != nil {
-		logger.L().Warn(ctx, "Failed to remove sandbox from global expiration index", zap.Error(err), logger.WithSandboxID(sandboxID))
+	zremCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	zremErr := s.redisClient.ZRem(zremCtx, globalExpirationSet, expirationMember(teamID.String(), sandboxID)).Err()
+	cancel()
+	if zremErr != nil {
+		logger.L().Warn(ctx, "Failed to remove sandbox from global expiration index", zap.Error(zremErr), logger.WithSandboxID(sandboxID))
 	}
 
 	return nil
@@ -111,7 +126,9 @@ func (s *Storage) Remove(ctx context.Context, teamID uuid.UUID, sandboxID string
 func (s *Storage) TeamItems(ctx context.Context, teamID uuid.UUID, states []sandbox.State) ([]sandbox.Sandbox, error) {
 	// Get sandbox IDs from team index
 	teamKey := GetSandboxStorageTeamIndexKey(teamID.String())
-	sandboxIDs, err := s.redisClient.SMembers(ctx, teamKey).Result()
+	smembersCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	sandboxIDs, err := s.redisClient.SMembers(smembersCtx, teamKey).Result()
+	cancel()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sandbox IDs from team index: %w", err)
 	}
@@ -126,7 +143,9 @@ func (s *Storage) TeamItems(ctx context.Context, teamID uuid.UUID, states []sand
 		return getSandboxKey(team, id)
 	})
 
-	results, err := s.redisClient.MGet(ctx, keys...).Result()
+	mgetCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	results, err := s.redisClient.MGet(mgetCtx, keys...).Result()
+	cancel()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sandboxes from Redis: %w", err)
 	}
@@ -181,7 +200,9 @@ func (s *Storage) Update(ctx context.Context, teamID uuid.UUID, sandboxID string
 	}()
 
 	// Get current value
-	data, err := s.redisClient.Get(ctx, key).Bytes()
+	getCtx, getCancel := context.WithTimeout(ctx, redisOpTimeout)
+	data, err := s.redisClient.Get(getCtx, key).Bytes()
+	getCancel()
 	if errors.Is(err, redis.Nil) {
 		return sandbox.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandbox.ErrNotFound)
 	}
@@ -208,18 +229,23 @@ func (s *Storage) Update(ctx context.Context, teamID uuid.UUID, sandboxID string
 	}
 
 	// Execute transaction
-	err = s.redisClient.Set(ctx, key, newData, redis.KeepTTL).Err()
+	setCtx, setCancel := context.WithTimeout(ctx, redisOpTimeout)
+	err = s.redisClient.Set(setCtx, key, newData, redis.KeepTTL).Err()
+	setCancel()
 	if err != nil {
 		return sandbox.Sandbox{}, fmt.Errorf("failed to store sandbox in Redis: %w", err)
 	}
 
 	// Re-score the expiration index if EndTime changed.
 	if !updatedSbx.EndTime.Equal(sbx.EndTime) {
-		if err := s.redisClient.ZAdd(ctx, globalExpirationSet, redis.Z{
+		zaddCtx, zaddCancel := context.WithTimeout(ctx, redisOpTimeout)
+		zaddErr := s.redisClient.ZAdd(zaddCtx, globalExpirationSet, redis.Z{
 			Score:  float64(updatedSbx.EndTime.UnixMilli()),
 			Member: expirationMember(teamID.String(), sandboxID),
-		}).Err(); err != nil {
-			return sandbox.Sandbox{}, fmt.Errorf("failed to update sandbox in global expiration index: %w", err)
+		}).Err()
+		zaddCancel()
+		if zaddErr != nil {
+			return sandbox.Sandbox{}, fmt.Errorf("failed to update sandbox in global expiration index: %w", zaddErr)
 		}
 	}
 
@@ -227,7 +253,9 @@ func (s *Storage) Update(ctx context.Context, teamID uuid.UUID, sandboxID string
 }
 
 func (s *Storage) TeamsWithSandboxCount(ctx context.Context) (map[uuid.UUID]int64, error) {
-	members, err := s.redisClient.ZRangeWithScores(ctx, globalTeamsSet, 0, -1).Result()
+	zrangeCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	members, err := s.redisClient.ZRangeWithScores(zrangeCtx, globalTeamsSet, 0, -1).Result()
+	cancel()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get teams from global index: %w", err)
 	}
@@ -260,7 +288,9 @@ func (s *Storage) TeamsWithSandboxCount(ctx context.Context) (map[uuid.UUID]int6
 		return map[uuid.UUID]int64{}, nil
 	}
 
-	_, err = pipe.Exec(ctx)
+	pipeCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	_, err = pipe.Exec(pipeCtx)
+	cancel()
 	if err != nil {
 		return nil, fmt.Errorf("SCARD pipeline failed: %w", err)
 	}
@@ -282,8 +312,11 @@ func (s *Storage) TeamsWithSandboxCount(ctx context.Context) (map[uuid.UUID]int6
 
 	// Prune stale entries from the global teams index
 	if len(stale) > 0 {
-		if err := s.redisClient.ZRem(ctx, globalTeamsSet, stale...).Err(); err != nil {
-			logger.L().Warn(ctx, "Failed to prune stale teams from global index", zap.Error(err), zap.Int("count", len(stale)))
+		zremCtx, zremCancel := context.WithTimeout(ctx, redisOpTimeout)
+		zremErr := s.redisClient.ZRem(zremCtx, globalTeamsSet, stale...).Err()
+		zremCancel()
+		if zremErr != nil {
+			logger.L().Warn(ctx, "Failed to prune stale teams from global index", zap.Error(zremErr), zap.Int("count", len(stale)))
 		}
 	}
 

--- a/packages/api/internal/sandbox/storage/redis/state_change.go
+++ b/packages/api/internal/sandbox/storage/redis/state_change.go
@@ -56,7 +56,9 @@ func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID
 	}()
 
 	// Get current sandbox state first
-	data, err := s.redisClient.Get(ctx, key).Bytes()
+	getCtx, getCancel := context.WithTimeout(ctx, redisOpTimeout)
+	data, err := s.redisClient.Get(getCtx, key).Bytes()
+	getCancel()
 	if errors.Is(err, redis.Nil) {
 		return sandbox.Sandbox{}, false, nil, fmt.Errorf("sandbox %q: %w", sandboxID, sandbox.ErrNotFound)
 	}
@@ -70,7 +72,9 @@ func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID
 	}
 
 	// Check if there's an existing transition
-	transactionID, err := s.redisClient.Get(ctx, transitionKey).Result()
+	transitionGetCtx, transitionGetCancel := context.WithTimeout(ctx, redisOpTimeout)
+	transactionID, err := s.redisClient.Get(transitionGetCtx, transitionKey).Result()
+	transitionGetCancel()
 	if err != nil && !errors.Is(err, redis.Nil) {
 		return sbx, false, nil, fmt.Errorf("failed to check transition key: %w", err)
 	}
@@ -135,7 +139,9 @@ func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID
 	ttlSeconds := int(transitionKeyTTL.Seconds())
 	resultTtlSeconds := int(transitionResultKeyTTL.Seconds())
 
-	err = startTransitionScript.Run(ctx, s.redisClient, []string{key, transitionKey, resultKey}, newData, transitionID, ttlSeconds, resultTtlSeconds).Err()
+	scriptCtx, scriptCancel := context.WithTimeout(ctx, redisOpTimeout)
+	err = startTransitionScript.Run(scriptCtx, s.redisClient, []string{key, transitionKey, resultKey}, newData, transitionID, ttlSeconds, resultTtlSeconds).Err()
+	scriptCancel()
 	if err != nil {
 		return sbx, false, nil, fmt.Errorf("failed to update sandbox state: %w", err)
 	}
@@ -185,13 +191,17 @@ func (s *Storage) createCallback(teamID uuid.UUID, sandboxID, transitionKey, res
 		}
 
 		// Set result key with short TTL
-		setErr := s.redisClient.Set(cbCtx, resultKey, resultValue, transitionResultKeyTTL).Err()
+		setCtx, setCancel := context.WithTimeout(cbCtx, redisOpTimeout)
+		setErr := s.redisClient.Set(setCtx, resultKey, resultValue, transitionResultKeyTTL).Err()
+		setCancel()
 		if setErr != nil {
 			logger.L().Warn(cbCtx, "Failed to set transition result", logger.WithSandboxID(sandboxID), zap.String("transitionID", transitionID), zap.Error(setErr))
 		}
 
 		// Delete transition key
-		delErr := s.redisClient.Del(cbCtx, transitionKey).Err()
+		delCtx, delCancel := context.WithTimeout(cbCtx, redisOpTimeout)
+		delErr := s.redisClient.Del(delCtx, transitionKey).Err()
+		delCancel()
 		if delErr != nil {
 			logger.L().Warn(cbCtx, "Failed to delete transition key", logger.WithSandboxID(sandboxID), zap.Error(delErr))
 		}
@@ -201,7 +211,9 @@ func (s *Storage) createCallback(teamID uuid.UUID, sandboxID, transitionKey, res
 		// The routing key is published as the payload so the single global channel
 		// can serve all sandboxes across all teams.
 		routingKey := getTransitionRoutingKey(teamID.String(), sandboxID, transitionID)
-		pubErr := s.redisClient.Publish(cbCtx, globalStorageNotifyChannel, routingKey).Err()
+		pubCtx, pubCancel := context.WithTimeout(cbCtx, redisOpTimeout)
+		pubErr := s.redisClient.Publish(pubCtx, globalStorageNotifyChannel, routingKey).Err()
+		pubCancel()
 		if pubErr != nil {
 			logger.L().Warn(cbCtx, "Failed to publish transition notification",
 				logger.WithSandboxID(sandboxID),
@@ -230,7 +242,9 @@ func (s *Storage) restoreToRunning(ctx context.Context, teamID uuid.UUID, sandbo
 // WaitForStateChange waits for a sandbox state transition to complete.
 func (s *Storage) WaitForStateChange(ctx context.Context, teamID uuid.UUID, sandboxID string) error {
 	transitionKey := getTransitionKey(teamID.String(), sandboxID)
-	transactionID, err := s.redisClient.Get(ctx, transitionKey).Result()
+	getCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	transactionID, err := s.redisClient.Get(getCtx, transitionKey).Result()
+	cancel()
 	if errors.Is(err, redis.Nil) {
 		logger.L().Debug(ctx, "No ongoing transition", logger.WithSandboxID(sandboxID))
 
@@ -260,7 +274,9 @@ func (s *Storage) waitForTransition(
 	defer cleanup()
 
 	// Initial check: the transition may have completed before we subscribed.
-	currentID, err := s.redisClient.Get(ctx, transitionKey).Result()
+	initialGetCtx, initialGetCancel := context.WithTimeout(ctx, redisOpTimeout)
+	currentID, err := s.redisClient.Get(initialGetCtx, transitionKey).Result()
+	initialGetCancel()
 	if errors.Is(err, redis.Nil) || currentID != transitionID {
 		return s.checkTransitionResult(ctx, resultKey)
 	}
@@ -280,7 +296,9 @@ func (s *Storage) waitForTransition(
 			return s.checkTransitionResult(ctx, resultKey)
 		case <-ticker.C:
 			// Fallback poll: check whether the transition key is still present.
-			currentID, err := s.redisClient.Get(ctx, transitionKey).Result()
+			pollCtx, pollCancel := context.WithTimeout(ctx, redisOpTimeout)
+			currentID, err := s.redisClient.Get(pollCtx, transitionKey).Result()
+			pollCancel()
 			if errors.Is(err, redis.Nil) || currentID != transitionID {
 				return s.checkTransitionResult(ctx, resultKey)
 			}
@@ -293,7 +311,9 @@ func (s *Storage) waitForTransition(
 
 // checkTransitionResult checks the result key for the outcome of a completed transition.
 func (s *Storage) checkTransitionResult(ctx context.Context, resultKey string) error {
-	result, err := s.redisClient.Get(ctx, resultKey).Result()
+	getCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	result, err := s.redisClient.Get(getCtx, resultKey).Result()
+	cancel()
 	if errors.Is(err, redis.Nil) {
 		// Result expired or never set - assume success (transition key was deleted)
 		return nil


### PR DESCRIPTION
Wrap every redis call in packages/api/internal/sandbox with a context.WithTimeout(ctx, 5s) so a stuck redis round trip cannot block callers (e.g. while holding a distributed lock) indefinitely.

Sites left unchanged: lock.Obtain (already bounded by caller timeout), lock publishReleaseNotification (own 5s timeout), and the long-lived subscription manager pubsub Subscribe.