### PR TITLE
uffd: unregister empty and removed huge pages from UFFD missing pages tracking

### DIFF
--- a/packages/orchestrator/pkg/sandbox/uffd/uffd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/uffd.go
@@ -204,6 +204,13 @@ func (u *Uffd) handle(ctx context.Context, sandboxId string, fdExit *fdexit.FdEx
 		u.memfd.Store(memfd)
 	}
 
+	// Drop MISSING tracking for the snapshot's empty ranges before the guest can
+	// fault, so the kernel serves those zero hugepages directly while WP-async
+	// still catches writes.
+	if err = uffd.DropMissingForEmptyRanges(ctx, u.memfile.Header()); err != nil {
+		return fmt.Errorf("failed to drop MISSING tracking for empty ranges: %w", err)
+	}
+
 	u.handler.SetValue(uffd)
 
 	u.readyOnce.Do(func() { close(u.readyCh) })

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/drop_missing_empty_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/drop_missing_empty_test.go
@@ -11,12 +11,16 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"golang.org/x/sys/unix"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/memory"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/testutils"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 // faultTimeout bounds in-process page faults. A fault that never returns means
@@ -200,4 +204,47 @@ func TestDropMissingForEmptyRanges4KNoop(t *testing.T) {
 	// faulting a page, which blocks forever with no handler, so we assert the
 	// contract via the guard returning nil.
 	require.NoError(t, u.DropMissingForEmptyRanges(t.Context(), h))
+}
+
+// TestDropMissingForEmptyRangesMetric runs the real start-time pass over a
+// hugepage snapshot with two empty ranges and asserts the unregister timer
+// records source="empty" with one operation and the two unregistered hugepages'
+// worth of bytes — i.e. the production path wires the metric correctly.
+//
+//nolint:paralleltest // swaps the package-level unregisterTimer
+func TestDropMissingForEmptyRangesMetric(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("this test requires root privileges")
+	}
+
+	const numberOfPages = 4
+	pagesize := uint64(header.HugepageSize)
+	emptyPages := map[uint64]bool{0: true, 2: true} // two empty hugepages
+	h := buildHeader(t, pagesize, numberOfPages, emptyPages)
+
+	u, _, _ := newHandler(t, pagesize, numberOfPages)
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prev := unregisterTimer
+	unregisterTimer = utils.Must(telemetry.NewTimerFactory(
+		mp.Meter("github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/userfaultfd"),
+		unregisterMetricName,
+		"Time spent dropping MISSING uffd tracking (unregister + WP re-arm)",
+		"Bytes whose MISSING uffd tracking was dropped",
+		"UFFD unregister operations",
+	))
+	t.Cleanup(func() { unregisterTimer = prev })
+
+	require.NoError(t, u.DropMissingForEmptyRanges(t.Context(), h))
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	counts, bytesSum := collectTripletBy(t, rm, unregisterMetricName, "source")
+
+	assert.Equal(t, int64(1), counts["empty"], "one DropMissingForEmptyRanges pass")
+	assert.Equal(t, int64(len(emptyPages))*int64(pagesize), bytesSum["empty"],
+		"bytes for the two empty hugepages")
+	assert.NotContains(t, counts, "remove", "start-time pass must not record source=remove")
 }

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/drop_missing_empty_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/drop_missing_empty_test.go
@@ -1,0 +1,203 @@
+//go:build linux
+
+package userfaultfd
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/memory"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/testutils"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+)
+
+// faultTimeout bounds in-process page faults. A fault that never returns means
+// MISSING tracking is still registered with no handler serving it — surface
+// that as a clean failure instead of hanging the whole test binary.
+const faultTimeout = 5 * time.Second
+
+// runWithTimeout runs fn in a goroutine and fails the test if it does not
+// return within faultTimeout.
+func runWithTimeout(t *testing.T, what string, fn func() error) {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, what)
+	case <-time.After(faultTimeout):
+		t.Fatalf("%s timed out after %s: page fault was not served (MISSING tracking likely still registered)", what, faultTimeout)
+	}
+}
+
+// newHandler builds a Userfaultfd over a freshly mmap'd, MISSING|WP registered
+// region. It returns the handler, the mapped memory and its start address.
+func newHandler(t *testing.T, pagesize uint64, numberOfPages uint64) (*Userfaultfd, []byte, uintptr) {
+	t.Helper()
+
+	size := pagesize * numberOfPages
+
+	// Random source content: an empty page served from source (the regression
+	// we're guarding against) would read as non-zero, so the zero-content
+	// assertion below would catch it.
+	src := RandomPages(pagesize, numberOfPages)
+
+	memoryArea, memoryStart, err := testutils.NewPageMmap(t, size, pagesize)
+	require.NoError(t, err)
+
+	uffdFd, err := newFd(unix.O_CLOEXEC | unix.O_NONBLOCK)
+	require.NoError(t, err)
+	t.Cleanup(func() { uffdFd.close() })
+
+	require.NoError(t, configureApi(uffdFd, pagesize, false))
+	require.NoError(t, register(uffdFd, memoryStart, size, UFFDIO_REGISTER_MODE_MISSING|UFFDIO_REGISTER_MODE_WP))
+
+	mapping := memory.NewMapping([]memory.Region{
+		{
+			BaseHostVirtAddr: memoryStart,
+			Size:             uintptr(size),
+			Offset:           0,
+			PageSize:         uintptr(pagesize),
+		},
+	})
+
+	log, err := logger.NewDevelopmentLogger()
+	require.NoError(t, err)
+
+	u, err := NewUserfaultfdFromFd(uintptr(uffdFd), src, mapping, log)
+	require.NoError(t, err)
+
+	return u, memoryArea, memoryStart
+}
+
+// buildHeader builds a header whose mapping marks emptyPages as uuid.Nil (holes)
+// and every other page as backed by a real build. The pages are 0-indexed in
+// units of pagesize.
+func buildHeader(t *testing.T, pagesize uint64, numberOfPages uint64, emptyPages map[uint64]bool) *header.Header {
+	t.Helper()
+
+	buildID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	var maps []header.BuildMap
+	var storage uint64
+	for p := range numberOfPages {
+		m := header.BuildMap{
+			Offset: p * pagesize,
+			Length: pagesize,
+		}
+		if emptyPages[p] {
+			m.BuildId = uuid.Nil
+		} else {
+			m.BuildId = buildID
+			m.BuildStorageOffset = storage
+			storage += pagesize
+		}
+		maps = append(maps, m)
+	}
+
+	h, err := header.NewHeader(header.NewTemplateMetadata(buildID, pagesize, pagesize*numberOfPages), maps)
+	require.NoError(t, err)
+
+	return h
+}
+
+// TestDropMissingForEmptyRangesHugepage verifies that DropMissingForEmptyRanges:
+//   - drops MISSING tracking for the snapshot's empty (uuid.Nil) hugepages, so
+//     the kernel serves them as zero without a handler (no fault hang);
+//   - keeps WP-async tracking armed: a read-only empty page stays clean
+//     (present + WP set) while a written one turns dirty (present + WP clear);
+//   - leaves non-empty pages untouched (still MISSING-registered, not present).
+//
+// It also implicitly validates that UFFDIO_WRITEPROTECT works on an unpopulated
+// hugepage range on this kernel — if it doesn't, the method returns an error.
+func TestDropMissingForEmptyRangesHugepage(t *testing.T) {
+	t.Parallel()
+
+	if os.Geteuid() != 0 {
+		t.Skip("this test requires root privileges (reads /proc/self/pagemap WP bit)")
+	}
+
+	const numberOfPages = 4
+	pagesize := uint64(header.HugepageSize)
+
+	// Pages 0 and 2 are holes; 1 and 3 are backed.
+	emptyPages := map[uint64]bool{0: true, 2: true}
+	h := buildHeader(t, pagesize, numberOfPages, emptyPages)
+
+	u, memoryArea, memoryStart := newHandler(t, pagesize, numberOfPages)
+
+	require.NoError(t, u.DropMissingForEmptyRanges(t.Context(), h))
+
+	pagemap, err := testutils.NewPagemapReader()
+	require.NoError(t, err)
+	defer pagemap.Close()
+
+	pageAddr := func(p uint64) uintptr { return memoryStart + uintptr(p*pagesize) }
+	pageBytes := func(p uint64) []byte { return memoryArea[p*pagesize : (p+1)*pagesize] }
+
+	// Empty page, read-only: served by the kernel as zero, stays clean.
+	runWithTimeout(t, "read empty page 0", func() error {
+		return unix.Madvise(pageBytes(0), unix.MADV_POPULATE_READ)
+	})
+
+	entry, err := pagemap.ReadEntry(pageAddr(0))
+	require.NoError(t, err)
+	assert.True(t, entry.IsPresent(), "read empty page should be present")
+	assert.True(t, entry.IsWriteProtected(), "read-only empty page should stay clean (WP set)")
+	assert.True(t, bytes.Equal(pageBytes(0), make([]byte, pagesize)),
+		"empty page must be kernel-served zeros, not source content")
+
+	// Empty page, written: WP-async clears the WP bit → dirty.
+	runWithTimeout(t, "write empty page 2", func() error {
+		return unix.Madvise(pageBytes(2), unix.MADV_POPULATE_WRITE)
+	})
+
+	entry, err = pagemap.ReadEntry(pageAddr(2))
+	require.NoError(t, err)
+	assert.True(t, entry.IsPresent(), "written empty page should be present")
+	assert.False(t, entry.IsWriteProtected(), "written empty page should be dirty (WP cleared)")
+
+	// Non-empty pages are left MISSING-registered, so they must not have been
+	// faulted in by the call.
+	for _, p := range []uint64{1, 3} {
+		entry, err := pagemap.ReadEntry(pageAddr(p))
+		require.NoError(t, err)
+		assert.False(t, entry.IsPresent(), "non-empty page %d must be left untouched", p)
+	}
+}
+
+// TestDropMissingForEmptyRanges4KNoop verifies the method is a no-op for 4K
+// pages: dropping MISSING for anonymous 4K pages would zap the PTE and lose WP
+// tracking, so those pages must stay MISSING-registered (the call returns
+// without touching the kernel registration).
+func TestDropMissingForEmptyRanges4KNoop(t *testing.T) {
+	t.Parallel()
+
+	if os.Geteuid() != 0 {
+		t.Skip("this test requires root privileges")
+	}
+
+	const numberOfPages = 4
+	pagesize := uint64(header.PageSize)
+
+	emptyPages := map[uint64]bool{0: true, 2: true}
+	h := buildHeader(t, pagesize, numberOfPages, emptyPages)
+
+	u, _, _ := newHandler(t, pagesize, numberOfPages)
+
+	// 4K is the no-op path: the call must return cleanly without unregistering
+	// anything. A positive "still MISSING-registered" check would require
+	// faulting a page, which blocks forever with no handler, so we assert the
+	// contract via the guard returning nil.
+	require.NoError(t, u.DropMissingForEmptyRanges(t.Context(), h))
+}

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/fd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/fd.go
@@ -150,6 +150,35 @@ func getPagefaultAddress(pagefault *UffdPagefault) uintptr {
 // Fd is a helper type that wraps uffd fd.
 type Fd uintptr
 
+// register a memory region with UFFD
+func (f Fd) register(addr, length uintptr, mode CULong) error {
+	uffdRegister := newUffdioRegister(CULong(addr), CULong(length), mode)
+	if _, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		uintptr(f),
+		UFFDIO_REGISTER,
+		uintptr(unsafe.Pointer(&uffdRegister)),
+	); errno != 0 {
+		return errno
+	}
+
+	return nil
+}
+
+// unregister calls to unregister a memory region from UFFD tracking
+func (f Fd) unregister(addr, length uintptr) error {
+	uffdRange := newUffdioRange(CULong(addr), CULong(length))
+	if _, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		uintptr(f),
+		UFFDIO_UNREGISTER,
+		uintptr(unsafe.Pointer(&uffdRange))); errno != 0 {
+		return errno
+	}
+
+	return nil
+}
+
 // copy requires UFFDIO_COPY_MODE_WP when both MISSING and WP tracking are active.
 func (f Fd) copy(addr, pagesize uintptr, data []byte, mode CULong) error {
 	if len(data) == 0 {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics.go
@@ -100,6 +100,50 @@ func buildServeAttrs() [numPageClass][numFaultResult]metric.MeasurementOption {
 	return t
 }
 
+// unregisterMetricName is the metric under which the time / bytes / count of
+// dropping MISSING uffd tracking (UFFDIO_UNREGISTER + WP re-arm) is reported (a
+// TimerFactory triplet), tagged by the source that triggered it.
+const unregisterMetricName = "orchestrator.sandbox.uffd.unregister"
+
+// unregisterTimer records, per unregister operation, the time spent (ms
+// histogram), the bytes whose MISSING tracking was dropped (counter) and the
+// operation count (counter), tagged by source. The operation is a whole REMOVE
+// batch for source="remove" and a whole DropMissingForEmptyRanges pass for
+// source="empty". Divide bytes by u.pageSize for pages.
+var unregisterTimer = utils.Must(telemetry.NewTimerFactory(
+	meter,
+	unregisterMetricName,
+	"Time spent dropping MISSING uffd tracking (unregister + WP re-arm)",
+	"Bytes whose MISSING uffd tracking was dropped",
+	"UFFD unregister operations",
+))
+
+// unregisterSource classifies what triggered an unregister.
+type unregisterSource uint8
+
+const (
+	unregisterSourceRemove unregisterSource = iota // UFFD_EVENT_REMOVE (guest freed the pages)
+	unregisterSourceEmpty                          // start-time pass over snapshot empty (uuid.Nil) ranges
+	numUnregisterSource
+)
+
+// unregisterAttrs holds a precomputed metric.MeasurementOption per source.
+var unregisterAttrs = buildUnregisterAttrs()
+
+func buildUnregisterAttrs() [numUnregisterSource]metric.MeasurementOption {
+	names := [numUnregisterSource]string{
+		unregisterSourceRemove: "remove",
+		unregisterSourceEmpty:  "empty",
+	}
+
+	var t [numUnregisterSource]metric.MeasurementOption
+	for s := range names {
+		t[s] = telemetry.PrecomputeAttrs(attribute.String("source", names[s]))
+	}
+
+	return t
+}
+
 // prefaultMetricName is the metric under which per-page prefault latency /
 // installed bytes / attempt count are reported (a TimerFactory triplet).
 const prefaultMetricName = "orchestrator.sandbox.uffd.prefault"

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics.go
@@ -53,23 +53,25 @@ const (
 type faultResult uint8
 
 const (
-	faultResultInstalled faultResult = iota // page installed by this serve
-	faultResultPresent                      // page already present: resident short-circuit or lost install race (EEXIST)
-	faultResultDeferred                     // EAGAIN: must be retried later
-	faultResultDiscarded                    // ESRCH: faulting thread gone, retry pointless
-	faultResultError                        // serving failed
-	faultResultSkipped                      // prefault only: tracker already Dirty/Zero — prefetch arrived too late
+	faultResultInstalled   faultResult = iota // page installed by this serve
+	faultResultPresent                        // page already present: resident short-circuit or lost install race (EEXIST)
+	faultResultDeferred                       // EAGAIN: must be retried later
+	faultResultDiscarded                      // ESRCH: faulting thread gone, retry pointless
+	faultResultError                          // serving failed
+	faultResultSkipped                        // prefault only: tracker already Dirty/Zero — prefetch arrived too late
+	faultResultAfterRemove                    // page removed in the same loop
 	numFaultResult
 )
 
 // resultNames maps faultResult values to their metric label strings.
 var resultNames = [numFaultResult]string{
-	faultResultInstalled: "installed",
-	faultResultPresent:   "present",
-	faultResultDeferred:  "deferred",
-	faultResultDiscarded: "discarded",
-	faultResultError:     "error",
-	faultResultSkipped:   "skipped",
+	faultResultInstalled:   "installed",
+	faultResultPresent:     "present",
+	faultResultDeferred:    "deferred",
+	faultResultDiscarded:   "discarded",
+	faultResultError:       "error",
+	faultResultSkipped:     "skipped",
+	faultResultAfterRemove: "removed",
 }
 
 // serveAttrs holds a precomputed metric.MeasurementOption per

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics_test.go
@@ -144,6 +144,56 @@ func TestPrefaultMetric(t *testing.T) {
 	assert.Equal(t, int64(0), bytesSum["deferred"])
 }
 
+// TestUnregisterMetric exercises the unregister recording exactly as the serve
+// loop (per REMOVE batch) and DropMissingForEmptyRanges (per pass) do —
+// unregisterTimer.Begin() + RecordRaw(ctx, bytes, unregisterAttrs[source]) — and
+// asserts the orchestrator.sandbox.uffd.unregister datapoints carry the right
+// source attribute, operation counts and unregistered bytes. Like the other
+// metric tests it pins the metric definition + attrs table in-process (the real
+// paths need a real userfaultfd / forked harness). NOT parallel: it swaps the
+// package-level unregisterTimer.
+//
+//nolint:paralleltest // swaps the package-level unregisterTimer
+func TestUnregisterMetric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	prev := unregisterTimer
+	unregisterTimer = utils.Must(telemetry.NewTimerFactory(
+		mp.Meter("github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/userfaultfd"),
+		unregisterMetricName,
+		"Time spent dropping MISSING uffd tracking (unregister + WP re-arm)",
+		"Bytes whose MISSING uffd tracking was dropped",
+		"UFFD unregister operations",
+	))
+	t.Cleanup(func() { unregisterTimer = prev })
+
+	ctx := context.Background()
+	hp := int64(header.HugepageSize)
+
+	record := func(source unregisterSource, bytes int64, n int) {
+		for range n {
+			sw := unregisterTimer.Begin()
+			sw.RecordRaw(ctx, bytes, unregisterAttrs[source])
+		}
+	}
+	// 3 REMOVE batches, two hugepages dropped each.
+	record(unregisterSourceRemove, 2*hp, 3)
+	// 1 start-time pass, five hugepages dropped.
+	record(unregisterSourceEmpty, 5*hp, 1)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	counts, bytesSum := collectTripletBy(t, rm, unregisterMetricName, "source")
+
+	assert.Equal(t, int64(3), counts["remove"], "remove operation count")
+	assert.Equal(t, 3*(2*hp), bytesSum["remove"], "remove unregistered bytes")
+
+	assert.Equal(t, int64(1), counts["empty"], "empty operation count")
+	assert.Equal(t, 5*hp, bytesSum["empty"], "empty unregistered bytes")
+}
+
 func key(pageClass, result string) string { return pageClass + "/" + result }
 
 // attrKey returns "page_class/result" for serve datapoints and just "result"
@@ -190,6 +240,53 @@ func collectTriplet(t *testing.T, rm metricdata.ResourceMetrics, name string) (c
 				}
 				for _, dp := range data.DataPoints {
 					bytesSum[attrKey(t, dp.Attributes)] += dp.Value
+				}
+			}
+		}
+	}
+
+	require.True(t, sawMetric, "metric %q not found in collected metrics", name)
+
+	return counts, bytesSum
+}
+
+// collectTripletBy is collectTriplet keyed on a single attribute (e.g. "source")
+// rather than the page_class/result pair, for TimerFactory metrics that carry
+// just one label.
+func collectTripletBy(t *testing.T, rm metricdata.ResourceMetrics, name, attrName string) (counts, bytesSum map[string]int64) {
+	t.Helper()
+
+	counts = map[string]int64{}
+	bytesSum = map[string]int64{}
+	sawMetric := false
+
+	keyOf := func(attrs attribute.Set) string {
+		v, ok := attrs.Value(attribute.Key(attrName))
+		require.True(t, ok, "datapoint missing %q attribute", attrName)
+
+		return v.AsString()
+	}
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sawMetric = true
+
+			switch data := m.Data.(type) {
+			case metricdata.Histogram[int64]:
+				for _, dp := range data.DataPoints {
+					counts[keyOf(dp.Attributes)] += int64(dp.Count)
+				}
+			case metricdata.Sum[int64]:
+				// The TimerFactory emits two same-named counters; the
+				// bytes one carries the "By" unit.
+				if m.Unit != "By" {
+					continue
+				}
+				for _, dp := range data.DataPoints {
+					bytesSum[keyOf(dp.Attributes)] += dp.Value
 				}
 			}
 		}

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/remove_event_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/remove_event_test.go
@@ -1,0 +1,143 @@
+//go:build linux
+
+package userfaultfd
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/testutils"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+)
+
+// TestRemoveEventAfterWPReRegister pins the kernel contract that
+// dropMissingEventsTracking relies on: UFFD_EVENT_REMOVE is gated on the VMA
+// being associated with a uffd ctx that negotiated UFFD_FEATURE_EVENT_REMOVE —
+// not on MISSING registration. It walks three phases on the same region:
+//
+//	registered (MISSING|WP)        MADV_DONTNEED -> REMOVE event(s)
+//	unregistered (no re-arm)       MADV_DONTNEED -> NO event (ctx gone)
+//	re-armed WP-only               MADV_DONTNEED -> REMOVE event(s) again
+//
+// The middle phase shows that without the WP-only re-register the events stop;
+// the last shows the WP-only re-register restores them (what the handler does).
+//
+// It drives the fd directly (no Serve loop). A single MADV_DONTNEED can deliver
+// more than one REMOVE message, so each phase fully drains the queue (rather
+// than reading a single message) — otherwise a leftover from one phase would be
+// misread as an event in the next.
+func TestRemoveEventAfterWPReRegister(t *testing.T) {
+	t.Parallel()
+
+	if os.Geteuid() != 0 {
+		t.Skip("this test requires root privileges (userfaultfd creation)")
+	}
+
+	pagesize := uint64(header.HugepageSize)
+	size := pagesize * 2
+
+	mem, start, err := testutils.NewPageMmap(t, size, pagesize) // skips if no hugepages
+	require.NoError(t, err)
+
+	// Non-blocking fd so the drain loop can read until EAGAIN.
+	fd, err := newFd(syscall.O_CLOEXEC | syscall.O_NONBLOCK)
+	require.NoError(t, err)
+	t.Cleanup(func() { fd.close() })
+
+	// removeEnabled=true negotiates UFFD_FEATURE_EVENT_REMOVE.
+	require.NoError(t, configureApi(fd, pagesize, true))
+	require.NoError(t, register(fd, start, size, UFFDIO_REGISTER_MODE_MISSING|UFFDIO_REGISTER_MODE_WP))
+	t.Cleanup(func() {
+		// Unregister before close so a teardown path can't block on an un-acked
+		// event (mirrors the cross-process harness cleanup).
+		_ = unregister(fd, start, size)
+	})
+
+	// Phase 1 — registered (MISSING|WP): a free delivers REMOVE event(s).
+	n1 := freeAndDrainRemoves(t, fd, mem, start, uintptr(size))
+	t.Logf("phase 1 (registered MISSING|WP): %d REMOVE event(s)", n1)
+	require.Positive(t, n1, "registered region should deliver a REMOVE event")
+
+	// Phase 2 — unregister WITHOUT re-arming. The VMA loses its uffd ctx, so a
+	// free should emit no REMOVE event at all (userfaultfd_remove returns early).
+	require.NoError(t, unregister(fd, start, size))
+	n2 := freeAndDrainRemoves(t, fd, mem, start, uintptr(size))
+	t.Logf("phase 2 (unregistered, not re-armed): %d REMOVE event(s)", n2)
+	require.Zero(t, n2, "unregistered region must deliver no REMOVE event")
+
+	// Phase 3 — re-arm WP-only (what dropMissingEventsTracking does on a hugepage
+	// REMOVE): the ctx association is restored, so REMOVE events resume.
+	require.NoError(t, register(fd, start, size, UFFDIO_REGISTER_MODE_WP))
+	n3 := freeAndDrainRemoves(t, fd, mem, start, uintptr(size))
+	t.Logf("phase 3 (WP re-armed): %d REMOVE event(s)", n3)
+	require.Positive(t, n3, "WP re-registered region should deliver a REMOVE event again")
+}
+
+// freeAndDrainRemoves triggers MADV_DONTNEED over mem (in a goroutine — an
+// event-generating free parks until its events are read) and returns the number
+// of UFFD_EVENT_REMOVE messages delivered while it ran, asserting every message
+// is a REMOVE within [start, start+size). It loops polling + draining until the
+// madvise reports completion, so the queue is empty when it returns. A free that
+// generates no event (unregistered range) returns immediately → count 0.
+func freeAndDrainRemoves(t *testing.T, fd Fd, mem []byte, start, size uintptr) int {
+	t.Helper()
+
+	madviseDone := make(chan error, 1)
+	go func() { madviseDone <- unix.Madvise(mem, unix.MADV_DONTNEED) }()
+
+	buf := make([]byte, unsafe.Sizeof(UffdMsg{}))
+	pfds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
+	deadline := time.Now().Add(5 * time.Second)
+
+	// drain reads every currently-queued message, asserting each is a REMOVE.
+	drain := func() (removes int) {
+		for {
+			rn, err := syscall.Read(int(fd), buf)
+			if errors.Is(err, syscall.EAGAIN) {
+				return removes
+			}
+			require.NoError(t, err)
+			require.Equal(t, int(unsafe.Sizeof(UffdMsg{})), rn, "short uffd msg read")
+
+			msg := (*UffdMsg)(unsafe.Pointer(&buf[0]))
+			require.Equal(t, CUChar(UFFD_EVENT_REMOVE), getMsgEvent(msg), "expected only REMOVE events")
+
+			arg := getMsgArg(msg)
+			rm := *(*UffdRemove)(unsafe.Pointer(&arg[0]))
+			assert.GreaterOrEqual(t, uint64(rm.start), uint64(start), "REMOVE start in range")
+			assert.LessOrEqual(t, uint64(rm.end), uint64(start+size), "REMOVE end in range")
+			removes++
+		}
+	}
+
+	count := 0
+	for {
+		count += drain()
+
+		select {
+		case err := <-madviseDone:
+			require.NoError(t, err, "MADV_DONTNEED")
+			// userfaultfd_remove runs synchronously inside the syscall, so all
+			// events are queued by the time it returns — one final drain.
+			count += drain()
+
+			return count
+		default:
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatal("MADV_DONTNEED did not complete within timeout")
+		}
+		// Wait briefly for the madvise to make progress / queue more events.
+		_, err := unix.Poll(pfds, 100)
+		require.NoError(t, err)
+	}
+}

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/remove_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/remove_test.go
@@ -223,8 +223,21 @@ func TestRemoveThenFault(t *testing.T) {
 			states, err := h.pageStates()
 			require.NoError(t, err)
 
-			assert.Empty(t, states.removed, "page should not be in removed state after re-fault")
-			assert.Contains(t, states.faulted, uint(0), "page should be back in faulted state")
+			if tt.pagesize == header.HugepageSize {
+				// Hugepage REMOVE drops MISSING tracking, so the post-remove
+				// write is served by the kernel — the handler never re-faults.
+				// The page stays zero/removed in the tracker; the write is still
+				// captured via WP-async (asserted by checkDirtiness below).
+				assert.Contains(t, states.removed, uint(0),
+					"removed hugepage stays removed: write was kernel-served, not re-faulted")
+				assert.NotContains(t, states.faulted, uint(0),
+					"handler must not re-fault a removed hugepage")
+			} else {
+				// 4K keeps MISSING tracking, so the write re-faults through the
+				// handler.
+				assert.Empty(t, states.removed, "page should not be in removed state after re-fault")
+				assert.Contains(t, states.faulted, uint(0), "page should be back in faulted state")
+			}
 
 			h.checkDirtiness(t, tt.operations)
 		})

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/remove_wp_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/remove_wp_test.go
@@ -1,0 +1,69 @@
+//go:build linux
+
+package userfaultfd
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/testutils"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+)
+
+// TestRemoveHugepageDropsMissingKeepsWP exercises the hugepage REMOVE
+// optimization end-to-end through the real serve loop: after MADV_DONTNEED the
+// handler unregisters MISSING for the range (so the kernel serves the zero page
+// directly, with no re-fault to the handler) while WP-async keeps tracking
+// writes.
+//
+// A post-remove write is therefore NOT observed by the handler — the page stays
+// in the removed/zero tracker state — yet it still shows up as dirty in the
+// pagemap, which is what the snapshot diff relies on.
+func TestRemoveHugepageDropsMissingKeepsWP(t *testing.T) {
+	t.Parallel()
+
+	tt := testConfig{
+		name:          "hugepage remove then write keeps WP tracking",
+		pagesize:      header.HugepageSize,
+		numberOfPages: 2,
+		removeEnabled: true,
+		operations: []operation{
+			{offset: 0, mode: operationModeRead},
+			{offset: 0, mode: operationModeRemove},
+			// Let the serve loop process the REMOVE (unregister + WP re-arm)
+			// before the write, so the write is genuinely kernel-served.
+			{mode: operationModeSleep},
+			{offset: 0, mode: operationModeWrite},
+		},
+	}
+
+	h, err := configureCrossProcessTest(t.Context(), t, tt)
+	require.NoError(t, err)
+
+	h.executeAll(t, tt.operations)
+
+	states, err := h.pageStates()
+	require.NoError(t, err)
+
+	// MISSING was dropped on REMOVE, so the kernel served the post-remove write
+	// without delivering a fault to the handler.
+	assert.Contains(t, states.removed, uint(0),
+		"removed hugepage should stay in the zero/removed tracker state (no re-fault)")
+	assert.NotContains(t, states.faulted, uint(0),
+		"handler must not observe a MISSING fault for the kernel-served write")
+
+	// The write is still captured by WP-async: the page is present and its uffd
+	// WP bit is cleared (dirty).
+	pagemap, err := testutils.NewPagemapReader()
+	require.NoError(t, err)
+	defer pagemap.Close()
+
+	memStart := uintptr(unsafe.Pointer(&(*h.memoryArea)[0]))
+	entry, err := pagemap.ReadEntry(memStart)
+	require.NoError(t, err)
+	assert.True(t, entry.IsPresent(), "written hugepage should be present")
+	assert.False(t, entry.IsWriteProtected(), "written hugepage should be dirty (WP cleared)")
+}

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -268,6 +268,49 @@ func (u *Userfaultfd) dropMissingEventsTracking(ctx context.Context, addr, lengt
 	return nil
 }
 
