### PR TITLE
refactor: migrate errors.As to errors.AsType (Go 1.26 generics)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,6 +78,9 @@ linters:
   settings:
     forbidigo:
       forbid:
+        - pattern: 'errors\.As$'
+          pkg: '^errors$'
+          msg: "Use errors.AsType[T](err) (Go 1.26 generics) instead of errors.As(err, &target)."
         - pattern: '.*\.ErrNoRows$'
           pkg: "^database/sql$"
           msg: "Use github.com/e2b-dev/infra/packages/db/pkg/dberrors.IsNotFoundError instead."

--- a/packages/api/internal/cache/templates/errors.go
+++ b/packages/api/internal/cache/templates/errors.go
@@ -48,17 +48,16 @@ func ErrorToAPIError(err error, fallbackIdentifier string) *api.APIError {
 }
 
 func ToAPIError(err error, identifier string) *api.APIError {
-	var tagErr templateTagNotFoundError
-	switch {
-	case errors.As(err, &tagErr):
+	if tagErr, ok := errors.AsType[templateTagNotFoundError](err); ok {
 		return &api.APIError{
 			Code:      http.StatusNotFound,
 			ClientMsg: fmt.Sprintf("tag '%s' does not exist for template '%s'", tagErr.Tag, identifier),
 			Err:       err,
 		}
-	case errors.Is(err, ErrTemplateNotFound):
-		var notFoundErr templateNotFoundError
-		if errors.As(err, &notFoundErr) {
+	}
+
+	if errors.Is(err, ErrTemplateNotFound) {
+		if notFoundErr, ok := errors.AsType[templateNotFoundError](err); ok {
 			identifier = notFoundErr.Identifier
 		}
 
@@ -67,13 +66,17 @@ func ToAPIError(err error, identifier string) *api.APIError {
 			ClientMsg: fmt.Sprintf("template '%s' not found", identifier),
 			Err:       err,
 		}
-	case errors.Is(err, ErrAccessDenied):
+	}
+
+	if errors.Is(err, ErrAccessDenied) {
 		return &api.APIError{
 			Code:      http.StatusForbidden,
 			ClientMsg: fmt.Sprintf("you don't have access to template '%s'", identifier),
 			Err:       err,
 		}
-	case errors.Is(err, ErrClusterMismatch):
+	}
+
+	if errors.Is(err, ErrClusterMismatch) {
 		return &api.APIError{
 			Code:      http.StatusBadRequest,
 			ClientMsg: fmt.Sprintf("template '%s' is not available in the requested cluster", identifier),
@@ -97,8 +100,8 @@ func (r TemplateRef) APIError(err error) *api.APIError {
 		}
 	}
 
-	var tagErr templateTagNotFoundError
-	if !errors.As(err, &tagErr) {
+	tagErr, ok := errors.AsType[templateTagNotFoundError](err)
+	if !ok {
 		return ToAPIError(err, r.Identifier)
 	}
 

--- a/packages/api/internal/cfg/model.go
+++ b/packages/api/internal/cfg/model.go
@@ -129,8 +129,8 @@ func (e *FailureError) Unwrap() error {
 }
 
 func ParseFailureCondition(err error) (FailureCondition, bool) {
-	var failureErr *FailureError
-	if !errors.As(err, &failureErr) {
+	failureErr, ok := errors.AsType[*FailureError](err)
+	if !ok {
 		return "", false
 	}
 

--- a/packages/api/internal/handlers/admin_api_keys.go
+++ b/packages/api/internal/handlers/admin_api_keys.go
@@ -28,8 +28,7 @@ func (a *APIStore) PostAdminTeamsTeamIDApiKeys(c *gin.Context, teamID openapi_ty
 
 	teamInfo, err := a.authService.GetTeamByID(ctx, teamID)
 	if err != nil {
-		var forbiddenErr *sharedauth.TeamForbiddenError
-		if errors.As(err, &forbiddenErr) {
+		if forbiddenErr, ok := errors.AsType[*sharedauth.TeamForbiddenError](err); ok {
 			a.sendAPIStoreError(c, http.StatusForbidden, forbiddenErr.Error())
 
 			return

--- a/packages/api/internal/handlers/sandbox_connect.go
+++ b/packages/api/internal/handlers/sandbox_connect.go
@@ -77,8 +77,8 @@ func (a *APIStore) PostSandboxesSandboxIDConnect(c *gin.Context, sandboxID api.S
 		}
 
 		// Sandbox exists but isn't running → check which transitional state.
-		var notRunningErr *sandbox.NotRunningError
-		if !errors.As(apiErr.Err, &notRunningErr) {
+		notRunningErr, ok := errors.AsType[*sandbox.NotRunningError](apiErr.Err)
+		if !ok {
 			telemetry.ReportErrorByCode(ctx, apiErr.Code, "error keeping sandbox alive", apiErr.Err,
 				telemetry.WithSandboxID(sandboxID),
 				telemetry.WithTeamID(teamID.String()),

--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -271,8 +271,7 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 			return
 		}
 
-		var vne InvalidVolumeMountsError
-		if errors.As(err, &vne) {
+		if vne, ok := errors.AsType[InvalidVolumeMountsError](err); ok {
 			a.sendAPIStoreError(c, http.StatusBadRequest, vne.Error())
 
 			return

--- a/packages/api/internal/handlers/sandbox_pause.go
+++ b/packages/api/internal/handlers/sandbox_pause.go
@@ -58,7 +58,13 @@ func (a *APIStore) PostSandboxesSandboxIDPause(c *gin.Context, sandboxID api.San
 	pause.LogInitiated(ctx, sandboxID, teamID.String(), pause.ReasonRequest)
 
 	err = a.orchestrator.RemoveSandbox(ctx, teamID, sandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause, FilesystemOnly: filesystemOnly})
-	var transErr *sandbox.InvalidStateTransitionError
+
+	if transErr, ok := errors.AsType[*sandbox.InvalidStateTransitionError](err); ok {
+		pause.LogFailure(ctx, sandboxID, teamID.String(), pause.ReasonRequest, err)
+		a.sendAPIStoreError(c, http.StatusConflict, fmt.Sprintf("Sandbox '%s' cannot be paused while in '%s' state", sandboxID, transErr.CurrentState))
+
+		return
+	}
 
 	switch {
 	case err == nil:
@@ -74,11 +80,6 @@ func (a *APIStore) PostSandboxesSandboxIDPause(c *gin.Context, sandboxID api.San
 			pause.LogFailure(ctx, sandboxID, teamID.String(), pause.ReasonRequest, err)
 		}
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
-
-		return
-	case errors.As(err, &transErr):
-		pause.LogFailure(ctx, sandboxID, teamID.String(), pause.ReasonRequest, err)
-		a.sendAPIStoreError(c, http.StatusConflict, fmt.Sprintf("Sandbox '%s' cannot be paused while in '%s' state", sandboxID, transErr.CurrentState))
 
 		return
 	default:

--- a/packages/api/internal/handlers/snapshot_template_create.go
+++ b/packages/api/internal/handlers/snapshot_template_create.go
@@ -129,8 +129,7 @@ func (a *APIStore) PostSandboxesSandboxIDSnapshots(c *gin.Context, sandboxID api
 			return
 		}
 
-		var transErr *sandbox.InvalidStateTransitionError
-		if errors.As(err, &transErr) {
+		if transErr, ok := errors.AsType[*sandbox.InvalidStateTransitionError](err); ok {
 			a.sendAPIStoreError(c, http.StatusConflict, fmt.Sprintf("Sandbox '%s' cannot be snapshotted while in '%s' state", sandboxID, transErr.CurrentState))
 
 			return

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -444,8 +444,7 @@ func (a *APIStore) GetTeamFromAdminToken(ctx context.Context, _ *gin.Context, te
 
 	team, err := a.authService.GetTeamByID(ctx, teamUUID)
 	if err != nil {
-		var forbiddenErr *sharedauth.TeamForbiddenError
-		if errors.As(err, &forbiddenErr) {
+		if _, ok := errors.AsType[*sharedauth.TeamForbiddenError](err); ok {
 			return nil, &api.APIError{
 				Code:      http.StatusForbidden,
 				ClientMsg: err.Error(),

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -153,10 +153,7 @@ func (o *Orchestrator) CreateSandbox(
 	// Check if team has reached max instances
 	finishStart, waitForStart, err := o.sandboxStore.Reserve(ctx, team.Team.ID, sandboxID, int(totalConcurrentInstances))
 	if err != nil {
-		var limitErr *sandbox.LimitExceededError
-
-		switch {
-		case errors.As(err, &limitErr):
+		if _, ok := errors.AsType[*sandbox.LimitExceededError](err); ok {
 			return sandbox.Sandbox{}, &api.APIError{
 				Code: http.StatusTooManyRequests,
 				ClientMsg: fmt.Sprintf(
@@ -164,14 +161,14 @@ func (o *Orchestrator) CreateSandbox(
 						"please visit 'https://e2b.dev/docs/billing'", totalConcurrentInstances),
 				Err: fmt.Errorf("team '%s' has reached the maximum number of instances (%d)", team.ID, totalConcurrentInstances),
 			}
-		default:
-			logger.L().Error(ctx, "failed to reserve sandbox for team", logger.WithSandboxID(sandboxID), zap.Error(err))
+		}
 
-			return sandbox.Sandbox{}, &api.APIError{
-				Code:      http.StatusInternalServerError,
-				ClientMsg: fmt.Sprintf("Failed to create sandbox: %s", err),
-				Err:       err,
-			}
+		logger.L().Error(ctx, "failed to reserve sandbox for team", logger.WithSandboxID(sandboxID), zap.Error(err))
+
+		return sandbox.Sandbox{}, &api.APIError{
+			Code:      http.StatusInternalServerError,
+			ClientMsg: fmt.Sprintf("Failed to create sandbox: %s", err),
+			Err:       err,
 		}
 	}
 
@@ -185,8 +182,7 @@ func (o *Orchestrator) CreateSandbox(
 		if err != nil {
 			logger.L().Warn(ctx, "Error waiting for sandbox to start", zap.Error(err), logger.WithSandboxID(sandboxID))
 
-			var apiErr *api.APIError
-			if errors.As(err, &apiErr) {
+			if apiErr, ok := errors.AsType[*api.APIError](err); ok {
 				return sandbox.Sandbox{}, apiErr
 			}
 

--- a/packages/api/internal/orchestrator/delete_instance.go
+++ b/packages/api/internal/orchestrator/delete_instance.go
@@ -65,8 +65,7 @@ func (o *Orchestrator) RemoveSandbox(ctx context.Context, teamID uuid.UUID, sand
 				return ErrSandboxNotFound
 			}
 
-			var transErr *sandbox.InvalidStateTransitionError
-			if errors.As(err, &transErr) {
+			if transErr, ok := errors.AsType[*sandbox.InvalidStateTransitionError](err); ok {
 				if transErr.CurrentState == sandbox.StateKilling {
 					logger.L().Info(ctx, "Sandbox is already killed", logger.WithSandboxID(sandboxID))
 

--- a/packages/api/internal/orchestrator/keep_alive.go
+++ b/packages/api/internal/orchestrator/keep_alive.go
@@ -43,19 +43,21 @@ func (o *Orchestrator) KeepAliveFor(ctx context.Context, teamID uuid.UUID, sandb
 		return sbx, nil
 	}
 
-	var sbxNotRunningErr *sandbox.NotRunningError
 	sbx, err := o.sandboxStore.Update(ctx, teamID, sandboxID, updateFunc)
 	if err != nil {
-		switch {
-		case errors.As(err, &sbxNotRunningErr):
+		if sbxNotRunningErr, ok := errors.AsType[*sandbox.NotRunningError](err); ok {
 			return nil, &api.APIError{Code: http.StatusConflict, ClientMsg: utils.SandboxChangingStateMsg(sandboxID, sbxNotRunningErr.State), Err: err}
-		case errors.Is(err, sandbox.ErrNotFound):
-			return nil, &api.APIError{Code: http.StatusNotFound, ClientMsg: utils.SandboxNotFoundMsg(sandboxID), Err: err}
-		case errors.Is(err, errMaxInstanceLengthExceeded):
-			return nil, &api.APIError{Code: http.StatusBadRequest, ClientMsg: "Max instance length exceeded", Err: err}
-		default:
-			return nil, &api.APIError{Code: http.StatusInternalServerError, ClientMsg: "Error when setting sandbox timeout", Err: err}
 		}
+
+		if errors.Is(err, sandbox.ErrNotFound) {
+			return nil, &api.APIError{Code: http.StatusNotFound, ClientMsg: utils.SandboxNotFoundMsg(sandboxID), Err: err}
+		}
+
+		if errors.Is(err, errMaxInstanceLengthExceeded) {
+			return nil, &api.APIError{Code: http.StatusBadRequest, ClientMsg: "Max instance length exceeded", Err: err}
+		}
+
+		return nil, &api.APIError{Code: http.StatusInternalServerError, ClientMsg: "Error when setting sandbox timeout", Err: err}
 	}
 	err = o.UpdateSandbox(ctx, sandboxID, sbx.EndTime, sbx.ClusterID, sbx.NodeID)
 	if err != nil {

--- a/packages/api/internal/orchestrator/update_network.go
+++ b/packages/api/internal/orchestrator/update_network.go
@@ -64,18 +64,17 @@ func (o *Orchestrator) UpdateSandboxNetworkConfig(
 		return sbx, nil
 	}
 
-	var sbxNotRunningErr *sandbox.NotRunningError
-
 	sbx, err := o.sandboxStore.Update(ctx, teamID, sandboxID, updateFunc)
 	if err != nil {
-		switch {
-		case errors.As(err, &sbxNotRunningErr):
+		if sbxNotRunningErr, ok := errors.AsType[*sandbox.NotRunningError](err); ok {
 			return &api.APIError{Code: http.StatusConflict, ClientMsg: utils.SandboxChangingStateMsg(sandboxID, sbxNotRunningErr.State), Err: err}
-		case errors.Is(err, sandbox.ErrNotFound):
-			return &api.APIError{Code: http.StatusNotFound, ClientMsg: utils.SandboxNotFoundMsg(sandboxID), Err: err}
-		default:
-			return &api.APIError{Code: http.StatusInternalServerError, ClientMsg: "Error updating sandbox network config", Err: err}
 		}
+
+		if errors.Is(err, sandbox.ErrNotFound) {
+			return &api.APIError{Code: http.StatusNotFound, ClientMsg: utils.SandboxNotFoundMsg(sandboxID), Err: err}
+		}
+
+		return &api.APIError{Code: http.StatusInternalServerError, ClientMsg: "Error updating sandbox network config", Err: err}
 	}
 
 	// Apply the network update on the orchestrator node.

--- a/packages/api/internal/sandbox/reservations/redis/reservation_test.go
+++ b/packages/api/internal/sandbox/reservations/redis/reservation_test.go
@@ -292,8 +292,7 @@ func TestReservation_ConcurrentReservations(t *testing.T) {
 			if err == nil {
 				successCount.Add(1)
 			} else {
-				var limitExceededError *sandboxtypes.LimitExceededError
-				if errors.As(err, &limitExceededError) {
+				if _, ok := errors.AsType[*sandboxtypes.LimitExceededError](err); ok {
 					limitExceededCount.Add(1)
 				}
 			}
@@ -448,8 +447,7 @@ func TestReservation_RaceConditionStressTest(t *testing.T) {
 						}()
 					}
 				} else {
-					var limitExceededError *sandboxtypes.LimitExceededError
-					if errors.As(err, &limitExceededError) || errors.Is(err, sandboxtypes.ErrAlreadyExists) {
+					if _, ok := errors.AsType[*sandboxtypes.LimitExceededError](err); ok || errors.Is(err, sandboxtypes.ErrAlreadyExists) {
 						operationCount.Add(1)
 					}
 				}

--- a/packages/api/internal/sandbox/reservations/redis/result.go
+++ b/packages/api/internal/sandbox/reservations/redis/result.go
@@ -29,8 +29,7 @@ func encodeResult(sbx sandboxtypes.Sandbox, err error) ([]byte, error) {
 
 	if err != nil {
 		re := &reservationError{Message: err.Error()}
-		var apiErr *api.APIError
-		if errors.As(err, &apiErr) {
+		if apiErr, ok := errors.AsType[*api.APIError](err); ok {
 			re.Code = apiErr.Code
 			re.ClientMsg = apiErr.ClientMsg
 		}
@@ -55,7 +54,7 @@ func decodeResult(data []byte) (sandboxtypes.Sandbox, error) {
 
 // reconstructError rebuilds the appropriate error type from the serialized representation.
 // If the error had an API code, it reconstructs an *api.APIError to preserve
-// errors.As(err, &apiErr) behavior in create_instance.go.
+// errors.AsType[*api.APIError](err) behavior in create_instance.go.
 func reconstructError(re *reservationError) error {
 	if re.Code != 0 {
 		return &api.APIError{

--- a/packages/api/internal/template-manager/create_template.go
+++ b/packages/api/internal/template-manager/create_template.go
@@ -132,8 +132,7 @@ func (tm *TemplateManager) CreateTemplate(
 	if err != nil {
 		// If the error is related to fromTemplate, set the build status to failed with the appropriate message
 		// This is to unify the error handling with fromImage errors
-		var fromTemplateErr *FromTemplateError
-		if !errors.As(err, &fromTemplateErr) {
+		if _, ok := errors.AsType[*FromTemplateError](err); !ok {
 			return fmt.Errorf("failed to set template source: %w", err)
 		}
 

--- a/packages/api/internal/utils/error.go
+++ b/packages/api/internal/utils/error.go
@@ -122,19 +122,17 @@ func processCustomErrors(e *openapi3filter.SecurityRequirementsError) error {
 	unwrapped := e.Errors
 	err := unwrapped[0]
 
-	var teamForbidden *sharedauth.TeamForbiddenError
-	var teamBlocked *sharedauth.TeamBlockedError
 	// Return only the first non-missing authorization header error (if possible)
 	for _, errW := range unwrapped {
 		if errors.Is(errW, sharedauth.ErrNoAuthHeader) {
 			continue
 		}
 
-		if errors.As(errW, &teamForbidden) {
+		if teamForbidden, ok := errors.AsType[*sharedauth.TeamForbiddenError](errW); ok {
 			return fmt.Errorf("%s%s", forbiddenErrPrefix, teamForbidden.Error())
 		}
 
-		if errors.As(errW, &teamBlocked) {
+		if teamBlocked, ok := errors.AsType[*sharedauth.TeamBlockedError](errW); ok {
 			return fmt.Errorf("%s%s", blockedErrPrefix, teamBlocked.Error())
 		}
 

--- a/packages/auth/pkg/auth/middleware.go
+++ b/packages/auth/pkg/auth/middleware.go
@@ -93,8 +93,7 @@ func (a *commonAuthenticator[T]) Authenticate(ctx context.Context, ginCtx *gin.C
 
 		ginCtx.Status(validationError.Code)
 
-		var forbiddenError *TeamForbiddenError
-		if errors.As(validationError.Err, &forbiddenError) {
+		if _, ok := errors.AsType[*TeamForbiddenError](validationError.Err); ok {
 			return validationError.Err
 		}
 

--- a/packages/auth/pkg/auth/service.go
+++ b/packages/auth/pkg/auth/service.go
@@ -104,8 +104,7 @@ func (s *authService) ValidateAPIKey(ctx context.Context, ginCtx *gin.Context, a
 		return s.store.GetTeamByHashedAPIKey(ctx, key)
 	})
 	if err != nil {
-		var forbiddenErr *TeamForbiddenError
-		if errors.As(err, &forbiddenErr) {
+		if _, ok := errors.AsType[*TeamForbiddenError](err); ok {
 			return nil, &APIError{
 				Err:       err,
 				ClientMsg: err.Error(),
@@ -226,8 +225,7 @@ func (s *authService) ValidateAuthProviderTeam(ctx context.Context, ginCtx *gin.
 		return s.store.GetTeamByIDAndUserID(ctx, userID, teamID)
 	})
 	if err != nil {
-		var forbiddenErr *TeamForbiddenError
-		if errors.As(err, &forbiddenErr) {
+		if _, ok := errors.AsType[*TeamForbiddenError](err); ok {
 			return nil, &APIError{
 				Err:       fmt.Errorf("failed getting team: %w", err),
 				ClientMsg: fmt.Sprintf("Forbidden: %s", err.Error()),

--- a/packages/client-proxy/internal/proxy/proxy.go
+++ b/packages/client-proxy/internal/proxy/proxy.go
@@ -155,22 +155,19 @@ func NewClientProxy(meterProvider metric.MeterProvider, serviceName string, port
 			envdAccessToken := r.Header.Get(proxygrpc.MetadataEnvdHTTPAccessToken)
 			nodeIP, err := catalogResolution(ctx, sandboxId, port, trafficAccessToken, envdAccessToken, catalog, pausedSandboxResumer)
 			if err != nil {
-				var resumeDeniedErr *reverseproxy.SandboxResumePermissionDeniedError
-				if errors.As(err, &resumeDeniedErr) {
+				if resumeDeniedErr, ok := errors.AsType[*reverseproxy.SandboxResumePermissionDeniedError](err); ok {
 					l.Warn(ctx, "sandbox resume denied", zap.Error(err))
 
 					return nil, resumeDeniedErr
 				}
 
-				var resourceExhaustedErr *reverseproxy.SandboxResourceExhaustedError
-				if errors.As(err, &resourceExhaustedErr) {
+				if resourceExhaustedErr, ok := errors.AsType[*reverseproxy.SandboxResourceExhaustedError](err); ok {
 					l.Warn(ctx, "sandbox resource exhausted", zap.Error(err))
 
 					return nil, resourceExhaustedErr
 				}
 
-				var stillTransitioningErr *reverseproxy.SandboxStillTransitioningError
-				if errors.As(err, &stillTransitioningErr) {
+				if stillTransitioningErr, ok := errors.AsType[*reverseproxy.SandboxStillTransitioningError](err); ok {
 					l.Warn(ctx, "sandbox still transitioning", zap.Error(err))
 
 					return nil, stillTransitioningErr

--- a/packages/dashboard-api/internal/cfg/model.go
+++ b/packages/dashboard-api/internal/cfg/model.go
@@ -55,8 +55,8 @@ func (e *FailureError) Unwrap() error {
 }
 
 func ParseFailureCondition(err error) (FailureCondition, bool) {
-	var failureErr *FailureError
-	if !errors.As(err, &failureErr) {
+	failureErr, ok := errors.AsType[*FailureError](err)
+	if !ok {
 		return "", false
 	}
 

--- a/packages/dashboard-api/internal/handlers/sandbox_record.go
+++ b/packages/dashboard-api/internal/handlers/sandbox_record.go
@@ -83,7 +83,7 @@ func (s *APIStore) GetSandboxesSandboxIDRecord(c *gin.Context, sandboxID api.San
 }
 
 func isUndefinedTableError(err error) bool {
-	var pgErr *pgconn.PgError
+	pgErr, ok := errors.AsType[*pgconn.PgError](err)
 
-	return errors.As(err, &pgErr) && pgErr.Code == undefinedTableErrorCode
+	return ok && pgErr.Code == undefinedTableErrorCode
 }

--- a/packages/dashboard-api/internal/handlers/utils_provisioning.go
+++ b/packages/dashboard-api/internal/handlers/utils_provisioning.go
@@ -25,8 +25,7 @@ func (s *APIStore) sendProvisioningError(ctx context.Context, c *gin.Context, op
 		return
 	}
 
-	var provisionErr *internalteamprovision.ProvisionError
-	if errors.As(err, &provisionErr) {
+	if provisionErr, ok := errors.AsType[*internalteamprovision.ProvisionError](err); ok {
 		if provisionErr.StatusCode < http.StatusBadRequest || provisionErr.StatusCode >= 600 {
 			telemetry.ReportErrorByCode(ctx, http.StatusInternalServerError, operation+" failed", err, attrs...)
 			s.sendAPIStoreError(c, http.StatusInternalServerError, "Failed to "+operation)

--- a/packages/db/pkg/dberrors/dberrors.go
+++ b/packages/db/pkg/dberrors/dberrors.go
@@ -13,8 +13,7 @@ func IsNotFoundError(err error) bool {
 }
 
 func IsUniqueConstraintViolation(err error) bool {
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pgErr.Code == "23505"
 	}
 
@@ -22,8 +21,7 @@ func IsUniqueConstraintViolation(err error) bool {
 }
 
 func IsForeignKeyViolation(err error) bool {
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pgErr.Code == "23503"
 	}
 

--- a/packages/db/pkg/retry/errors.go
+++ b/packages/db/pkg/retry/errors.go
@@ -25,20 +25,17 @@ func IsRetriable(err error) bool {
 	}
 
 	// Check for PostgreSQL errors
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return isRetriablePgError(pgErr)
 	}
 
 	// Check for connection errors
-	var connErr *pgconn.ConnectError
-	if errors.As(err, &connErr) {
+	if _, ok := errors.AsType[*pgconn.ConnectError](err); ok {
 		return true
 	}
 
 	// Check for network errors
-	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if _, ok := errors.AsType[net.Error](err); ok {
 		return true
 	}
 

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -425,8 +425,8 @@ func (a *API) unmountNFS(ctx context.Context, logger zerolog.Logger, path string
 	// findmnt returns exit code 1 when path is not a mount point - that's not an error.
 	data, err := exec.CommandContext(ctx, "findmnt", "--noheadings", "--output", "SOURCE", path).CombinedOutput()
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		exitErr, ok := errors.AsType[*exec.ExitError](err)
+		if ok && exitErr.ExitCode() == 1 {
 			// Not mounted - nothing to unmount
 			return nil
 		}

--- a/packages/envd/internal/services/filesystem/dir.go
+++ b/packages/envd/internal/services/filesystem/dir.go
@@ -159,8 +159,8 @@ func walkDir(requestedPath string, dirPath string, depth int) (entries []*rpc.En
 
 		entryInfo, err := entryInfo(path)
 		if err != nil {
-			var connectErr *connect.Error
-			if errors.As(err, &connectErr) && connectErr.Code() == connect.CodeNotFound {
+			connectErr, ok := errors.AsType[*connect.Error](err)
+			if ok && connectErr.Code() == connect.CodeNotFound {
 				// Skip entries that don't exist anymore
 				return nil
 			}

--- a/packages/envd/internal/services/filesystem/dir_test.go
+++ b/packages/envd/internal/services/filesystem/dir_test.go
@@ -117,8 +117,7 @@ func TestListDirNonExistingPath(t *testing.T) {
 	})
 	_, err = svc.ListDir(ctx, req)
 	require.Error(t, err)
-	var connectErr *connect.Error
-	ok := errors.As(err, &connectErr)
+	connectErr, ok := errors.AsType[*connect.Error](err)
 	assert.True(t, ok, "expected error to be of type *connect.Error")
 	assert.Equal(t, connect.CodeNotFound, connectErr.Code())
 }
@@ -231,8 +230,7 @@ func TestListDir_Symlinks(t *testing.T) {
 		})
 		_, err := svc.ListDir(ctx, req)
 		require.Error(t, err)
-		var connectErr *connect.Error
-		ok := errors.As(err, &connectErr)
+		connectErr, ok := errors.AsType[*connect.Error](err)
 		assert.True(t, ok, "expected error to be of type *connect.Error")
 		assert.Equal(t, connect.CodeFailedPrecondition, connectErr.Code())
 		assert.Contains(t, connectErr.Error(), "cyclic symlink")

--- a/packages/envd/internal/services/filesystem/move_test.go
+++ b/packages/envd/internal/services/filesystem/move_test.go
@@ -170,8 +170,7 @@ func TestMoveNonExistingFile(t *testing.T) {
 	// Verify the correct error is returned
 	require.Error(t, err)
 
-	var connectErr *connect.Error
-	ok := errors.As(err, &connectErr)
+	connectErr, ok := errors.AsType[*connect.Error](err)
 	assert.True(t, ok, "expected error to be of type *connect.Error")
 	assert.Equal(t, connect.CodeNotFound, connectErr.Code())
 	assert.Contains(t, connectErr.Message(), "source file not found")

--- a/packages/local-dev/seed-local-database.go
+++ b/packages/local-dev/seed-local-database.go
@@ -174,8 +174,7 @@ func upsertUserToken(ctx context.Context, db *authdb.Client, tokenPrefix, token 
 
 func ignoreConstraints(err error) error {
 	// sqlc check
-	var pgconnErr *pgconn.PgError
-	if errors.As(err, &pgconnErr) {
+	if pgconnErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		if pgconnErr.Code == "23505" {
 			return nil
 		}

--- a/packages/orchestrator/cmd/resume-build/shell.go
+++ b/packages/orchestrator/cmd/resume-build/shell.go
@@ -33,9 +33,9 @@ func (e *shellExitedError) Error() string {
 }
 
 func isShellExited(err error) bool {
-	var s *shellExitedError
+	_, ok := errors.AsType[*shellExitedError](err)
 
-	return errors.As(err, &s)
+	return ok
 }
 
 // shellEnv builds the environment passed into the in-guest PTY shell.

--- a/packages/orchestrator/pkg/factories/run.go
+++ b/packages/orchestrator/pkg/factories/run.go
@@ -980,10 +980,11 @@ func run(config cfg.Config, opts Options) (success bool) {
 	}
 
 	logger.L().Info(ctx, "Waiting for services to finish")
-	var sde serviceDoneError
-	if err := g.Wait(); err != nil && !errors.As(err, &sde) {
-		logger.L().Error(ctx, "service group error", zap.Error(err))
-		success = false
+	if err := g.Wait(); err != nil {
+		if _, ok := errors.AsType[serviceDoneError](err); !ok {
+			logger.L().Error(ctx, "service group error", zap.Error(err))
+			success = false
+		}
 	}
 
 	return success

--- a/packages/orchestrator/pkg/sandbox/block/overlay.go
+++ b/packages/orchestrator/pkg/sandbox/block/overlay.go
@@ -39,7 +39,7 @@ func (o *Overlay) ReadAt(ctx context.Context, p []byte, off int64) (int, error) 
 			continue
 		}
 
-		if !errors.As(err, &BytesNotAvailableError{}) {
+		if _, ok := errors.AsType[BytesNotAvailableError](err); !ok {
 			return n, fmt.Errorf("error reading from cache: %w", err)
 		}
 

--- a/packages/orchestrator/pkg/sandbox/block/streaming_chunk.go
+++ b/packages/orchestrator/pkg/sandbox/block/streaming_chunk.go
@@ -81,7 +81,7 @@ func (c *Chunker) Slice(ctx context.Context, off, length int64, upstream storage
 		return b, nil
 	}
 
-	if !errors.As(err, &BytesNotAvailableError{}) {
+	if _, ok := errors.AsType[BytesNotAvailableError](err); !ok {
 		c.metrics.ChunkSliceTimerFactory.Record(ctx, time.Since(sliceStart), 0, storage.ErrAttrs(c.objType, storage.SourceMmap, ct, err))
 
 		return nil, fmt.Errorf("failed read from cache at offset %d: %w", off, err)

--- a/packages/orchestrator/pkg/sandbox/build/build.go
+++ b/packages/orchestrator/pkg/sandbox/build/build.go
@@ -137,8 +137,7 @@ func (b *File) readAt(ctx context.Context, p []byte, off int64) (int, error) {
 		// A Diff can be evicted and closed between planning and reading. Re-plan
 		// the whole read; reads are idempotent, so re-filling already-written
 		// regions is safe and getBuild re-resolves the closed Diff.
-		var closed *block.CacheClosedError
-		if errors.As(err, &closed) {
+		if _, ok := errors.AsType[*block.CacheClosedError](err); ok {
 			continue
 		}
 

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff.go
@@ -173,8 +173,7 @@ func (b *File) createDiff(ctx context.Context, buildID uuid.UUID) (Diff, error) 
 
 				break
 			}
-			var transErr *storage.PeerTransitionedError
-			if !errors.As(peerErr, &transErr) {
+			if _, ok := errors.AsType[*storage.PeerTransitionedError](peerErr); !ok {
 				return nil, fmt.Errorf("createDiff: peer Size for build %s: %w", buildID, peerErr)
 			}
 		}
@@ -306,8 +305,8 @@ func (b *StorageDiff) ReadAt(ctx context.Context, p []byte, off int64, callerFT 
 		return 0, err
 	}
 	n, err := b.chunker.ReadAt(ctx, p, off, up, ft)
-	var transErr *storage.PeerTransitionedError
-	if !errors.As(err, &transErr) {
+	transErr, ok := errors.AsType[*storage.PeerTransitionedError](err)
+	if !ok {
 		return n, err
 	}
 	up, ft, err = b.recoverFromPeerTransition(ctx, transErr, callerFT)
@@ -344,8 +343,8 @@ func (b *StorageDiff) Slice(ctx context.Context, off, length int64, callerFT *st
 		return nil, err
 	}
 	out, err := b.chunker.Slice(ctx, off, length, up, ft)
-	var transErr *storage.PeerTransitionedError
-	if !errors.As(err, &transErr) {
+	transErr, ok := errors.AsType[*storage.PeerTransitionedError](err)
+	if !ok {
 		return out, err
 	}
 	up, ft, err = b.recoverFromPeerTransition(ctx, transErr, callerFT)

--- a/packages/orchestrator/pkg/sandbox/fc/client.go
+++ b/packages/orchestrator/pkg/sandbox/fc/client.go
@@ -472,8 +472,7 @@ func (c *apiClient) startBalloonHinting(ctx context.Context, acknowledgeOnStop b
 		// FC returns 204 (no content) on success, but the FC OpenAPI spec only
 		// declares 200/400 — go-swagger treats any other 2xx as "unexpected
 		// success" and surfaces it as a *runtime.APIError. Honour the 2xx.
-		var apiErr *openapiruntime.APIError
-		if errors.As(err, &apiErr) && apiErr.IsSuccess() {
+		if apiErr, ok := errors.AsType[*openapiruntime.APIError](err); ok && apiErr.IsSuccess() {
 			return nil
 		}
 

--- a/packages/orchestrator/pkg/sandbox/fc/process.go
+++ b/packages/orchestrator/pkg/sandbox/fc/process.go
@@ -280,8 +280,7 @@ func (p *Process) configure(
 
 		waitErr := p.cmd.Wait()
 		if waitErr != nil {
-			var exitErr *exec.ExitError
-			if errors.As(waitErr, &exitErr) {
+			if exitErr, ok := errors.AsType[*exec.ExitError](waitErr); ok {
 				// Check if the process was killed by a signal
 				if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() && (status.Signal() == syscall.SIGKILL || status.Signal() == syscall.SIGTERM) {
 					p.Exit.SetError(nil)
@@ -774,8 +773,7 @@ func (p *Process) DrainBalloon(ctx context.Context) error {
 	}
 
 	if err := p.client.startBalloonHinting(ctx, true); err != nil {
-		var notConfigured *operations.StartBalloonHintingBadRequest
-		if errors.As(err, &notConfigured) {
+		if _, ok := errors.AsType[*operations.StartBalloonHintingBadRequest](err); ok {
 			outcome = "not-configured"
 
 			return nil

--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -33,8 +33,11 @@ func ignoreExpectedAbsent(err error, isExpected func(error) bool) bool {
 		return true
 	}
 
+	// multiUnwrapError is a marker interface without an Error() method, so it
+	// can't be used as the type parameter of errors.AsType (which requires E
+	// to satisfy error). Keep errors.As here.
 	var joined multiUnwrapError
-	if errors.As(err, &joined) {
+	if errors.As(err, &joined) { //nolint:forbidigo // marker interface, see comment above
 		for _, child := range joined.Unwrap() {
 			if !ignoreExpectedAbsent(child, isExpected) {
 				return false
@@ -48,9 +51,12 @@ func ignoreExpectedAbsent(err error, isExpected func(error) bool) bool {
 }
 
 func isIPTablesNotExist(err error) bool {
+	// notExistError is a marker interface without an Error() method, so it
+	// can't be used as the type parameter of errors.AsType (which requires E
+	// to satisfy error). Keep errors.As here.
 	var notExist notExistError
 
-	return errors.As(err, &notExist) && notExist.IsNotExist()
+	return errors.As(err, &notExist) && notExist.IsNotExist() //nolint:forbidigo // marker interface, see comment above
 }
 
 func isRouteNotExist(err error) bool {
@@ -58,9 +64,9 @@ func isRouteNotExist(err error) bool {
 }
 
 func isLinkNotExist(err error) bool {
-	var linkNotFound netlink.LinkNotFoundError
+	_, ok := errors.AsType[netlink.LinkNotFoundError](err)
 
-	return errors.As(err, &linkNotFound) || errors.Is(err, unix.ENODEV) || errors.Is(err, unix.ENOENT)
+	return ok || errors.Is(err, unix.ENODEV) || errors.Is(err, unix.ENOENT)
 }
 
 func isNamespaceNotExist(err error) bool {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/harness_parent_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/harness_parent_test.go
@@ -139,8 +139,7 @@ func configureCrossProcessTest(ctx context.Context, t *testing.T, tt testConfig)
 
 		waitErr := cmd.Wait()
 		if waitErr != nil {
-			var exitErr *exec.ExitError
-			if !errors.As(waitErr, &exitErr) {
+			if _, ok := errors.AsType[*exec.ExitError](waitErr); !ok {
 				t.Logf("helper process Wait: %v", waitErr)
 			}
 		}

--- a/packages/orchestrator/pkg/template/build/commands/copy_test.go
+++ b/packages/orchestrator/pkg/template/build/commands/copy_test.go
@@ -49,8 +49,7 @@ func executeScript(t *testing.T, script string, workDir string) (stdout, stderr 
 	stderr = errBuf.String()
 
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			exitCode = exitErr.ExitCode()
 		} else {
 			t.Fatalf("Failed to execute script: %v", err)

--- a/packages/orchestrator/pkg/template/build/core/oci/oci.go
+++ b/packages/orchestrator/pkg/template/build/core/oci/oci.go
@@ -76,8 +76,7 @@ func wrapImagePullError(ctx context.Context, err error, imageRef string) error {
 	logger.L().Warn(ctx, "failed to pull image", zap.String("image_ref", imageRef), zap.Error(err))
 
 	// Check for transport errors with specific error codes from the registry API
-	var transportErr *transport.Error
-	if errors.As(err, &transportErr) {
+	if transportErr, ok := errors.AsType[*transport.Error](err); ok {
 		for _, e := range transportErr.Errors {
 			switch e.Code {
 			case transport.ManifestUnknownErrorCode:

--- a/packages/orchestrator/pkg/template/build/core/rootfs/rootfs.go
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/rootfs.go
@@ -158,8 +158,7 @@ func (r *Rootfs) CreateExt4Filesystem(
 	maxRootfsSize := units.MBToBytes(int64(r.featureFlags.IntFlag(ctx, featureflags.BuildBaseRootfsSizeLimitMB)))
 	ext4Size, err := oci.ToExt4(ctx, l, img, rootfsPath, maxRootfsSize, template.RootfsBlockSize())
 	if err != nil {
-		var imgErr *oci.ImageTooLargeError
-		if errors.As(err, &imgErr) {
+		if imgErr, ok := errors.AsType[*oci.ImageTooLargeError](err); ok {
 			return containerregistry.Config{}, phases.NewPhaseBuildError(phaseMetadata, imgErr)
 		}
 

--- a/packages/orchestrator/pkg/template/build/phases/errors.go
+++ b/packages/orchestrator/pkg/template/build/phases/errors.go
@@ -29,10 +29,10 @@ func NewPhaseBuildError(phaseMetadata PhaseMeta, err error) *PhaseBuildError {
 }
 
 func UnwrapPhaseBuildError(err error) *PhaseBuildError {
-	var phaseBuildError *PhaseBuildError
-	if errors.As(err, &phaseBuildError) {
-		return phaseBuildError
+	phaseBuildError, ok := errors.AsType[*PhaseBuildError](err)
+	if !ok {
+		return nil
 	}
 
-	return nil
+	return phaseBuildError
 }

--- a/packages/shared/pkg/proxy/handler.go
+++ b/packages/shared/pkg/proxy/handler.go
@@ -18,8 +18,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 		ctx := r.Context()
 		d, err := getDestination(r)
 
-		var mhe MissingHeaderError
-		if errors.As(err, &mhe) {
+		if mhe, ok := errors.AsType[MissingHeaderError](err); ok {
 			logger.L().Warn(ctx, "missing header", zap.Error(mhe))
 			http.Error(w, "missing header", http.StatusBadRequest)
 
@@ -40,16 +39,14 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 			return
 		}
 
-		var invalidPortErr *InvalidSandboxPortError
-		if errors.As(err, &invalidPortErr) {
+		if invalidPortErr, ok := errors.AsType[*InvalidSandboxPortError](err); ok {
 			logger.L().Warn(ctx, "invalid sandbox port", zap.String("host", r.Host), zap.String("port", invalidPortErr.Port))
 			http.Error(w, "Invalid sandbox port", http.StatusBadRequest)
 
 			return
 		}
 
-		var notFoundErr *SandboxNotFoundError
-		if errors.As(err, &notFoundErr) {
+		if notFoundErr, ok := errors.AsType[*SandboxNotFoundError](err); ok {
 			logger.L().Warn(ctx, "sandbox not found",
 				zap.String("host", r.Host),
 				logger.WithSandboxID(notFoundErr.SandboxId))
@@ -67,8 +64,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 			return
 		}
 
-		var resumeDeniedErr *SandboxResumePermissionDeniedError
-		if errors.As(err, &resumeDeniedErr) {
+		if resumeDeniedErr, ok := errors.AsType[*SandboxResumePermissionDeniedError](err); ok {
 			logger.L().Warn(ctx, "sandbox resume permission denied",
 				zap.String("host", r.Host),
 				logger.WithSandboxID(resumeDeniedErr.SandboxId))
@@ -86,8 +82,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 			return
 		}
 
-		var stillTransitioningErr *SandboxStillTransitioningError
-		if errors.As(err, &stillTransitioningErr) {
+		if stillTransitioningErr, ok := errors.AsType[*SandboxStillTransitioningError](err); ok {
 			logger.L().Warn(ctx, "sandbox still transitioning",
 				zap.String("host", r.Host),
 				logger.WithSandboxID(stillTransitioningErr.SandboxId))
@@ -105,8 +100,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 			return
 		}
 
-		var resourceExhaustedErr *SandboxResourceExhaustedError
-		if errors.As(err, &resourceExhaustedErr) {
+		if resourceExhaustedErr, ok := errors.AsType[*SandboxResourceExhaustedError](err); ok {
 			logger.L().Warn(ctx, "team sandbox limit reached",
 				zap.String("host", r.Host),
 				logger.WithSandboxID(resourceExhaustedErr.SandboxId))
@@ -124,8 +118,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 			return
 		}
 
-		var trafficMissingTokenErr *MissingTrafficAccessTokenError
-		if errors.As(err, &trafficMissingTokenErr) {
+		if trafficMissingTokenErr, ok := errors.AsType[*MissingTrafficAccessTokenError](err); ok {
 			logger.L().Warn(ctx, "traffic access token is missing", zap.String("host", r.Host))
 
 			err = template.
@@ -141,8 +134,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 			return
 		}
 
-		var trafficInvalidTokenErr *InvalidTrafficAccessTokenError
-		if errors.As(err, &trafficInvalidTokenErr) {
+		if trafficInvalidTokenErr, ok := errors.AsType[*InvalidTrafficAccessTokenError](err); ok {
 			logger.L().Warn(ctx, "traffic access token is invalid", zap.String("host", r.Host))
 
 			err = template.

--- a/packages/shared/pkg/storage/metrics.go
+++ b/packages/shared/pkg/storage/metrics.go
@@ -74,7 +74,6 @@ var sourceStrings = [numSources]string{
 // Outcome maps a read-path error to the outcome enum. PeerTransitionedError is a
 // routing signal, not a failure, so it gets its own bucket (not err_io).
 func Outcome(err error) string {
-	var transErr *PeerTransitionedError
 	switch {
 	case err == nil:
 		return OutcomeOK
@@ -84,13 +83,19 @@ func Outcome(err error) string {
 		return OutcomeErrCanceled
 	case errors.Is(err, context.DeadlineExceeded):
 		return OutcomeErrTimeout
-	case errors.As(err, &transErr):
+	case isPeerTransitioned(err):
 		return OutcomeTransitioned
 	case errors.Is(err, lock.ErrLockAlreadyHeld):
 		return OutcomeContended
 	default:
 		return OutcomeErrIO
 	}
+}
+
+func isPeerTransitioned(err error) bool {
+	_, ok := errors.AsType[*PeerTransitionedError](err)
+
+	return ok
 }
 
 // numCodecs tracks the CompressionType enum so a new codec grows the table

--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -177,8 +177,7 @@ func (o *awsObject) WriteTo(ctx context.Context, dst io.Writer) (n int64, err er
 
 	resp, err := o.client.GetObject(ctx, &s3.GetObjectInput{Bucket: &o.bucketName, Key: &o.path})
 	if err != nil {
-		var nsk *types.NoSuchKey
-		if errors.As(err, &nsk) {
+		if _, ok := errors.AsType[*types.NoSuchKey](err); ok {
 			return 0, ErrObjectNotExist
 		}
 
@@ -321,8 +320,7 @@ func (o *awsObject) openRangeReader(ctx context.Context, off, length int64) (Ran
 		Range:  aws.String(fmt.Sprintf("bytes=%d-%d", off, off+length-1)),
 	})
 	if err != nil {
-		var nsk *types.NoSuchKey
-		if errors.As(err, &nsk) {
+		if _, ok := errors.AsType[*types.NoSuchKey](err); ok {
 			return nil, ErrObjectNotExist
 		}
 
@@ -342,9 +340,10 @@ func (o *awsObject) Size(ctx context.Context) (_ int64, err error) {
 
 	resp, err := o.client.HeadObject(ctx, &s3.HeadObjectInput{Bucket: &o.bucketName, Key: &o.path})
 	if err != nil {
-		var nsk *types.NoSuchKey
-		var nfd *types.NotFound
-		if errors.As(err, &nsk) || errors.As(err, &nfd) {
+		if _, ok := errors.AsType[*types.NoSuchKey](err); ok {
+			return 0, ErrObjectNotExist
+		}
+		if _, ok := errors.AsType[*types.NotFound](err); ok {
 			return 0, ErrObjectNotExist
 		}
 

--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -590,13 +590,8 @@ func (o *gcpObject) OpenRangeReader(ctx context.Context, offsetU int64, length i
 }
 
 func isResourceExhausted(err error) bool {
-	type grpcStatusProvider interface {
-		GRPCStatus() *status.Status
-	}
-
-	var se grpcStatusProvider
-	if errors.As(err, &se) {
-		return se.GRPCStatus().Code() == codes.ResourceExhausted
+	if s, ok := status.FromError(err); ok {
+		return s.Code() == codes.ResourceExhausted
 	}
 
 	return false

--- a/packages/shared/pkg/storage/storage_url.go
+++ b/packages/shared/pkg/storage/storage_url.go
@@ -59,8 +59,7 @@ func ParseStorageURL(raw string) (Spec, error) {
 	if err != nil {
 		// Do not echo the raw URL: it may carry credentials. url.Error also
 		// embeds the URL, so unwrap it and keep only the underlying cause.
-		var urlErr *url.Error
-		if errors.As(err, &urlErr) {
+		if urlErr, ok := errors.AsType[*url.Error](err); ok {
 			err = urlErr.Err
 		}
 


### PR DESCRIPTION
refactor: migrate errors.As to errors.AsType (Go 1.26 generics)