### PR TITLE
API: Cluster reinitialize on data change

### DIFF
--- a/packages/api/internal/clusters/cluster.go
+++ b/packages/api/internal/clusters/cluster.go
@@ -51,7 +51,7 @@ type clusterConfig struct {
 	token       string
 
 	sandboxDomain *string
-	oauthOrgID    string
+	oauthOrgID    *string
 }
 
 var (
@@ -194,7 +194,11 @@ func (c *Cluster) GetSandboxDomain() *string {
 }
 
 func (c *Cluster) GetOAuthOrgID() string {
-	return c.config.oauthOrgID
+	if c.config.oauthOrgID == nil {
+		return ""
+	}
+
+	return *c.config.oauthOrgID
 }
 
 func (c *Cluster) GetTemplateBuilderByNodeID(nodeID string) (*Instance, error) {

--- a/packages/api/internal/clusters/cluster.go
+++ b/packages/api/internal/clusters/cluster.go
@@ -37,13 +37,21 @@ const (
 )
 
 type Cluster struct {
-	ID            uuid.UUID
-	SandboxDomain *string
-	AuthOrgID     string
+	ID uuid.UUID
 
+	config          clusterConfig
+	resources       ClusterResource
 	instances       *smap.Map[*Instance]
 	synchronization *synchronization.Synchronize[discovery.Item, *Instance]
-	resources       ClusterResource
+}
+
+type clusterConfig struct {
+	endpoint    string
+	endpointTLS bool
+	token       string
+
+	sandboxDomain *string
+	oauthOrgID    string
 }
 
 var (
@@ -53,19 +61,18 @@ var (
 
 func NewCluster(
 	clusterID uuid.UUID,
-	domain *string,
-	authOrgID string,
+	config clusterConfig,
 	sandboxes *smap.Map[*Instance],
 	synchronization *synchronization.Synchronize[discovery.Item, *Instance],
 	resources ClusterResource,
 ) *Cluster {
 	return &Cluster{
-		ID:              clusterID,
-		SandboxDomain:   domain,
-		AuthOrgID:       authOrgID,
+		ID: clusterID,
+
+		config:          config,
+		resources:       resources,
 		instances:       sandboxes,
 		synchronization: synchronization,
-		resources:       resources,
 	}
 }
 
@@ -75,7 +82,7 @@ func newLocalCluster(
 	storeDiscovery discovery.Discovery,
 	clickhouse clickhouse.Clickhouse,
 	queryLogsProvider *loki.LokiQueryProvider,
-	config cfg.Config,
+	cfg cfg.Config,
 ) *Cluster {
 	clusterID := consts.LocalClusterID
 
@@ -86,14 +93,14 @@ func newLocalCluster(
 	}
 
 	store := instancesSyncStore{clusterID: clusterID, instances: instances, discovery: storeDiscovery, instanceCreation: instanceCreation}
+	config := clusterConfig{}
 
 	c := NewCluster(
 		clusterID,
-		nil,
-		"",
+		config,
 		instances,
 		synchronization.NewSynchronize("cluster-instances", "Cluster instances", store),
-		newLocalClusterResourceProvider(clickhouse, queryLogsProvider, instances, config),
+		newLocalClusterResourceProvider(clickhouse, queryLogsProvider, instances, cfg),
 	)
 
 	// Periodically sync cluster instances
@@ -105,27 +112,22 @@ func newLocalCluster(
 func newRemoteCluster(
 	ctx context.Context,
 	tel *telemetry.Client,
-	endpoint string,
-	endpointTLS bool,
-	secret string,
 	clusterID uuid.UUID,
-	sandboxDomain *string,
-	authOrgID string,
+	config clusterConfig,
 ) (*Cluster, error) {
 	scheme := "http"
-	if endpointTLS {
+	if config.endpointTLS {
 		scheme = "https"
 	}
 
-	endpointBaseUrl := fmt.Sprintf("%s://%s", scheme, endpoint)
-
+	endpointBaseUrl := fmt.Sprintf("%s://%s", scheme, config.endpoint)
 	httpClient, err := api.NewClientWithResponses(
 		endpointBaseUrl,
 		func(c *api.Client) error {
 			c.RequestEditors = append(
 				c.RequestEditors,
 				func(_ context.Context, req *http.Request) error {
-					req.Header.Set(consts.EdgeApiAuthHeader, secret)
+					req.Header.Set(consts.EdgeApiAuthHeader, config.token)
 
 					return nil
 				},
@@ -141,9 +143,9 @@ func newRemoteCluster(
 	instances := smap.New[*Instance]()
 	instanceCreation := func(ctx context.Context, item discovery.Item) (*Instance, error) {
 		// For remote cluster we are doing connection to endpoint that works as gRPC proxy and handles auth and routing for us.
-		auth := &instanceAuthorization{secret: secret, tls: endpointTLS, serviceInstanceID: item.InstanceID}
+		auth := &instanceAuthorization{secret: config.token, tls: config.endpointTLS, serviceInstanceID: item.InstanceID}
 
-		return newInstance(ctx, tel, auth, clusterID, item, endpoint, endpointTLS)
+		return newInstance(ctx, tel, auth, clusterID, item, config.endpoint, config.endpointTLS)
 	}
 
 	storeDiscovery := discovery.NewRemoteServiceDiscovery(clusterID, httpClient)
@@ -151,8 +153,7 @@ func newRemoteCluster(
 
 	c := NewCluster(
 		clusterID,
-		sandboxDomain,
-		authOrgID,
+		config,
 		instances,
 		synchronization.NewSynchronize("cluster-instances", "Cluster instances", store),
 		newRemoteClusterResourceProvider(clusterID, instances, httpClient),
@@ -186,6 +187,14 @@ func (c *Cluster) Close(ctx context.Context) error {
 	wg.Wait()
 
 	return nil
+}
+
+func (c *Cluster) GetSandboxDomain() *string {
+	return c.config.sandboxDomain
+}
+
+func (c *Cluster) GetOAuthOrgID() string {
+	return c.config.oauthOrgID
 }
 
 func (c *Cluster) GetTemplateBuilderByNodeID(nodeID string) (*Instance, error) {

--- a/packages/api/internal/clusters/clusters_sync.go
+++ b/packages/api/internal/clusters/clusters_sync.go
@@ -59,17 +59,12 @@ func NewPool(
 		}
 
 		// Remote cluster
-		authOrgID := ""
-		if source.AuthOrgID != nil {
-			authOrgID = *source.AuthOrgID
-		}
-
 		config := clusterConfig{
 			endpoint:      source.Endpoint,
 			endpointTLS:   source.EndpointTls,
 			token:         source.Token,
 			sandboxDomain: source.SandboxProxyDomain,
-			oauthOrgID:    authOrgID,
+			oauthOrgID:    source.AuthOrgID,
 		}
 
 		c, err := newRemoteCluster(context.WithoutCancel(ctx), tel, source.ID, config)
@@ -194,7 +189,15 @@ func (d clustersSyncStore) PoolInsert(ctx context.Context, source queries.Cluste
 	logger.L().Info(ctx, "Cluster initialized successfully", logger.WithClusterID(clusterID))
 }
 
-func (d clustersSyncStore) PoolUpdate(_ context.Context, e *Cluster, _ queries.Cluster) {}
+func (d clustersSyncStore) PoolUpdate(ctx context.Context, e *Cluster, s queries.Cluster) {
+	needsRecreation := clusterRecreationNeeded(s, e.config)
+	if needsRecreation {
+		logger.L().Info(ctx, "Cluster configuration changed, recreating cluster", logger.WithClusterID(e.ID))
+		d.PoolRemove(ctx, e)
+		d.PoolInsert(ctx, s)
+		logger.L().Info(ctx, "Cluster recreated successfully", logger.WithClusterID(e.ID))
+	}
+}
 
 func (d clustersSyncStore) PoolRemove(ctx context.Context, cluster *Cluster) {
 	logger.L().Info(ctx, "Removing cluster from pool", logger.WithClusterID(cluster.ID))
@@ -205,4 +208,40 @@ func (d clustersSyncStore) PoolRemove(ctx context.Context, cluster *Cluster) {
 	}
 
 	d.clusters.Remove(cluster.ID.String())
+}
+
+func clusterRecreationNeeded(source queries.Cluster, existing clusterConfig) bool {
+	if source.Endpoint != existing.endpoint {
+		return true
+	}
+
+	if source.EndpointTls != existing.endpointTLS {
+		return true
+	}
+
+	if source.Token != existing.token {
+		return true
+	}
+
+	if !compareNilableStrings(source.SandboxProxyDomain, existing.sandboxDomain) {
+		return true
+	}
+
+	if !compareNilableStrings(source.AuthOrgID, existing.oauthOrgID) {
+		return true
+	}
+
+	return false
+}
+
+func compareNilableStrings(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+
+	if a != nil && b != nil && *a != *b {
+		return false
+	}
+
+	return true
 }

--- a/packages/api/internal/clusters/clusters_sync.go
+++ b/packages/api/internal/clusters/clusters_sync.go
@@ -136,14 +136,14 @@ func (d clustersSyncStore) SourceList(ctx context.Context) ([]queries.Cluster, e
 	return entries, nil
 }
 
-func (d clustersSyncStore) SourceExists(_ context.Context, s []queries.Cluster, p *Cluster) bool {
+func (d clustersSyncStore) SourceGet(_ context.Context, s []queries.Cluster, p *Cluster) (queries.Cluster, bool) {
 	for _, item := range s {
 		if item.ID == p.ID {
-			return true
+			return item, true
 		}
 	}
 
-	return false
+	return queries.Cluster{}, false
 }
 
 func (d clustersSyncStore) PoolList(_ context.Context) []*Cluster {
@@ -155,10 +155,8 @@ func (d clustersSyncStore) PoolList(_ context.Context) []*Cluster {
 	return items
 }
 
-func (d clustersSyncStore) PoolExists(_ context.Context, cluster queries.Cluster) bool {
-	_, found := d.clusters.Get(cluster.ID.String())
-
-	return found
+func (d clustersSyncStore) PoolGet(_ context.Context, source queries.Cluster) (*Cluster, bool) {
+	return d.clusters.Get(source.ID.String())
 }
 
 func (d clustersSyncStore) PoolInsert(ctx context.Context, cluster queries.Cluster) {
@@ -204,9 +202,7 @@ func (d clustersSyncStore) PoolInsert(ctx context.Context, cluster queries.Clust
 	logger.L().Info(ctx, "Remote cluster initialized successfully", logger.WithClusterID(cluster.ID))
 }
 
-func (d clustersSyncStore) PoolUpdate(_ context.Context, _ *Cluster) {
-	// Clusters pool currently does not do something special during synchronization
-}
+func (d clustersSyncStore) PoolUpdate(_ context.Context, _ *Cluster, _ queries.Cluster) {}
 
 func (d clustersSyncStore) PoolRemove(ctx context.Context, cluster *Cluster) {
 	logger.L().Info(ctx, "Removing cluster from pool", logger.WithClusterID(cluster.ID))

--- a/packages/api/internal/clusters/clusters_sync.go
+++ b/packages/api/internal/clusters/clusters_sync.go
@@ -49,11 +49,36 @@ func NewPool(
 	localDiscovery discovery.Discovery,
 	queryMetricsProvider clickhouse.Clickhouse,
 	queryLogsProvider *loki.LokiQueryProvider,
-	config cfg.Config,
+	cfg cfg.Config,
 ) (*Pool, error) {
 	clusters := smap.New[*Cluster]()
+	clusterCreateFunc := func(ctx context.Context, source queries.Cluster) (*Cluster, error) {
+		// Local cluster
+		if source.ID == consts.LocalClusterID {
+			return newLocalCluster(context.WithoutCancel(ctx), tel, localDiscovery, queryMetricsProvider, queryLogsProvider, cfg), nil
+		}
 
-	localCluster := localClusterConfig()
+		// Remote cluster
+		authOrgID := ""
+		if source.AuthOrgID != nil {
+			authOrgID = *source.AuthOrgID
+		}
+
+		config := clusterConfig{
+			endpoint:      source.Endpoint,
+			endpointTLS:   source.EndpointTls,
+			token:         source.Token,
+			sandboxDomain: source.SandboxProxyDomain,
+			oauthOrgID:    authOrgID,
+		}
+
+		c, err := newRemoteCluster(context.WithoutCancel(ctx), tel, source.ID, config)
+		if err != nil {
+			return nil, err
+		}
+
+		return c, nil
+	}
 
 	p := &Pool{
 		db:       db,
@@ -63,14 +88,10 @@ func NewPool(
 			"clusters-pool",
 			"Clusters pool",
 			clustersSyncStore{
-				config:               config,
-				db:                   db,
-				tel:                  tel,
-				clusters:             clusters,
-				local:                localCluster,
-				localDiscovery:       localDiscovery,
-				queryLogsProvider:    queryLogsProvider,
-				queryMetricsProvider: queryMetricsProvider,
+				db:                db,
+				clusters:          clusters,
+				clusterCreateFunc: clusterCreateFunc,
+				local:             localClusterConfig(),
 			},
 		),
 	}
@@ -106,15 +127,12 @@ func (p *Pool) Close(ctx context.Context) {
 }
 
 // SynchronizationStore is an interface that defines methods for synchronizing the clusters pool with the database
+
 type clustersSyncStore struct {
-	db                   *client.Client
-	tel                  *telemetry.Client
-	clusters             *smap.Map[*Cluster]
-	local                *queries.Cluster
-	localDiscovery       discovery.Discovery
-	queryMetricsProvider clickhouse.Clickhouse
-	queryLogsProvider    *loki.LokiQueryProvider
-	config               cfg.Config
+	db                *client.Client
+	local             *queries.Cluster
+	clusters          *smap.Map[*Cluster]
+	clusterCreateFunc func(context.Context, queries.Cluster) (*Cluster, error)
 }
 
 func (d clustersSyncStore) SourceList(ctx context.Context) ([]queries.Cluster, error) {
@@ -123,7 +141,7 @@ func (d clustersSyncStore) SourceList(ctx context.Context) ([]queries.Cluster, e
 		return nil, err
 	}
 
-	entries := make([]queries.Cluster, 0)
+	entries := make([]queries.Cluster, 0, len(db))
 	for _, row := range db {
 		entries = append(entries, row.Cluster)
 	}
@@ -159,50 +177,24 @@ func (d clustersSyncStore) PoolGet(_ context.Context, source queries.Cluster) (*
 	return d.clusters.Get(source.ID.String())
 }
 
-func (d clustersSyncStore) PoolInsert(ctx context.Context, cluster queries.Cluster) {
-	clusterID := cluster.ID.String()
+func (d clustersSyncStore) PoolInsert(ctx context.Context, source queries.Cluster) {
+	clusterID := source.ID
 
-	logger.L().Info(ctx, "Initializing newly discovered cluster", logger.WithClusterID(cluster.ID))
+	logger.L().Info(ctx, "Initializing newly discovered cluster", logger.WithClusterID(clusterID))
 
-	var c *Cluster
-	var err error
-
-	// Local cluster
-	if cluster.ID == consts.LocalClusterID {
-		c = newLocalCluster(context.WithoutCancel(ctx), d.tel, d.localDiscovery, d.queryMetricsProvider, d.queryLogsProvider, d.config)
-		d.clusters.Insert(clusterID, c)
-		logger.L().Info(ctx, "Local cluster initialized successfully", logger.WithClusterID(cluster.ID))
-
-		return
-	}
-
-	// Remote cluster
-	authOrgID := ""
-	if cluster.AuthOrgID != nil {
-		authOrgID = *cluster.AuthOrgID
-	}
-
-	c, err = newRemoteCluster(
-		context.WithoutCancel(ctx),
-		d.tel,
-		cluster.Endpoint,
-		cluster.EndpointTls,
-		cluster.Token,
-		cluster.ID,
-		cluster.SandboxProxyDomain,
-		authOrgID,
-	)
+	c, err := d.clusterCreateFunc(ctx, source)
 	if err != nil {
-		logger.L().Error(ctx, "Initializing remote cluster failed", zap.Error(err), logger.WithClusterID(cluster.ID))
+		logger.L().Error(ctx, "Error during initializing newly discovered cluster", zap.Error(err), logger.WithClusterID(clusterID))
 
 		return
 	}
 
-	d.clusters.Insert(clusterID, c)
-	logger.L().Info(ctx, "Remote cluster initialized successfully", logger.WithClusterID(cluster.ID))
+	d.clusters.Insert(clusterID.String(), c)
+
+	logger.L().Info(ctx, "Cluster initialized successfully", logger.WithClusterID(clusterID))
 }
 
-func (d clustersSyncStore) PoolUpdate(_ context.Context, _ *Cluster, _ queries.Cluster) {}
+func (d clustersSyncStore) PoolUpdate(_ context.Context, e *Cluster, _ queries.Cluster) {}
 
 func (d clustersSyncStore) PoolRemove(ctx context.Context, cluster *Cluster) {
 	logger.L().Info(ctx, "Removing cluster from pool", logger.WithClusterID(cluster.ID))

--- a/packages/api/internal/clusters/instances_sync.go
+++ b/packages/api/internal/clusters/instances_sync.go
@@ -30,15 +30,15 @@ func (d instancesSyncStore) SourceList(ctx context.Context) ([]discovery.Item, e
 	return items, nil
 }
 
-func (d instancesSyncStore) SourceExists(_ context.Context, s []discovery.Item, p *Instance) bool {
+func (d instancesSyncStore) SourceGet(_ context.Context, s []discovery.Item, p *Instance) (discovery.Item, bool) {
 	for _, item := range s {
 		// With comparing unique identifier that should ensure we are not re-adding same instance again
 		if item.UniqueIdentifier == p.uniqueIdentifier {
-			return true
+			return item, true
 		}
 	}
 
-	return false
+	return discovery.Item{}, false
 }
 
 func (d instancesSyncStore) PoolList(_ context.Context) []*Instance {
@@ -50,10 +50,8 @@ func (d instancesSyncStore) PoolList(_ context.Context) []*Instance {
 	return mapped
 }
 
-func (d instancesSyncStore) PoolExists(_ context.Context, s discovery.Item) bool {
-	_, found := d.instances.Get(s.NodeID)
-
-	return found
+func (d instancesSyncStore) PoolGet(_ context.Context, s discovery.Item) (*Instance, bool) {
+	return d.instances.Get(s.NodeID)
 }
 
 func (d instancesSyncStore) PoolInsert(ctx context.Context, item discovery.Item) {
@@ -79,7 +77,7 @@ func (d instancesSyncStore) PoolInsert(ctx context.Context, item discovery.Item)
 	d.instances.Insert(item.NodeID, instance)
 }
 
-func (d instancesSyncStore) PoolUpdate(ctx context.Context, instance *Instance) {
+func (d instancesSyncStore) PoolUpdate(ctx context.Context, instance *Instance, _ discovery.Item) {
 	_ = d.tryToSyncInstance(ctx, instance)
 }
 

--- a/packages/api/internal/handlers/proxy_grpc.go
+++ b/packages/api/internal/handlers/proxy_grpc.go
@@ -157,7 +157,7 @@ func (s *SandboxService) ResumeSandbox(ctx context.Context, req *proxygrpc.Sandb
 				return nil, status.Errorf(codes.Internal, "cluster with ID '%s' not found", *team.ClusterID)
 			}
 
-			authOrgID = cluster.AuthOrgID
+			authOrgID = cluster.GetOAuthOrgID()
 		}
 
 		if err := oauth.RequireOrgClaims(clientProxyClaims, authOrgID); err != nil {

--- a/packages/api/internal/handlers/sandbox_get.go
+++ b/packages/api/internal/handlers/sandbox_get.go
@@ -104,7 +104,7 @@ func (a *APIStore) GetSandboxesSandboxID(c *gin.Context, id string) {
 			return
 		}
 
-		sbxDomain = cluster.SandboxDomain
+		sbxDomain = cluster.GetSandboxDomain()
 	}
 
 	// Try to get the running sandbox first

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -60,7 +60,7 @@ func (o *Orchestrator) connectToClusterNode(ctx context.Context, cluster *cluste
 		connectCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), nodeConnectTimeout)
 		defer cancel()
 
-		orchestratorNode, err := nodemanager.NewClusterNode(connectCtx, i.GetClient(), cluster.ID, cluster.SandboxDomain, i, o.featureFlagsClient)
+		orchestratorNode, err := nodemanager.NewClusterNode(connectCtx, i.GetClient(), cluster.ID, cluster.GetSandboxDomain(), i, o.featureFlagsClient)
 		if err != nil {
 			logger.L().Error(ctx, "Failed to create node", zap.Error(err))
 

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -225,7 +225,7 @@ func (o *Orchestrator) CreateSandbox(
 			}
 		}
 
-		sbxDomain = cluster.SandboxDomain
+		sbxDomain = cluster.GetSandboxDomain()
 	}
 
 	var trafficAccessToken *string = nil

--- a/packages/shared/pkg/synchronization/synchronization.go
+++ b/packages/shared/pkg/synchronization/synchronization.go
@@ -17,13 +17,13 @@ var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/shared/pkg/synchroni
 
 type Store[SourceItem any, PoolItem any] interface {
 	SourceList(ctx context.Context) ([]SourceItem, error)
-	SourceExists(ctx context.Context, s []SourceItem, p PoolItem) bool
+	SourceGet(ctx context.Context, s []SourceItem, p PoolItem) (SourceItem, bool)
 
 	PoolList(ctx context.Context) []PoolItem
-	PoolExists(ctx context.Context, s SourceItem) bool
+	PoolGet(ctx context.Context, s SourceItem) (PoolItem, bool)
 	PoolInsert(ctx context.Context, s SourceItem)
-	PoolUpdate(ctx context.Context, s PoolItem)
-	PoolRemove(ctx context.Context, s PoolItem)
+	PoolUpdate(ctx context.Context, p PoolItem, s SourceItem)
+	PoolRemove(ctx context.Context, p PoolItem)
 }
 
 // Synchronize is a generic type that provides methods for synchronizing a pool of items with a source.
@@ -124,7 +124,7 @@ func (s *Synchronize[SourceItem, PoolItem]) syncDiscovered(ctx context.Context, 
 			defer wg.Done()
 
 			// item already exists in the pool, skip it
-			if ok := s.store.PoolExists(ctx, item); ok {
+			if _, found := s.store.PoolGet(ctx, item); found {
 				return
 			}
 
@@ -146,9 +146,9 @@ func (s *Synchronize[SourceItem, PoolItem]) syncOutdated(ctx context.Context, so
 		go func(poolItem PoolItem) {
 			defer wg.Done()
 
-			found := s.store.SourceExists(ctx, sourceItems, poolItem)
+			source, found := s.store.SourceGet(ctx, sourceItems, poolItem)
 			if found {
-				s.store.PoolUpdate(ctx, poolItem)
+				s.store.PoolUpdate(ctx, poolItem, source)
 
 				return
 			}

--- a/packages/shared/pkg/synchronization/synchronization_test.go
+++ b/packages/shared/pkg/synchronization/synchronization_test.go
@@ -37,8 +37,12 @@ func (s *testStore) SourceList(context.Context) ([]string, error) {
 	return append([]string(nil), s.source...), nil
 }
 
-func (s *testStore) SourceExists(_ context.Context, source []string, p string) bool {
-	return slices.Contains(source, p)
+func (s *testStore) SourceGet(_ context.Context, source []string, p string) (string, bool) {
+	if slices.Contains(source, p) {
+		return p, true
+	}
+
+	return "", false
 }
 
 func (s *testStore) PoolList(context.Context) []string {
@@ -53,12 +57,12 @@ func (s *testStore) PoolList(context.Context) []string {
 	return out
 }
 
-func (s *testStore) PoolExists(_ context.Context, item string) bool {
+func (s *testStore) PoolGet(_ context.Context, item string) (string, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_, ok := s.pool[item]
+	v, ok := s.pool[item]
 
-	return ok
+	return v, ok
 }
 
 func (s *testStore) PoolInsert(_ context.Context, value string) {
@@ -68,7 +72,7 @@ func (s *testStore) PoolInsert(_ context.Context, value string) {
 	s.inserts++
 }
 
-func (s *testStore) PoolUpdate(context.Context, string) { /* not used */ }
+func (s *testStore) PoolUpdate(context.Context, string, string) { /* not used */ }
 
 func (s *testStore) PoolRemove(_ context.Context, item string) {
 	s.mu.Lock()
@@ -168,5 +172,6 @@ func TestSynchronize_InsertAndRemove(t *testing.T) {
 
 	assert.Equal(t, 1, s.removes)
 	assert.Len(t, s.pool, 1)
-	assert.True(t, s.PoolExists(ctx, "a"))
+	_, ok := s.PoolGet(ctx, "a")
+	assert.True(t, ok)
 }


### PR DESCRIPTION
Handle the case where the cluster configuration (sbx domain, endpoint, secret) is changed, and we are not fetching it, meaning it will be outdated until closed.