+// handleRemoves applies a batch of UFFD_EVENT_REMOVE events under
+// settleRequests.Lock: for hugepages it drops MISSING tracking (so the kernel
+// serves the freed pages directly) and marks the range zero in the tracker. It
+// returns the total bytes whose MISSING tracking was dropped, for the
+// unregisterTimer bytes counter.
+func (u *Userfaultfd) handleRemoves(ctx context.Context, removes []*UffdRemove) (int64, error) {
+	u.settleRequests.Lock()
+	defer u.settleRequests.Unlock()
+
+	var unregisteredBytes int64
+	for _, rm := range removes {
+		// rm.start (inclusive) and rm.end (exclusive) are page-aligned to
+		// u.pageSize for the registered VMA (UFFD invariant), so startOff is a
+		// multiple of pageSize and length is an integer number of pages — both
+		// divisions below are exact, and SetRange's half-open [startIdx, endIdx)
+		// lines up with the half-open [rm.start, rm.end).
+		startOff, err := u.ma.GetOffset(uintptr(rm.start))
+		if err != nil {
+			u.logger.Error(ctx, "UFFD REMOVE: failed to map start address",
+				zap.Uintptr("start", uintptr(rm.start)), zap.Error(err))
+
+			continue
+		}
+
+		startIdx := uint32(header.BlockIdx(startOff, int64(u.pageSize)))
+		endIdx := startIdx + uint32(uint64(rm.end-rm.start)/uint64(u.pageSize))
+
+		// For huge pages we can stop tracking MISSING events and keep WP-tracking
+		// enabled. We can't do the same for anonymous 4K pages. When 4K pages are
+		// freed the page table entry is zapped and we lose capability for WP
+		// tracking.
+		if u.pageSize == header.HugepageSize {
+			if err = u.dropMissingEventsTracking(ctx, uintptr(rm.start), uintptr(rm.end-rm.start)); err != nil {
+				return unregisteredBytes, err
+			}
+			unregisteredBytes += int64(rm.end - rm.start)
+		}
+		u.pageTracker.SetRange(startIdx, endIdx, block.Zero)
+	}
+
+	return unregisteredBytes, nil
+}
+
 // writeProtectWithRetry write-protects [addr, addr+length), retrying on EAGAIN.
 // When this runs from the REMOVE handler the triggering MADV_DONTNEED still
 // holds mmap_changing until its thread is rescheduled to ack the event, and the
