### PR TITLE
perf(orch): free guest memory incrementally during snapshot copy

### DIFF
--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -99,6 +99,7 @@ func NewCacheFromMemfd(
 	filePath string,
 	memfd *Memfd,
 	dirty *roaring.Bitmap,
+	punchSource bool,
 ) (*Cache, error) {
 	ctx, span := tracer.Start(ctx, "export-memory-from-memfd",
 		trace.WithAttributes(
@@ -111,7 +112,7 @@ func NewCacheFromMemfd(
 	if err != nil {
 		return nil, errors.Join(err, memfd.Close())
 	}
-	if err := copyFromMemfd(ctx, cache, memfd, dirty, blockSize); err != nil {
+	if err := copyFromMemfd(ctx, cache, memfd, dirty, blockSize, punchSource); err != nil {
 		return nil, errors.Join(err, memfd.Close(), cache.Close())
 	}
 	if err := memfd.Close(); err != nil {
@@ -121,7 +122,12 @@ func NewCacheFromMemfd(
 	return cache, nil
 }
 
-func copyFromMemfd(ctx context.Context, cache *Cache, memfd *Memfd, dirty *roaring.Bitmap, blockSize int64) error {
+// copyFromMemfd copies each dirty range from the memfd into the cache. When
+// punchSource is set, it frees each range from the memfd (memfd.punchHole) as
+// soon as it has been copied, keeping peak (source + destination) memory ~1x
+// instead of ~2x. Punching is DESTRUCTIVE to the guest pages, so callers must
+// only set it on the pause-and-discard path.
+func copyFromMemfd(ctx context.Context, cache *Cache, memfd *Memfd, dirty *roaring.Bitmap, blockSize int64, punchSource bool) error {
 	var cacheOff int64
 	for r := range BitsetRanges(dirty, blockSize) {
 		if err := ctx.Err(); err != nil {
@@ -136,6 +142,16 @@ func copyFromMemfd(ctx context.Context, cache *Cache, memfd *Memfd, dirty *roari
 		copy((*cache.mmap)[cacheOff:cacheOff+r.Size], src)
 		cache.setIsCached(cacheOff, r.Size)
 		cacheOff += r.Size
+
+		// Free the guest range now that it is in the cache. Punch at the source
+		// offset r.Start (the memfd is addressed by guest offset), not the
+		// packed cacheOff. Each dirty range is visited once and never re-read,
+		// so the range reading back as zero afterwards is harmless.
+		if punchSource {
+			if err := memfd.punchHole(r.Start, r.Size); err != nil {
+				return fmt.Errorf("punch memfd source [%d,%d): %w", r.Start, r.Start+r.Size, err)
+			}
+		}
 	}
 
 	return nil
@@ -161,6 +177,7 @@ func NewCacheFromMemfdAsync(
 	filePath string,
 	memfd *Memfd,
 	dirty *roaring.Bitmap,
+	punchSource bool,
 ) (*MemfdCache, error) {
 	ctx, span := tracer.Start(ctx, "export-memory-from-memfd",
 		trace.WithAttributes(
@@ -187,13 +204,13 @@ func NewCacheFromMemfdAsync(
 	copyCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	m := &MemfdCache{cache: cache, cancel: cancel, done: done}
 
-	go m.runCopy(copyCtx, memfd, dirty, blockSize)
+	go m.runCopy(copyCtx, memfd, dirty, blockSize, punchSource)
 
 	return m, nil
 }
 
-func (m *MemfdCache) runCopy(ctx context.Context, memfd *Memfd, dirty *roaring.Bitmap, blockSize int64) {
-	err := copyFromMemfd(ctx, m.cache, memfd, dirty, blockSize)
+func (m *MemfdCache) runCopy(ctx context.Context, memfd *Memfd, dirty *roaring.Bitmap, blockSize int64, punchSource bool) {
+	err := copyFromMemfd(ctx, m.cache, memfd, dirty, blockSize, punchSource)
 	if closeErr := memfd.Close(); closeErr != nil {
 		err = errors.Join(err, fmt.Errorf("close memfd: %w", closeErr))
 	}

--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -69,6 +69,28 @@ func (m *Memfd) Close() error {
 	return err
 }
 
+// punchHole releases the backing pages for [off, off+length) of the memfd via
+// MADV_REMOVE, which frees the shmem/hugetlbfs backing store (like a fallocate
+// hole-punch). It lets a snapshot copy free each guest range as soon as it has
+// been read into the cache, keeping peak (source + destination) memory ~1x
+// instead of ~2x for large sandboxes.
+//
+// off and length must be huge-page aligned: hugetlbfs rejects sub-hugepage
+// ranges, and callers iterate block-aligned dirty ranges, so a misaligned range
+// is a bug rather than a runtime condition. The mapping is PROT_READ, so there
+// is deliberately no clear() fallback (unlike Cache.punchHole): writing would
+// fault and would not free anything.
+//
+// DESTRUCTIVE: this zeroes the pages for every mapping of the fd, including
+// Firecracker's. Only call when the VM is committed to teardown.
+func (m *Memfd) punchHole(off, length int64) error {
+	if off%header.HugepageSize != 0 || length%header.HugepageSize != 0 {
+		return fmt.Errorf("punch range [%d,%d) not %d-aligned", off, off+length, header.HugepageSize)
+	}
+
+	return unix.Madvise(m.mmap[off:off+length], unix.MADV_REMOVE)
+}
+
 // NewCacheFromMemfd builds a Cache populated from a memfd. The memfd is
 // consumed and closed during construction.
 func NewCacheFromMemfd(

--- a/packages/orchestrator/pkg/sandbox/block/memfd_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd_test.go
@@ -141,7 +141,7 @@ func TestNewCacheFromMemfd_NonAdjacentBlocks(t *testing.T) {
 	dirty := roaring.New()
 	dirty.AddMany([]uint32{0, 2, 5})
 
-	cache, err := NewCacheFromMemfd(t.Context(), pageSize, t.TempDir()+"/cache", memfd, dirty)
+	cache, err := NewCacheFromMemfd(t.Context(), pageSize, t.TempDir()+"/cache", memfd, dirty, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = cache.Close() })
 
@@ -164,7 +164,7 @@ func TestNewCacheFromMemfd_NonZeroRangeStart(t *testing.T) {
 	dirty := roaring.New()
 	dirty.AddMany([]uint32{3, 4})
 
-	cache, err := NewCacheFromMemfd(t.Context(), pageSize, t.TempDir()+"/cache", memfd, dirty)
+	cache, err := NewCacheFromMemfd(t.Context(), pageSize, t.TempDir()+"/cache", memfd, dirty, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = cache.Close() })
 
@@ -188,7 +188,7 @@ func TestNewCacheFromMemfdAsync_DetachesAndFlushes(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cachePath := t.TempDir() + "/cache"
-	cache, err := NewCacheFromMemfdAsync(ctx, pageSize, cachePath, memfd, dirty)
+	cache, err := NewCacheFromMemfdAsync(ctx, pageSize, cachePath, memfd, dirty, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = cache.Close() })
 

--- a/packages/orchestrator/pkg/sandbox/fc/memory.go
+++ b/packages/orchestrator/pkg/sandbox/fc/memory.go
@@ -80,6 +80,7 @@ func (p *Process) ExportMemory(
 	originalMemfile block.ReadonlyDevice,
 	dedupBestEffort bool,
 	dedupDirectIO bool,
+	punchSource bool,
 	inputEmpty *roaring.Bitmap,
 	metaOut *utils.SetOnce[*header.DiffMetadata],
 ) (_ block.DiffSource, e error) {
@@ -97,6 +98,8 @@ func (p *Process) ExportMemory(
 	inputMeta := &header.DiffMetadata{Dirty: include, Empty: inputEmpty, BlockSize: blockSize}
 	if memfd != nil {
 		if originalMemfile != nil {
+			// The dedup path is page-granular and does not support incremental
+			// punching, so punchSource is intentionally ignored here.
 			return block.NewCacheFromMemfdDeduped(ctx, originalMemfile, blockSize, cachePath, memfd, include,
 				dedupBestEffort, dedupDirectIO, inputEmpty, metaOut)
 		}
@@ -105,9 +108,9 @@ func (p *Process) ExportMemory(
 			err error
 		)
 		if bgCopy {
-			src, err = block.NewCacheFromMemfdAsync(ctx, blockSize, cachePath, memfd, include)
+			src, err = block.NewCacheFromMemfdAsync(ctx, blockSize, cachePath, memfd, include, punchSource)
 		} else {
-			src, err = block.NewCacheFromMemfd(ctx, blockSize, cachePath, memfd, include)
+			src, err = block.NewCacheFromMemfd(ctx, blockSize, cachePath, memfd, include, punchSource)
 		}
 		if err != nil {
 			return nil, err

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1153,6 +1153,12 @@ func (s *Sandbox) Pause(
 		dedupBestEffort = dedupCfg.Get("bestEffort").BoolValue()
 		dedupDirectIO = dedupCfg.Get("directIO").BoolValue()
 	}
+	// Punch each guest range out of the memfd as it is copied into the cache,
+	// freeing the source pages so peak memory stays ~1x. This is DESTRUCTIVE to
+	// the guest memory, so it is only safe once we are committed to discarding
+	// this VM — a failed copy leaves both the cache and the memfd unusable, so
+	// the snapshot must not be rolled back into a resumed sandbox once enabled.
+	punchSource := s.featureFlags.BoolFlag(ctx, featureflags.MemfdPunchOnSnapshotFlag, sandboxLDContext(s.Runtime, s.Config))
 	memfileDiff, memfileDiffHeader, err := pauseProcessMemory(
 		ctx,
 		buildID,
@@ -1165,6 +1171,7 @@ func (s *Sandbox) Pause(
 		dedupBase,
 		dedupBestEffort,
 		dedupDirectIO,
+		punchSource,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error while post processing: %w", err)
@@ -1251,6 +1258,7 @@ func pauseProcessMemory(
 	originalMemfile block.ReadonlyDevice,
 	dedupBestEffort bool,
 	dedupDirectIO bool,
+	punchSource bool,
 ) (d build.Diff, h *DiffHeader, e error) {
 	ctx, span := tracer.Start(ctx, "process-memory")
 	defer span.End()
@@ -1260,7 +1268,7 @@ func pauseProcessMemory(
 	// ExportMemory owns memfd and closes it on all paths.
 	cache, err := fc.ExportMemory(
 		ctx, diffMetadata.Dirty, memfileDiffPath, diffMetadata.BlockSize, memfd, bgCopy,
-		originalMemfile, dedupBestEffort, dedupDirectIO, diffMetadata.Empty, metaOut,
+		originalMemfile, dedupBestEffort, dedupDirectIO, punchSource, diffMetadata.Empty, metaOut,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to export memory: %w", err)

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -139,6 +139,14 @@ var (
 	// Only takes effect when UseMemFdFlag is also on.
 	MemfdBackgroundCopyFlag = NewBoolFlag("memfd-background-copy", false)
 
+	// MemfdPunchOnSnapshotFlag frees each guest memory range from the memfd
+	// (MADV_REMOVE) as soon as it has been copied into the snapshot cache,
+	// keeping peak (source + destination) memory ~1x instead of ~2x. Only
+	// takes effect when UseMemFdFlag is on. DESTRUCTIVE to the guest pages, so
+	// it must only run on the pause-and-discard path, never where the VM can
+	// still be resumed (rollback).
+	MemfdPunchOnSnapshotFlag = NewBoolFlag("memfd-punch-on-snapshot", false)
+
 	// MemfileDiffDedupFlag enables 4 KiB-page dedup of the memfile diff
 	// against the base memfile. bestEffort skips uncached blocks;
 	// directIO opens the dedup output with O_DIRECT.


### PR DESCRIPTION
Summary

On pause we copy guest memory from the memfd into the snapshot cache while the memfd is still fully resident, holding ~2× guest memory for the duration. This adds the option to punch each range out of the memfd (MADV_REMOVE) right after it's copied, keeping peak at ~1×. Gated behind a new flag, off by default.

Commits

1. Memfd.punchHole — MADV_REMOVE over a huge-page-aligned range (misalignment is a caller bug → error; no clear() fallback since the mapping is PROT_READ).
2. memfd-punch-on-snapshot flag — BoolFlag, default false.
3. Wiring — thread punchSource through copyFromMemfd → NewCacheFromMemfd/Async → ExportMemory → pauseProcessMemory; Pause reads the flag.

Scope

- Memfd path only (the process_vm_readv path has nothing to punch).
- Non-dedup path only (dedup is page-granular, can't punch at huge-page granularity).

⚠️  Safety

The punch is destructive — it zeroes the pages for every mapping of the fd, including Firecracker's. A failed copy leaves both cache and memfd unusable, so it's only correct on the pause-and-discard path. Before enabling, confirm a failed pause discards the sandbox rather than resuming it. Rollback safety is enforced by convention, not code.