### PR TITLE
Add AWS client cache volume

### DIFF
--- a/iac/provider-aws/modules/nodepool-client/main.tf
+++ b/iac/provider-aws/modules/nodepool-client/main.tf
@@ -148,6 +148,16 @@ resource "aws_launch_template" "client" {
     }
   }
 
+  block_device_mappings {
+    device_name = var.cache_disk_device_name
+
+    ebs {
+      volume_size           = var.cache_disk_size_gb
+      volume_type           = var.cache_disk_type
+      delete_on_termination = true
+    }
+  }
+
   cpu_options {
     nested_virtualization = var.nested_virtualization ? "enabled" : "disabled"
   }

--- a/iac/provider-aws/modules/nodepool-client/scripts/start-client.sh
+++ b/iac/provider-aws/modules/nodepool-client/scripts/start-client.sh
@@ -15,7 +15,68 @@ set -x
 # Inspired by https://alestic.com/2010/12/ec2-user-data-output/
 exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
-mkdir -p /orchestrator
+# Mount the dedicated cache EBS volume for orchestrator data.
+MOUNT_POINT="/orchestrator"
+root_source=$(findmnt -n -o SOURCE /)
+root_device=$(lsblk -no PKNAME "$root_source" 2>/dev/null | tr -d '[:space:]' || true)
+if [ -z "$root_device" ]; then
+  root_device=$(lsblk -rno PKNAME,MOUNTPOINT | while read -r pk mountpoint; do
+    if [ "$mountpoint" = "/" ]; then
+      echo "$pk"
+      break
+    fi
+  done)
+fi
+DISK=""
+
+for attempt in {1..60}; do
+  for candidate in /dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_* /dev/nvme*n1 /dev/xvd* /dev/sd*; do
+    if [ ! -b "$candidate" ]; then
+      continue
+    fi
+
+    candidate_type=$(lsblk -ndo TYPE "$candidate" || true)
+    if [ "$candidate_type" != "disk" ]; then
+      continue
+    fi
+
+    candidate_device=$(basename "$(readlink -f "$candidate")")
+    if [ "$candidate_device" = "$root_device" ]; then
+      continue
+    fi
+
+    if [ -n "$(lsblk -no MOUNTPOINT "$candidate" | tr -d '[:space:]')" ]; then
+      continue
+    fi
+
+    DISK="$candidate"
+    break
+  done
+
+  if [ -n "$DISK" ]; then
+    break
+  fi
+
+  echo "waiting for cache disk ($attempt/60)"
+  sleep 1
+done
+
+if [ -z "$DISK" ]; then
+  echo "failed to find cache disk"
+  lsblk
+  exit 1
+fi
+
+until mkfs.xfs -f -b size=4096 "$DISK"; do
+  echo "failed to make file system, trying again ... "
+  sleep 1
+done
+
+mkdir -p "$MOUNT_POINT"
+cache_disk_uuid=$(blkid -s UUID -o value "$DISK")
+echo "UUID=$cache_disk_uuid    $MOUNT_POINT    xfs noatime 0 0" | tee -a /etc/fstab
+mount "$MOUNT_POINT"
+
 mkdir -p /orchestrator/sandbox
 mkdir -p /orchestrator/template
 mkdir -p /orchestrator/build

--- a/iac/provider-aws/modules/nodepool-client/variables.tf
+++ b/iac/provider-aws/modules/nodepool-client/variables.tf
@@ -86,6 +86,24 @@ variable "boot_disk_size_gb" {
   description = "Root volume size in GB"
 }
 
+variable "cache_disk_size_gb" {
+  type        = number
+  default     = 500
+  description = "Cache volume size in GB"
+}
+
+variable "cache_disk_type" {
+  type        = string
+  default     = "gp3"
+  description = "Cache volume type"
+}
+
+variable "cache_disk_device_name" {
+  type        = string
+  default     = "/dev/sdf"
+  description = "Requested device name for the cache volume"
+}
+
 variable "consul_acl_token" {
   type = string
 }

--- a/iac/provider-aws/nomad-cluster-disk-image/main.pkr.hcl
+++ b/iac/provider-aws/nomad-cluster-disk-image/main.pkr.hcl
@@ -85,7 +85,7 @@ build {
   provisioner "shell" {
     inline = [
       "sudo apt-get update",
-      "sudo apt-get install -y nvme-cli unzip jq net-tools qemu-utils make build-essential openssh-client openssh-server", # TODO: openssh-server is updated to prevent security vulnerabilities
+      "sudo apt-get install -y nvme-cli unzip jq net-tools qemu-utils xfsprogs make build-essential openssh-client openssh-server", # TODO: openssh-server is updated to prevent security vulnerabilities
     ]
   }
 

--- a/iac/provider-aws/nomad-cluster-disk-image/variables.pkr.hcl
+++ b/iac/provider-aws/nomad-cluster-disk-image/variables.pkr.hcl
@@ -7,7 +7,7 @@ variable "aws_profile" {
 }
 
 variable "source_ami_filter_name" {
-  type = string
+  type    = string
   default = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
 }
 


### PR DESCRIPTION
## Summary
- attach a dedicated EBS cache volume to AWS client nodes
- format and mount the cache volume as XFS at /orchestrator
- install xfsprogs in the AWS client AMI build

## Validation
- terraform validate in iac/provider-aws/modules/nodepool-client
- packer validate in iac/provider-aws/nomad-cluster-disk-image
- bash -n iac/provider-aws/modules/nodepool-client/scripts/start-client.sh