@@ -317,6 +360,13 @@ func (u *Userfaultfd) DropMissingForEmptyRanges(ctx context.Context, h *header.H
 		return nil
 	}
 
+	// Time the whole pass, mirroring serveTimer. The deferred RecordRaw runs
+	// even on an early error return, so a partial pass still reports the bytes
+	// unregistered and the time spent.
+	sw := unregisterTimer.Begin()
+	var unregisteredBytes int64
+	defer func() { sw.RecordRaw(ctx, unregisteredBytes, unregisterAttrs[unregisterSourceEmpty]) }()
+
 	var ranges, pages int
 	for _, m := range h.Mapping.All() {
 		if m.BuildId != uuid.Nil {
@@ -332,6 +382,7 @@ func (u *Userfaultfd) DropMissingForEmptyRanges(ctx context.Context, h *header.H
 			if err := u.dropMissingEventsTracking(ctx, uintptr(r.Start), uintptr(r.Size)); err != nil {
 				return fmt.Errorf("failed to drop MISSING tracking for empty range [%#x, %#x): %w", r.Start, r.Start+r.Size, err)
 			}
+			unregisteredBytes += r.Size
 			ranges++
 			pages += int(r.Size / int64(u.pageSize))
 		}
@@ -452,37 +503,15 @@ func (u *Userfaultfd) Serve(
 			}
 
 			if len(removes) > 0 {
-				u.settleRequests.Lock()
-				for _, rm := range removes {
-					// rm.start (inclusive) and rm.end (exclusive) are page-aligned
-					// to u.pageSize for the registered VMA (UFFD invariant), so
-					// startOff is a multiple of pageSize and length is an integer
-					// number of pages — both divisions below are exact, and
-					// SetRange's half-open [startIdx, endIdx) lines up with the
-					// half-open [rm.start, rm.end).
-					startOff, err := u.ma.GetOffset(uintptr(rm.start))
-					if err != nil {
-						u.logger.Error(ctx, "UFFD REMOVE: failed to map start address",
-							zap.Uintptr("start", uintptr(rm.start)), zap.Error(err))
-
-						continue
-					}
-
-					startIdx := uint32(header.BlockIdx(startOff, int64(u.pageSize)))
-					endIdx := startIdx + uint32(uint64(rm.end-rm.start)/uint64(u.pageSize))
-
-					// For huge pages we can stop tracking MISSING events and keep WP-tracking
-					// enabled. We can't do the same for anonymous 4K pages. When 4K pages are
-					// freed the page table entry is zapped and we lose capability for WP
-					// tracking.
-					if u.pageSize == header.HugepageSize {
-						if err = u.dropMissingEventsTracking(ctx, uintptr(rm.start), uintptr(rm.end-rm.start)); err != nil {
-							return fmt.Errorf("failed to handle REMOVE: %w", err)
-						}
-					}
-					u.pageTracker.SetRange(startIdx, endIdx, block.Zero)
+				// Time the whole REMOVE batch (unregister + WP re-arm + tracker
+				// update), mirroring serveTimer. RecordRaw runs even on error so
+				// the latency of a failed batch is still captured.
+				sw := unregisterTimer.Begin()
+				unregisteredBytes, err := u.handleRemoves(ctx, removes)
+				sw.RecordRaw(ctx, unregisteredBytes, unregisterAttrs[unregisterSourceRemove])
+				if err != nil {
+					return fmt.Errorf("failed to handle REMOVE: %w", err)
 				}
-				u.settleRequests.Unlock()
 			}
 
 			u.readSerial.Unlock()

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -41,6 +41,16 @@ const (
 	sliceRetryBaseDelay = 50 * time.Millisecond
 	// sliceRetryMaxDelay is the maximum backoff delay between retries.
 	sliceRetryMaxDelay = 500 * time.Millisecond
+
+	// wpMaxRetries bounds the UFFDIO_WRITEPROTECT EAGAIN retry in
+	// dropMissingEventsTracking. Total attempts = wpMaxRetries + 1.
+	wpMaxRetries = 8
+	// wpRetryBaseDelay is the initial backoff before retrying a write-protect
+	// that raced mmap_changing; it doubles each attempt, capped at
+	// wpRetryMaxDelay. The delays are short because mmap_changing clears as soon
+	// as the REMOVE-triggering madvise thread is rescheduled.
+	wpRetryBaseDelay = 1 * time.Millisecond
+	wpRetryMaxDelay  = 10 * time.Millisecond
 )
 
 var ErrUnexpectedEventType = errors.New("unexpected event type")
@@ -138,6 +148,10 @@ const (
 	// faultDiscarded: no install happened and retry is pointless
 	// (e.g. ESRCH — the faulting thread is gone).
 	faultDiscarded
+	// faultAfterRemove: no install happened because we got a UFFD_EVENT_REMOVE
+	// concurrently with a page fault. We first handle the remove event, so
+	// the page fault will be handled by the kernel.
+	faultAfterRemove
 )
 
 // NewUserfaultfdFromFd creates a new userfaultfd instance. Page size is
@@ -233,6 +247,56 @@ func (u *Userfaultfd) readEvents(ctx context.Context) ([]*UffdRemove, []*UffdPag
 	}
 
 	return removes, pagefaults, nil
+}
+
+// dropMissingEventsTracking drops MISSING registration for [addr, addr+len) so the
+// kernel starts handling the page faults (we stop receiving UFFD_EVENT_PAGEFAULT
+// events). We do want the kernel to keep handling the WP bit asynchronously, so
+// we need to re-register the region for WP and write protect it.
+func (u *Userfaultfd) dropMissingEventsTracking(ctx context.Context, addr, length uintptr) error {
+	if err := u.fd.unregister(addr, length); err != nil {
+		return fmt.Errorf("uffd: failed to unregister memory: %w", err)
+	}
+	if err := u.fd.register(addr, length, UFFDIO_REGISTER_MODE_WP); err != nil {
+		return fmt.Errorf("uffd: failed to register memory: %w", err)
+	}
+	if err := u.writeProtectWithRetry(ctx, addr, length); err != nil {
+		return fmt.Errorf("uffd: failed to write protect memory: %w", err)
+	}
+
+	return nil
+}
+
+// writeProtectWithRetry write-protects [addr, addr+length), retrying on EAGAIN.
+// When this runs from the REMOVE handler the triggering MADV_DONTNEED still
+// holds mmap_changing until its thread is rescheduled to ack the event, and the
+// kernel rejects UFFDIO_WRITEPROTECT with EAGAIN until then. The short backoff
+// yields the CPU so that thread can release mmap_changing.
+func (u *Userfaultfd) writeProtectWithRetry(ctx context.Context, addr, length uintptr) error {
+	var err error
+	for attempt := range wpMaxRetries + 1 {
+		err = u.fd.writeProtect(addr, length, UFFDIO_WRITEPROTECT_MODE_WP)
+		if !errors.Is(err, unix.EAGAIN) {
+			// nil (success) or a non-retryable error.
+			return err
+		}
+
+		if attempt >= wpMaxRetries {
+			break
+		}
+
+		delay := min(wpRetryBaseDelay<<attempt, wpRetryMaxDelay)
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+
+			return errors.Join(err, ctx.Err())
+		case <-timer.C:
+		}
+	}
+
+	return err
 }
 
 func (u *Userfaultfd) Serve(
@@ -362,6 +426,16 @@ func (u *Userfaultfd) Serve(
 
 					startIdx := uint32(header.BlockIdx(startOff, int64(u.pageSize)))
 					endIdx := startIdx + uint32(uint64(rm.end-rm.start)/uint64(u.pageSize))
+
+					// For huge pages we can stop tracking MISSING events and keep WP-tracking
+					// enabled. We can't do the same for anonymous 4K pages. When 4K pages are
+					// freed the page table entry is zapped and we lose capability for WP
+					// tracking.
+					if u.pageSize == header.HugepageSize {
+						if err = u.dropMissingEventsTracking(ctx, uintptr(rm.start), uintptr(rm.end-rm.start)); err != nil {
+							return fmt.Errorf("failed to handle REMOVE: %w", err)
+						}
+					}
 					u.pageTracker.SetRange(startIdx, endIdx, block.Zero)
 				}
 				u.settleRequests.Unlock()
@@ -506,6 +580,9 @@ func (u *Userfaultfd) Serve(
 				case faultDiscarded:
 					// No install happened (ESRCH); retry would be pointless.
 					result = faultResultDiscarded
+				case faultAfterRemove:
+					// No install happened
+					result = faultResultAfterRemove
 				default:
 					result = faultResultError
 
@@ -564,7 +641,8 @@ func (u *Userfaultfd) faultPage(
 	case source == nil && u.pageSize == header.PageSize && accessType == block.Write:
 		writeErr = u.fd.zero(addr, u.pageSize, 0)
 	case source == nil && u.pageSize == header.HugepageSize:
-		writeErr = u.fd.copy(addr, u.pageSize, header.EmptyHugePage, mode)
+		// Nothing to do, handling removes in the current loop unregistered the page.
+		return faultAfterRemove, nil
 	default:
 		var b []byte
 		if u.pageSize == header.HugepageSize {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -14,6 +14,7 @@ import (
 	"unsafe"
 
 	"github.com/RoaringBitmap/roaring/v2"
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -297,6 +298,49 @@ func (u *Userfaultfd) writeProtectWithRetry(ctx context.Context, addr, length ui
 	}
 
 	return err
+}
+
+// DropMissingForEmptyRanges stops MISSING-fault tracking for every region the
+// snapshot we serve reports as empty (uuid.Nil mappings), so the kernel serves
+// those zero hugepages directly without a userspace round-trip while WP-async
+// keeps capturing any later writes. Hugepages only: dropping MISSING for
+// anonymous 4K pages zaps the PTE and loses WP tracking (see the REMOVE handler).
+//
+// Unlike the REMOVE path it does NOT mark the pages block.Zero. They are already
+// uuid.Nil in the base snapshot, so an untouched page falls through to the base
+// layer and a written one is caught by WP-async; marking them Zero would only
+// bloat every diff with redundant empty entries that duplicate the base.
+//
+// Must run before the guest can fault (before the handler is marked ready).
+func (u *Userfaultfd) DropMissingForEmptyRanges(ctx context.Context, h *header.Header) error {
+	if h == nil || u.pageSize != header.HugepageSize {
+		return nil
+	}
+
+	var ranges, pages int
+	for _, m := range h.Mapping.All() {
+		if m.BuildId != uuid.Nil {
+			continue
+		}
+
+		hostVirtRanges, err := u.ma.GetHostVirtRanges(int64(m.Offset), int64(m.Length))
+		if err != nil {
+			return fmt.Errorf("failed to resolve host virt ranges for empty range [%d, %d): %w", m.Offset, m.Offset+m.Length, err)
+		}
+
+		for _, r := range hostVirtRanges {
+			if err := u.dropMissingEventsTracking(ctx, uintptr(r.Start), uintptr(r.Size)); err != nil {
+				return fmt.Errorf("failed to drop MISSING tracking for empty range [%#x, %#x): %w", r.Start, r.Start+r.Size, err)
+			}
+			ranges++
+			pages += int(r.Size / int64(u.pageSize))
+		}
+	}
+
+	u.logger.Debug(ctx, "UFFD: dropped MISSING tracking for snapshot empty ranges",
+		zap.Int("ranges", ranges), zap.Int("pages", pages))
+
+	return nil
 }
 
 func (u *Userfaultfd) Serve(


### PR DESCRIPTION
## What

Unregister huge pages from UFFD in two cases:
* At sandbox start-up: all pages for all ranges with backing build Id that points to `nil`
* On demand: pages for which we receive a UFFD_EVENT_REMOVE event

Also, add tests that ensure that everything works as expected

## Why

UFFD handling for known zero pages (ranges with nil block ID) and pages that the guest has deallocated essentially boils down to providing a zero page. This is adds overhead in page fault handling (round-trip: `guest -> host kernel ->orchestrator -> host kernel -> guest`). Un-registering those pages from UFFD trims down the round trip to: `guest -> host kernel -> guest`.

This introduces real overhead to page fault handling. Using a simple `dd`-like command that touches 1GiB on my laptop shows a throughput of ~1.3GiB/sec on `main` vs ~2.0GiB/sec with the changes introduced here.

## How

We know the initially empty pages, so we unregister them before starting the sandbox. We also unregister all pages for which we receive a UFFD_EVENT_REMOVE. The catch is we use UFFD asynchronous write protection to track dirty pages. So, after unregistering the pages we re-register them, this time using only `UFFDIO_REGISTER_MODE_WP`. This way we keep accurate dirty-page info without handling zero pages.

**Note**: this doesn't work with anonymous 4K pages. As, [userfaultfd documentation](https://docs.kernel.org/admin-guide/mm/userfaultfd.html#write-protect-notifications) mentions:

> For anonymous memory, ioctl(UFFDIO_WRITEPROTECT) will ignore none ptes (e.g. when pages are missing and not populated). For file-backed memories like shmem and hugetlbfs, none ptes will be write protected just like a present pte. In other words, there will be a userfaultfd write fault message generated when writing to a missing page on file typed memories, as long as the page range was write-protected before. Such a message will not be generated on anonymous memories by default.

So, at the moment, this behaviour is restricted in 4K pages only

