### PR TITLE
Replace UUID v4 with UUID v7

### DIFF
--- a/packages/api/internal/cache/templates/template_build_test.go
+++ b/packages/api/internal/cache/templates/template_build_test.go
@@ -22,12 +22,12 @@ func TestRedisTemplatesBuildCache_Get_CacheHit(t *testing.T) {
 
 	c := NewTemplateBuildCache(db.SqlcClient, redisClient)
 
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 	info := TemplateBuildInfo{
-		TeamID:      uuid.New(),
+		TeamID:      uuid.Must(uuid.NewV7()),
 		TemplateID:  "test-template",
 		BuildStatus: types.BuildStatusGroupInProgress,
-		ClusterID:   uuid.New(),
+		ClusterID:   uuid.Must(uuid.NewV7()),
 	}
 
 	// Store in Redis via the cache's Set
@@ -50,12 +50,12 @@ func TestRedisTemplatesBuildCache_Get_L2Hit(t *testing.T) {
 
 	c := NewTemplateBuildCache(db.SqlcClient, redisClient)
 
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 	info := TemplateBuildInfo{
-		TeamID:      uuid.New(),
+		TeamID:      uuid.Must(uuid.NewV7()),
 		TemplateID:  "test-template",
 		BuildStatus: types.BuildStatusGroupInProgress,
-		ClusterID:   uuid.New(),
+		ClusterID:   uuid.Must(uuid.NewV7()),
 	}
 
 	// Store directly in Redis
@@ -107,7 +107,7 @@ func TestRedisTemplatesBuildCache_Get_NotFound(t *testing.T) {
 	defer c.Close(t.Context())
 
 	// Try to get non-existent build
-	_, err := c.Get(ctx, uuid.New(), "non-existent-template")
+	_, err := c.Get(ctx, uuid.Must(uuid.NewV7()), "non-existent-template")
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrTemplateBuildInfoNotFound)
 }
@@ -122,12 +122,12 @@ func TestRedisTemplatesBuildCache_Invalidate(t *testing.T) {
 	c := NewTemplateBuildCache(db.SqlcClient, redisClient)
 	defer c.Close(t.Context())
 
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 	info := TemplateBuildInfo{
-		TeamID:      uuid.New(),
+		TeamID:      uuid.Must(uuid.NewV7()),
 		TemplateID:  "test-template",
 		BuildStatus: types.BuildStatusGroupInProgress,
-		ClusterID:   uuid.New(),
+		ClusterID:   uuid.Must(uuid.NewV7()),
 	}
 
 	// Store in Redis via the cache

--- a/packages/api/internal/db/snapshots_test.go
+++ b/packages/api/internal/db/snapshots_test.go
@@ -18,8 +18,8 @@ import (
 func createTestSnapshot(t *testing.T, db *testutils.Database, teamID uuid.UUID, baseEnvID string) (string, string, uuid.UUID) {
 	t.Helper()
 
-	sandboxID := "sandbox-" + uuid.New().String()
-	envID := "env-" + uuid.New().String()
+	sandboxID := "sandbox-" + uuid.Must(uuid.NewV7()).String()
+	envID := "env-" + uuid.Must(uuid.NewV7()).String()
 	kernelVersion := "6.1.0"
 	firecrackerVersion := "1.4.0"
 	envdVersion := "v1.0.0"
@@ -71,7 +71,7 @@ func createTestSnapshot(t *testing.T, db *testutils.Database, teamID uuid.UUID, 
 func createTestEnvBuild(t *testing.T, db *testutils.Database, envID string) uuid.UUID {
 	t.Helper()
 
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 	vcpu := int32(2)
 	ramMb := int32(2048)
 	freeDisk := int64(512)

--- a/packages/api/internal/handlers/accesstoken.go
+++ b/packages/api/internal/handlers/accesstoken.go
@@ -40,7 +40,7 @@ func (a *APIStore) PostAccessTokens(c *gin.Context) {
 	}
 
 	accessTokenDB, err := a.authDB.Write.CreateAccessToken(ctx, authqueries.CreateAccessTokenParams{
-		ID:                    uuid.New(),
+		ID:                    uuid.Must(uuid.NewV7()),
 		UserID:                userID,
 		AccessTokenHash:       accessToken.HashedValue,
 		AccessTokenPrefix:     accessToken.Masked.Prefix,

--- a/packages/api/internal/handlers/admin_api_keys_test.go
+++ b/packages/api/internal/handlers/admin_api_keys_test.go
@@ -140,7 +140,7 @@ func TestPostAdminTeamsTeamIDApiKeysRejectsMissingTeam(t *testing.T) {
 	t.Parallel()
 
 	testDB := testutils.SetupDatabase(t)
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 
 	recorder := httptest.NewRecorder()
 	ginCtx, _ := gin.CreateTestContext(recorder)
@@ -164,7 +164,7 @@ func TestPostAdminTeamsTeamIDApiKeysRejectsNilTeam(t *testing.T) {
 	t.Parallel()
 
 	testDB := testutils.SetupDatabase(t)
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 
 	recorder := httptest.NewRecorder()
 	ginCtx, _ := gin.CreateTestContext(recorder)
@@ -236,7 +236,7 @@ func TestDeleteAdminTeamsTeamIDApiKeysRejectsMissingKey(t *testing.T) {
 	store := &APIStore{authDB: testDB.AuthDB}
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
-	missingKeyID := uuid.New()
+	missingKeyID := uuid.Must(uuid.NewV7())
 	ctx.Request = httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/admin/teams/"+teamID.String()+"/api-keys/"+missingKeyID.String(), nil)
 
 	store.DeleteAdminTeamsTeamIDApiKeysApiKeyID(ctx, teamID, missingKeyID.String())

--- a/packages/api/internal/handlers/sandbox.go
+++ b/packages/api/internal/handlers/sandbox.go
@@ -62,7 +62,7 @@ func (a *APIStore) startSandboxInternal(
 	endTime := startTime.Add(timeout)
 
 	// Unique ID for the execution (from start/resume to stop/pause)
-	executionID := uuid.New().String()
+	executionID := uuid.Must(uuid.NewV7()).String()
 
 	creationMeta := buildCreationMetadata(team, requestHeader, isResume, mcp)
 

--- a/packages/api/internal/handlers/sandbox_create_test.go
+++ b/packages/api/internal/handlers/sandbox_create_test.go
@@ -764,7 +764,7 @@ func setTemplatePublic(ctx context.Context, t *testing.T, db *testutils.Database
 func createTestTemplate(ctx context.Context, t *testing.T, db *testutils.Database, teamID uuid.UUID) string {
 	t.Helper()
 
-	templateID := "base-env-" + uuid.New().String()
+	templateID := "base-env-" + uuid.Must(uuid.NewV7()).String()
 
 	err := db.SqlcClient.TestsRawSQL(
 		ctx,
@@ -811,7 +811,7 @@ func simpleRule(headers map[string]string) api.SandboxNetworkRule {
 func TestValidateNetworkRules(t *testing.T) {
 	t.Parallel()
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 
 	tests := []struct {
 		name        string

--- a/packages/api/internal/handlers/volume_get_test.go
+++ b/packages/api/internal/handlers/volume_get_test.go
@@ -32,11 +32,11 @@ func TestGenerateVolumeContentToken_SetsTokidHeader(t *testing.T) {
 	}
 
 	// Arrange a team and volume
-	teamID := uuid.New()
-	clusterID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
+	clusterID := uuid.Must(uuid.NewV7())
 	team := &types.Team{Team: &authqueries.Team{ID: teamID, ClusterID: &clusterID}}
 
-	volID := uuid.New()
+	volID := uuid.Must(uuid.NewV7())
 	volume := queries.Volume{
 		ID:         volID,
 		TeamID:     teamID,

--- a/packages/api/internal/handlers/volume_token.go
+++ b/packages/api/internal/handlers/volume_token.go
@@ -38,7 +38,7 @@ func generateVolumeContentToken(config cfg.VolumesTokenConfig, volume queries.Vo
 		"exp": jwt.NewNumericDate(expiration),
 		"iat": jwt.NewNumericDate(now),
 		"iss": config.Issuer,
-		"jti": uuid.NewString(),
+		"jti": uuid.Must(uuid.NewV7()).String(),
 		"nbf": jwt.NewNumericDate(now),
 		"sub": team.ID.String(),
 

--- a/packages/api/internal/middleware/ratelimit/ratelimit_test.go
+++ b/packages/api/internal/middleware/ratelimit/ratelimit_test.go
@@ -118,7 +118,7 @@ func TestMiddleware_FailOpen(t *testing.T) {
 	defer badClient.Close()
 
 	limiter := redis_rate.NewLimiter(badClient)
-	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.New())
+	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.Must(uuid.NewV7()))
 
 	w := doRequest(t, r)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -135,7 +135,7 @@ func TestMiddleware_FailClosed(t *testing.T) {
 	defer badClient.Close()
 
 	limiter := redis_rate.NewLimiter(badClient)
-	r := newRouterWithTeam(t, limiter, Config{FailOpen: false}, ff, uuid.New())
+	r := newRouterWithTeam(t, limiter, Config{FailOpen: false}, ff, uuid.Must(uuid.NewV7()))
 
 	w := doRequest(t, r)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
@@ -150,7 +150,7 @@ func TestMiddleware_UnconfiguredRouteAllowsThrough(t *testing.T) {
 	defer badClient.Close()
 
 	limiter := redis_rate.NewLimiter(badClient)
-	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.New())
+	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.Must(uuid.NewV7()))
 
 	w := doRequest(t, r)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -171,7 +171,7 @@ func TestIntegration_AllowedRequestSetsHeaders(t *testing.T) {
 	limiter := redis_rate.NewLimiter(redisClient)
 	ff := newTestFF(t, routeConfig(10, 20))
 
-	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.New())
+	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.Must(uuid.NewV7()))
 
 	w := doRequest(t, r)
 
@@ -192,7 +192,7 @@ func TestIntegration_BurstThenDeny(t *testing.T) {
 	limiter := redis_rate.NewLimiter(redisClient)
 	ff := newTestFF(t, routeConfig(1, 3))
 
-	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.New())
+	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.Must(uuid.NewV7()))
 
 	// First 3 requests should succeed (burst).
 	for i := range 3 {
@@ -226,7 +226,7 @@ func TestIntegration_Refill(t *testing.T) {
 	limiter := redis_rate.NewLimiter(redisClient)
 	ff := newTestFF(t, routeConfig(10, 2))
 
-	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.New())
+	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.Must(uuid.NewV7()))
 
 	// Exhaust burst.
 	for range 2 {
@@ -256,8 +256,8 @@ func TestIntegration_IndependentTeams(t *testing.T) {
 
 	cfg := Config{FailOpen: true}
 
-	teamA := uuid.New()
-	teamB := uuid.New()
+	teamA := uuid.Must(uuid.NewV7())
+	teamB := uuid.Must(uuid.NewV7())
 
 	rA := newRouterWithTeam(t, limiter, cfg, ff, teamA)
 	rB := newRouterWithTeam(t, limiter, cfg, ff, teamB)
@@ -287,7 +287,7 @@ func TestIntegration_ConcurrentAccess(t *testing.T) {
 	})
 
 	burst := 10
-	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.New())
+	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.Must(uuid.NewV7()))
 
 	// Fire 20 concurrent requests; only `burst` should be allowed.
 	total := 20

--- a/packages/api/internal/orchestrator/autoresume_test.go
+++ b/packages/api/internal/orchestrator/autoresume_test.go
@@ -44,13 +44,13 @@ func newTestAutoResumeOrchestrator(t *testing.T) *Orchestrator {
 func testSandboxForAutoResume(state sandbox.State) sandbox.Sandbox {
 	return sandbox.Sandbox{
 		SandboxID:         "test-sandbox",
-		TeamID:            uuid.New(),
+		TeamID:            uuid.Must(uuid.NewV7()),
 		StartTime:         time.Now(),
 		EndTime:           time.Now().Add(time.Hour),
 		MaxInstanceLength: time.Hour,
 		State:             state,
 		NodeID:            "node-1",
-		ClusterID:         uuid.New(),
+		ClusterID:         uuid.Must(uuid.NewV7()),
 	}
 }
 

--- a/packages/api/internal/orchestrator/client_test.go
+++ b/packages/api/internal/orchestrator/client_test.go
@@ -105,7 +105,7 @@ func TestGetOrConnectNode_CacheHit(t *testing.T) {
 
 	o := newTestOrchestrator(t, nil)
 
-	clusterID := uuid.New()
+	clusterID := uuid.Must(uuid.NewV7())
 	testNode := nodemanager.NewTestNode("node-1", api.NodeStatusReady, 3, 4)
 	testNode.ClusterID = clusterID
 	o.nodes.Insert(o.scopedNodeID(clusterID, "node-1"), testNode)
@@ -320,7 +320,7 @@ func TestRegisterNode_NoDuplicates(t *testing.T) {
 
 	o := newTestOrchestrator(t, nil)
 
-	clusterID := uuid.New()
+	clusterID := uuid.Must(uuid.NewV7())
 	wg := sync.WaitGroup{}
 	for i := range 50 {
 		wg.Go(func() {

--- a/packages/api/internal/orchestrator/create_instance_events_test.go
+++ b/packages/api/internal/orchestrator/create_instance_events_test.go
@@ -121,7 +121,7 @@ func (e *fetcherError) Error() string { return e.msg }
 func fixedSandboxID(t *testing.T) string {
 	t.Helper()
 
-	return "sbx-" + uuid.New().String()[:8]
+	return "sbx-" + uuid.Must(uuid.NewV7()).String()[28:]
 }
 
 func TestCreateSandbox_FreshCreate_FiresCallbackOnce(t *testing.T) {
@@ -135,7 +135,7 @@ func TestCreateSandbox_FreshCreate_FiresCallbackOnce(t *testing.T) {
 	_, apiErr := o.CreateSandbox(
 		t.Context(),
 		sbxID,
-		uuid.New().String(),
+		uuid.Must(uuid.NewV7()).String(),
 		team,
 		successFetcher(),
 		now, now.Add(time.Hour), time.Hour,
@@ -163,7 +163,7 @@ func TestCreateSandbox_Resume_FiresCallbackOnceWithResumeFlag(t *testing.T) {
 	_, apiErr := o.CreateSandbox(
 		t.Context(),
 		sbxID,
-		uuid.New().String(),
+		uuid.Must(uuid.NewV7()).String(),
 		team,
 		successFetcher(),
 		now, now.Add(time.Hour), time.Hour,
@@ -214,7 +214,7 @@ func TestCreateSandbox_ConcurrentRace_LoserPathSkipsCallback(t *testing.T) {
 	wg.Go(func() {
 		_, winnerErr = o.CreateSandbox(
 			t.Context(),
-			sbxID, uuid.New().String(),
+			sbxID, uuid.Must(uuid.NewV7()).String(),
 			team, winnerFetcher,
 			now, now.Add(time.Hour), time.Hour,
 			false,
@@ -227,7 +227,7 @@ func TestCreateSandbox_ConcurrentRace_LoserPathSkipsCallback(t *testing.T) {
 	wg.Go(func() {
 		_, loserErr = o.CreateSandbox(
 			t.Context(),
-			sbxID, uuid.New().String(),
+			sbxID, uuid.Must(uuid.NewV7()).String(),
 			team, successFetcher(),
 			now, now.Add(time.Hour), time.Hour,
 			false,
@@ -285,7 +285,7 @@ func TestCreateSandbox_ManyConcurrentRacers_OnlyOneCallback(t *testing.T) {
 	wg.Go(func() {
 		_, apiErr := o.CreateSandbox(
 			t.Context(),
-			sbxID, uuid.New().String(),
+			sbxID, uuid.Must(uuid.NewV7()).String(),
 			team, fetcher,
 			now, now.Add(time.Hour), time.Hour,
 			false,
@@ -302,7 +302,7 @@ func TestCreateSandbox_ManyConcurrentRacers_OnlyOneCallback(t *testing.T) {
 		wg.Go(func() {
 			_, apiErr := o.CreateSandbox(
 				t.Context(),
-				sbxID, uuid.New().String(),
+				sbxID, uuid.Must(uuid.NewV7()).String(),
 				team, successFetcher(),
 				now, now.Add(time.Hour), time.Hour,
 				false,
@@ -338,7 +338,7 @@ func TestCreateSandbox_SequentialDuplicate_SecondCallSkipsCallback(t *testing.T)
 
 	_, apiErr := o.CreateSandbox(
 		t.Context(),
-		sbxID, uuid.New().String(),
+		sbxID, uuid.Must(uuid.NewV7()).String(),
 		team, successFetcher(),
 		now, now.Add(time.Hour), time.Hour,
 		false,
@@ -349,7 +349,7 @@ func TestCreateSandbox_SequentialDuplicate_SecondCallSkipsCallback(t *testing.T)
 
 	_, apiErr = o.CreateSandbox(
 		t.Context(),
-		sbxID, uuid.New().String(),
+		sbxID, uuid.Must(uuid.NewV7()).String(),
 		team, successFetcher(),
 		now, now.Add(time.Hour), time.Hour,
 		false,
@@ -370,7 +370,7 @@ func TestCreateSandbox_FetcherError_NoCallback(t *testing.T) {
 
 	_, apiErr := o.CreateSandbox(
 		t.Context(),
-		fixedSandboxID(t), uuid.New().String(),
+		fixedSandboxID(t), uuid.Must(uuid.NewV7()).String(),
 		team,
 		failingFetcher(http.StatusInternalServerError, "synthetic-fetcher-failure"),
 		now, now.Add(time.Hour), time.Hour,
@@ -394,7 +394,7 @@ func TestCreateSandbox_QuotaExceeded_NoCallback(t *testing.T) {
 
 	_, apiErr := o.CreateSandbox(
 		t.Context(),
-		fixedSandboxID(t), uuid.New().String(),
+		fixedSandboxID(t), uuid.Must(uuid.NewV7()).String(),
 		team, successFetcher(),
 		now, now.Add(time.Hour), time.Hour,
 		false,
@@ -405,7 +405,7 @@ func TestCreateSandbox_QuotaExceeded_NoCallback(t *testing.T) {
 
 	_, apiErr = o.CreateSandbox(
 		t.Context(),
-		fixedSandboxID(t), uuid.New().String(),
+		fixedSandboxID(t), uuid.Must(uuid.NewV7()).String(),
 		team, successFetcher(),
 		now, now.Add(time.Hour), time.Hour,
 		false,
@@ -424,11 +424,11 @@ func TestStoreReconcile_DoesNotFireCallback(t *testing.T) {
 	o, ec := newOrchestratorWithCounter(t)
 
 	sbx := sandbox.Sandbox{
-		SandboxID:         "reconcile-test-" + uuid.New().String()[:8],
+		SandboxID:         "reconcile-test-" + uuid.Must(uuid.NewV7()).String()[28:],
 		TemplateID:        "tpl-test",
 		BaseTemplateID:    "base-tpl",
-		TeamID:            uuid.New(),
-		BuildID:           uuid.New(),
+		TeamID:            uuid.Must(uuid.NewV7()),
+		BuildID:           uuid.Must(uuid.NewV7()),
 		StartTime:         time.Now(),
 		EndTime:           time.Now().Add(time.Hour),
 		MaxInstanceLength: time.Hour,

--- a/packages/api/internal/orchestrator/create_instance_test.go
+++ b/packages/api/internal/orchestrator/create_instance_test.go
@@ -31,7 +31,7 @@ func testBuild() queries.EnvBuild {
 	envdVer := "0.1.0"
 
 	return queries.EnvBuild{
-		ID:                 uuid.New(),
+		ID:                 uuid.Must(uuid.NewV7()),
 		Vcpu:               2,
 		RamMb:              512,
 		TotalDiskSizeMb:    &diskSize,
@@ -88,7 +88,7 @@ func newCreateSandboxTestOrchestrator(t *testing.T) (*Orchestrator, *nodemanager
 func testTeam() *teamtypes.Team {
 	return &teamtypes.Team{
 		Team: &authqueries.Team{
-			ID:   uuid.New(),
+			ID:   uuid.Must(uuid.NewV7()),
 			Name: "test-team",
 		},
 		Limits: &teamtypes.TeamLimits{
@@ -112,7 +112,7 @@ func TestCreateSandbox_StaleDataAfterConcurrentPause(t *testing.T) {
 
 		o, _ := newCreateSandboxTestOrchestrator(t)
 		team := testTeam()
-		sandboxID := "sbx-race-" + uuid.New().String()[:8]
+		sandboxID := "sbx-race-" + uuid.Must(uuid.NewV7()).String()[28:]
 		build := testBuild()
 		now := time.Now()
 
@@ -144,7 +144,7 @@ func TestCreateSandbox_StaleDataAfterConcurrentPause(t *testing.T) {
 		sbx1, apiErr := o.CreateSandbox(
 			t.Context(),
 			sandboxID,
-			uuid.New().String(),
+			uuid.Must(uuid.NewV7()).String(),
 			team,
 			makeFetcher(),
 			now,
@@ -168,7 +168,7 @@ func TestCreateSandbox_StaleDataAfterConcurrentPause(t *testing.T) {
 		sbx2, apiErr := o.CreateSandbox(
 			t.Context(),
 			sandboxID,
-			uuid.New().String(),
+			uuid.Must(uuid.NewV7()).String(),
 			team,
 			makeFetcher(),
 			now,

--- a/packages/api/internal/orchestrator/evictor/evict_test.go
+++ b/packages/api/internal/orchestrator/evictor/evict_test.go
@@ -34,7 +34,7 @@ func TestEvictSandbox_ReasonByAction(t *testing.T) {
 
 		e.evictSandbox(context.Background(), sandbox.Sandbox{
 			SandboxID: "sbx",
-			TeamID:    uuid.New(),
+			TeamID:    uuid.Must(uuid.NewV7()),
 			AutoPause: autoPause,
 			EndTime:   time.Now(),
 		})

--- a/packages/api/internal/orchestrator/nodemanager/mock.go
+++ b/packages/api/internal/orchestrator/nodemanager/mock.go
@@ -155,7 +155,7 @@ func (n *TestNode) SetSandboxClient(client orchestrator.SandboxServiceClient) {
 func NewTestNode(id string, status api.NodeStatus, cpuAllocated int64, cpuCount uint32, options ...TestOptions) *TestNode {
 	node := &Node{
 		ID:            id,
-		ClusterID:     uuid.New(),
+		ClusterID:     uuid.Must(uuid.NewV7()),
 		IPAddress:     "127.0.0.1",
 		SandboxDomain: nil,
 		PlacementMetrics: PlacementMetrics{

--- a/packages/api/internal/orchestrator/routing_test.go
+++ b/packages/api/internal/orchestrator/routing_test.go
@@ -21,7 +21,7 @@ func TestRouteNodeIPAddress(t *testing.T) {
 	}{
 		{
 			name:  "uses node ip when present",
-			node:  &nodemanager.Node{ClusterID: uuid.New(), IPAddress: "10.0.0.1"},
+			node:  &nodemanager.Node{ClusterID: uuid.Must(uuid.NewV7()), IPAddress: "10.0.0.1"},
 			local: false,
 			want:  "10.0.0.1",
 		},
@@ -39,7 +39,7 @@ func TestRouteNodeIPAddress(t *testing.T) {
 		},
 		{
 			name:  "remote cluster stays empty",
-			node:  &nodemanager.Node{ClusterID: uuid.New()},
+			node:  &nodemanager.Node{ClusterID: uuid.Must(uuid.NewV7())},
 			local: true,
 			want:  "",
 		},

--- a/packages/api/internal/sandbox/reservations/redis/reservation_pubsub_test.go
+++ b/packages/api/internal/sandbox/reservations/redis/reservation_pubsub_test.go
@@ -50,7 +50,7 @@ func TestWaitForStart_WokenByFinishStartPublish(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestReservationStorage(t)
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	sbxID := "pubsub-finish"
 
 	finishStart, _, err := storage.Reserve(t.Context(), teamID, sbxID, 10)
@@ -91,7 +91,7 @@ func TestWaitForStart_WokenByReleasePublish(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestReservationStorage(t)
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	sbxID := "pubsub-release"
 
 	finishStart, _, err := storage.Reserve(t.Context(), teamID, sbxID, 10)
@@ -127,7 +127,7 @@ func TestWaitForStart_FallbackTickerWhenPubSubMissed(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupReservationStorageWithoutSubManager(t)
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	sbxID := "pubsub-fallback"
 
 	finishStart, _, err := storage.Reserve(t.Context(), teamID, sbxID, 10)
@@ -171,7 +171,7 @@ func TestWaitForStart_ResultLandedBeforeSubscribe(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestReservationStorage(t)
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	sbxID := "pubsub-race"
 
 	finishStart, _, err := storage.Reserve(t.Context(), teamID, sbxID, 10)
@@ -211,7 +211,7 @@ func TestWaitForStart_ContextCancellation(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestReservationStorage(t)
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	sbxID := "pubsub-cancel"
 
 	_, _, err := storage.Reserve(t.Context(), teamID, sbxID, 10)
@@ -237,7 +237,7 @@ func TestWaitForStart_MultipleWaitersOnePublish(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestReservationStorage(t)
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	sbxID := "pubsub-multi"
 	const numWaiters = 10
 
@@ -291,7 +291,7 @@ func TestWaitForStart_FailedStartPropagatesPromptly(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestReservationStorage(t)
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	sbxID := "pubsub-failed"
 
 	finishStart, _, err := storage.Reserve(t.Context(), teamID, sbxID, 10)
@@ -334,7 +334,7 @@ func TestWaitForStart_RedisOpsBounded(t *testing.T) {
 
 	storage := NewReservationStorage(client, storageInstance.Notifier())
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	sbxID := "pubsub-bounded"
 
 	finishStart, _, err := storage.Reserve(t.Context(), teamID, sbxID, 10)

--- a/packages/api/internal/sandbox/reservations/redis/reservation_test.go
+++ b/packages/api/internal/sandbox/reservations/redis/reservation_test.go
@@ -26,7 +26,7 @@ const (
 	testSandboxID = "test-sandbox-id"
 )
 
-var testTeamID = uuid.New()
+var testTeamID = uuid.Must(uuid.NewV7())
 
 func setupTestReservationStorage(t *testing.T) (*ReservationStorage, goredis.UniversalClient) {
 	t.Helper()
@@ -63,7 +63,7 @@ func TestReservation_Exceeded(t *testing.T) {
 	t.Parallel()
 	storage, _ := setupTestReservationStorage(t)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	_, _, err := storage.Reserve(t.Context(), teamID, testSandboxID, 1)
 	require.NoError(t, err)
 	_, _, err = storage.Reserve(t.Context(), teamID, "sandbox-2", 1)
@@ -74,7 +74,7 @@ func TestReservation_SameSandbox(t *testing.T) {
 	t.Parallel()
 	storage, _ := setupTestReservationStorage(t)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	_, _, err := storage.Reserve(t.Context(), teamID, testSandboxID, 1)
 	require.NoError(t, err)
 
@@ -87,7 +87,7 @@ func TestReservation_Release(t *testing.T) {
 	t.Parallel()
 	storage, _ := setupTestReservationStorage(t)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	_, _, err := storage.Reserve(t.Context(), teamID, testSandboxID, 1)
 	require.NoError(t, err)
 	err = storage.Release(t.Context(), teamID, testSandboxID)
@@ -101,7 +101,7 @@ func TestReservation_MultipleWaiters(t *testing.T) {
 	t.Parallel()
 	storage, _ := setupTestReservationStorage(t)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	finishStart, _, err := storage.Reserve(t.Context(), teamID, testSandboxID, 10)
 	require.NoError(t, err)
 	require.NotNil(t, finishStart)
@@ -141,7 +141,7 @@ func TestReservation_Remove(t *testing.T) {
 	t.Parallel()
 	storage, _ := setupTestReservationStorage(t)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	finishStart, _, err := storage.Reserve(t.Context(), teamID, testSandboxID, 1)
 	require.NoError(t, err)
 	require.NotNil(t, finishStart)
@@ -171,8 +171,8 @@ func TestReservation_MultipleTeams(t *testing.T) {
 	t.Parallel()
 	storage, _ := setupTestReservationStorage(t)
 
-	team1 := uuid.New()
-	team2 := uuid.New()
+	team1 := uuid.Must(uuid.NewV7())
+	team2 := uuid.Must(uuid.NewV7())
 	sandbox1 := "sandbox-1"
 	sandbox2 := "sandbox-2"
 
@@ -197,7 +197,7 @@ func TestReservation_FailedStart(t *testing.T) {
 	t.Parallel()
 	storage, _ := setupTestReservationStorage(t)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	sbxID := "failed-sandbox"
 
 	// Reserve sandbox
@@ -218,7 +218,7 @@ func TestReservation_FailedStartWithWaiters(t *testing.T) {
 	t.Parallel()
 	storage, _ := setupTestReservationStorage(t)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	sbxID := "failed-with-waiters"
 	numWaiters := 10
 
@@ -275,7 +275,7 @@ func TestReservation_ConcurrentReservations(t *testing.T) {
 	t.Parallel()
 	storage, _ := setupTestReservationStorage(t)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	concurrency := 100
 	limit := 50
 
@@ -311,7 +311,7 @@ func TestReservation_ConcurrentSameSandbox(t *testing.T) {
 	t.Parallel()
 	storage, _ := setupTestReservationStorage(t)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	sbxID := "concurrent-sandbox"
 	concurrency := 50
 
@@ -350,7 +350,7 @@ func TestReservation_ConcurrentWaitAndFinish(t *testing.T) {
 	t.Parallel()
 	storage, _ := setupTestReservationStorage(t)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	sbxID := "wait-finish-sandbox"
 	numWaiters := 20
 
@@ -416,7 +416,7 @@ func TestReservation_RaceConditionStressTest(t *testing.T) {
 	t.Parallel()
 	storage, _ := setupTestReservationStorage(t)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	numOperations := 2000
 	numSandboxes := 100
 	limit := 5
@@ -473,7 +473,7 @@ func TestReservation_ResultKeyTTL(t *testing.T) {
 	t.Parallel()
 	storage, client := setupTestReservationStorage(t)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	sbxID := "ttl-test"
 
 	finishStart, _, err := storage.Reserve(t.Context(), teamID, sbxID, 10)
@@ -494,7 +494,7 @@ func TestReservation_StalePendingCleanup(t *testing.T) {
 	t.Parallel()
 	_, client := setupTestReservationStorage(t)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	pendingSetKey := getPendingSetKey(teamID.String())
 
 	// Simulate a crashed API instance by manually inserting a stale pending entry

--- a/packages/api/internal/sandbox/storage/redis/lock_test.go
+++ b/packages/api/internal/sandbox/storage/redis/lock_test.go
@@ -25,7 +25,7 @@ func TestStorageLocker_ObtainAfterReleaseNotification(t *testing.T) {
 
 	locker, subManager := setupTestLocker(t, true)
 
-	key := getSandboxKey(uuid.NewString(), "lock-notification")
+	key := getSandboxKey(uuid.Must(uuid.NewV7()).String(), "lock-notification")
 	lockKey := redis_utils.GetLockKey(key)
 	routingKey := getLockRoutingKey(lockKey)
 
@@ -54,7 +54,7 @@ func TestStorageLocker_ObtainTimesOutWhenHeld(t *testing.T) {
 	t.Parallel()
 
 	locker, _ := setupTestLocker(t, true)
-	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.NewString(), "lock-timeout"))
+	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.Must(uuid.NewV7()).String(), "lock-timeout"))
 
 	lock, err := locker.Obtain(t.Context(), lockKey, testLockTimeout)
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestStorageLocker_ObtainUsesProvidedContext(t *testing.T) {
 	t.Parallel()
 
 	locker, subManager := setupTestLocker(t, true)
-	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.NewString(), "lock-parent-deadline"))
+	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.Must(uuid.NewV7()).String(), "lock-parent-deadline"))
 	routingKey := getLockRoutingKey(lockKey)
 
 	lock, err := locker.Obtain(t.Context(), lockKey, testLockTimeout)
@@ -101,7 +101,7 @@ func TestStorageLocker_ObtainReturnsContextCancellation(t *testing.T) {
 	t.Parallel()
 
 	locker, _ := setupTestLocker(t, true)
-	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.NewString(), "lock-context-cancel"))
+	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.Must(uuid.NewV7()).String(), "lock-context-cancel"))
 
 	lock, err := locker.Obtain(t.Context(), lockKey, testLockTimeout)
 	require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestStorageLocker_ObtainFallsBackWhenNotificationMissed(t *testing.T) {
 	// notification and verifies the exponential fallback still makes progress.
 	locker, subManager := setupTestLocker(t, false)
 
-	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.NewString(), "lock-fallback"))
+	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.Must(uuid.NewV7()).String(), "lock-fallback"))
 	routingKey := getLockRoutingKey(lockKey)
 
 	lock, err := locker.Obtain(t.Context(), lockKey, testLockTimeout)
@@ -150,7 +150,7 @@ func TestStorageLock_ReleaseUsesProvidedContext(t *testing.T) {
 	t.Parallel()
 
 	locker, _ := setupTestLocker(t, false)
-	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.NewString(), "lock-canceled-release"))
+	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.Must(uuid.NewV7()).String(), "lock-canceled-release"))
 	routingKey := getLockRoutingKey(lockKey)
 
 	pubsub := locker.redisClient.Subscribe(t.Context(), globalStorageNotifyChannel)
@@ -173,7 +173,7 @@ func TestStorageLock_ReleaseReturnsErrorWhenLockAlreadyReleased(t *testing.T) {
 	t.Parallel()
 
 	locker, _ := setupTestLocker(t, true)
-	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.NewString(), "lock-double-release"))
+	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.Must(uuid.NewV7()).String(), "lock-double-release"))
 
 	lock, err := locker.Obtain(t.Context(), lockKey, testLockTimeout)
 	require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestStorageLocker_IgnoresUnrelatedNotification(t *testing.T) {
 	t.Parallel()
 
 	locker, subManager := setupTestLocker(t, true)
-	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.NewString(), "lock-unrelated-notification"))
+	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.Must(uuid.NewV7()).String(), "lock-unrelated-notification"))
 	routingKey := getLockRoutingKey(lockKey)
 
 	lock, err := locker.Obtain(t.Context(), lockKey, testLockTimeout)

--- a/packages/api/internal/sandbox/storage/redis/publisher_test.go
+++ b/packages/api/internal/sandbox/storage/redis/publisher_test.go
@@ -216,7 +216,7 @@ func TestStorageLock_ReleaseUsesNotifier(t *testing.T) {
 	subManager := newSubscriptionManager(client, globalStorageNotifyChannel)
 	locker := newStorageLocker(client, subManager, fakeNot)
 
-	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.NewString(), "fake-notifier"))
+	lockKey := redis_utils.GetLockKey(getSandboxKey(uuid.Must(uuid.NewV7()).String(), "fake-notifier"))
 	lock, err := locker.Obtain(t.Context(), lockKey, testLockTimeout)
 	require.NoError(t, err)
 	require.NoError(t, lock.Release(context.WithoutCancel(t.Context())))

--- a/packages/api/internal/sandbox/storage/redis/state_change.go
+++ b/packages/api/internal/sandbox/storage/redis/state_change.go
@@ -128,7 +128,7 @@ func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID
 	}
 
 	// Generate transition ID
-	transitionID := uuid.New().String()
+	transitionID := uuid.Must(uuid.NewV7()).String()
 	resultKey := getTransitionResultKey(teamID.String(), sandboxID, transitionID)
 
 	// Use atomic Lua script to update sandbox and set transition key with UUID

--- a/packages/api/internal/sandbox/storage/redis/state_change_test.go
+++ b/packages/api/internal/sandbox/storage/redis/state_change_test.go
@@ -32,8 +32,8 @@ func createTestSandbox(sandboxID string) sandboxtypes.Sandbox {
 		SandboxID:         sandboxID,
 		TemplateID:        "test-template",
 		ClientID:          "test-client",
-		TeamID:            uuid.New(),
-		ExecutionID:       uuid.New().String(), // Add ExecutionID for transition tracking
+		TeamID:            uuid.Must(uuid.NewV7()),
+		ExecutionID:       uuid.Must(uuid.NewV7()).String(), // Add ExecutionID for transition tracking
 		StartTime:         time.Now(),
 		EndTime:           time.Now().Add(time.Hour),
 		MaxInstanceLength: time.Hour,
@@ -252,7 +252,7 @@ func TestStartRemoving_NotFound(t *testing.T) {
 	storage, _ := setupTestStorage(t)
 	ctx := t.Context()
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	_, alreadyDone, callback, err := storage.StartRemoving(ctx, teamID, "non-existent", sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 	require.Error(t, err)
 	assert.False(t, alreadyDone)

--- a/packages/api/internal/sandbox/store_test.go
+++ b/packages/api/internal/sandbox/store_test.go
@@ -186,13 +186,13 @@ func (m *MockStorage) Add(ctx context.Context, sbx Sandbox) error {
 // createTestSandbox creates a test sandbox with default values
 func createTestSandbox() Sandbox {
 	return NewSandbox(
-		"test-sandbox-"+uuid.New().String()[:8],
+		"test-sandbox-"+uuid.Must(uuid.NewV7()).String()[28:],
 		"test-template",
 		consts.ClientID,
 		nil, // alias
 		"",  // executionID
-		uuid.New(),
-		uuid.New(),
+		uuid.Must(uuid.NewV7()),
+		uuid.Must(uuid.NewV7()),
 		map[string]string{"test": "metadata"},
 		time.Hour,                 // maxInstanceLength
 		time.Now(),                // startTime
@@ -204,7 +204,7 @@ func createTestSandbox() Sandbox {
 		"1.0",                     // firecracker
 		"1.0",                     // envd
 		"node-1",
-		uuid.New(),
+		uuid.Must(uuid.NewV7()),
 		false, // autoPause
 		nil,   // autoResume
 		nil,   // envdAccessToken
@@ -342,7 +342,7 @@ func TestAdd_ConcurrentCalls(t *testing.T) {
 		}
 		store := NewStore(storage, reservations, callbacks)
 
-		teamID := uuid.New()
+		teamID := uuid.Must(uuid.NewV7())
 		var wg sync.WaitGroup
 		errorsChan := make(chan error, numGoroutines)
 

--- a/packages/api/internal/template-manager/template_manager_test.go
+++ b/packages/api/internal/template-manager/template_manager_test.go
@@ -54,7 +54,7 @@ func TestPollBuildStatus_setStatus(t *testing.T) {
 				templateManagerClient: &fakeTemplateManagerClient{
 					getStatusResponse: nil,
 				},
-				buildID: uuid.New(),
+				buildID: uuid.Must(uuid.NewV7()),
 			},
 			wantErr: true,
 		},

--- a/packages/api/internal/template/register_build.go
+++ b/packages/api/internal/template/register_build.go
@@ -99,7 +99,7 @@ func RegisterBuild(
 	}
 
 	// Generate a build id for the new build
-	buildID, err := uuid.NewRandom()
+	buildID, err := uuid.NewV7()
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error when generating build id", err)
 

--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -285,7 +285,7 @@ func run() int {
 	flag.IntVar(&port, "port", defaultPort, "Port for test HTTP server")
 	flag.Parse()
 
-	serviceInstanceID := uuid.New().String()
+	serviceInstanceID := uuid.Must(uuid.NewV7()).String()
 	nodeID := env.GetNodeID()
 
 	tel, err := telemetry.New(ctx, nodeID, serviceName, commitSHA, serviceVersion, serviceInstanceID)

--- a/packages/auth/pkg/auth/identity_lookup_test.go
+++ b/packages/auth/pkg/auth/identity_lookup_test.go
@@ -36,7 +36,7 @@ func (l *countingIdentityLookup) GetUserIdentity(_ context.Context, iss, sub str
 func TestCachingIdentityLookup_CachesSuccess(t *testing.T) {
 	t.Parallel()
 
-	userID := uuid.New()
+	userID := uuid.Must(uuid.NewV7())
 	base := &countingIdentityLookup{results: map[string]struct {
 		id  uuid.UUID
 		err error
@@ -108,7 +108,7 @@ func TestCachingIdentityLookup_DoesNotCacheError(t *testing.T) {
 func TestCachingIdentityLookup_SeparateKeysPerIssuerAndSubject(t *testing.T) {
 	t.Parallel()
 
-	a, b := uuid.New(), uuid.New()
+	a, b := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
 	base := &countingIdentityLookup{results: map[string]struct {
 		id  uuid.UUID
 		err error

--- a/packages/auth/pkg/auth/legacy/legacy_test.go
+++ b/packages/auth/pkg/auth/legacy/legacy_test.go
@@ -18,7 +18,7 @@ func TestVerifier_Verify(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	userID := uuid.New()
+	userID := uuid.Must(uuid.NewV7())
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"sub": userID.String(),
 		"exp": time.Now().Add(time.Hour).Unix(),

--- a/packages/auth/pkg/auth/middleware_test.go
+++ b/packages/auth/pkg/auth/middleware_test.go
@@ -40,7 +40,7 @@ func TestAdminTeamAuthenticatorSetsTeamContext(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	team := types.NewTeam(&authqueries.Team{ID: teamID}, &authqueries.TeamLimit{})
 
 	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)

--- a/packages/auth/pkg/auth/oidc/oidc_test.go
+++ b/packages/auth/pkg/auth/oidc/oidc_test.go
@@ -43,7 +43,7 @@ func TestVerifier_Verify(t *testing.T) {
 	const keyID = "test-key"
 	server := NewTestServer(t, &privateKey.PublicKey, keyID, testIssuerURL)
 
-	internalUserID := uuid.New()
+	internalUserID := uuid.Must(uuid.NewV7())
 	lookup := &stubIdentityLookup{userID: internalUserID}
 
 	verifier, err := NewVerifier(t.Context(), Config{
@@ -160,7 +160,7 @@ func TestVerifier_RejectsWrongAudience(t *testing.T) {
 	const keyID = "test-key"
 	server := NewTestServer(t, &privateKey.PublicKey, keyID, testIssuerURL)
 
-	lookup := &stubIdentityLookup{userID: uuid.New()}
+	lookup := &stubIdentityLookup{userID: uuid.Must(uuid.NewV7())}
 	verifier, err := NewVerifier(t.Context(), Config{
 		Issuer: Issuer{
 			URL:          testIssuerURL,
@@ -173,7 +173,7 @@ func TestVerifier_RejectsWrongAudience(t *testing.T) {
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
 		"iss": testIssuerURL,
 		"aud": "other-audience",
-		"sub": uuid.NewString(),
+		"sub": uuid.Must(uuid.NewV7()).String(),
 		"exp": time.Now().Add(time.Hour).Unix(),
 	})
 	token.Header["kid"] = keyID

--- a/packages/auth/pkg/auth/verifier_test.go
+++ b/packages/auth/pkg/auth/verifier_test.go
@@ -84,7 +84,7 @@ func TestVerifier_VerifyWithMultipleStrategies(t *testing.T) {
 
 	lookup := newStubIdentityLookup()
 	const jwksSub = "external-subject"
-	jwksUserID := uuid.New()
+	jwksUserID := uuid.Must(uuid.NewV7())
 	lookup.set(testIssuerURL, jwksSub, jwksUserID)
 
 	verifier, err := NewVerifier(t.Context(), ProviderConfig{
@@ -104,7 +104,7 @@ func TestVerifier_VerifyWithMultipleStrategies(t *testing.T) {
 	}, server.Client(), lookup)
 	require.NoError(t, err)
 
-	hmacUserID := uuid.New()
+	hmacUserID := uuid.Must(uuid.NewV7())
 	hmacToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"sub": hmacUserID.String(),
 		"exp": time.Now().Add(time.Hour).Unix(),
@@ -151,7 +151,7 @@ func TestVerifier_VerifyMultipleJWTIssuers(t *testing.T) {
 
 	lookup := newStubIdentityLookup()
 	const tokenSub = "external-subject"
-	userID := uuid.New()
+	userID := uuid.Must(uuid.NewV7())
 	lookup.set(issuer2URL, tokenSub, userID)
 
 	verifier, err := NewVerifier(t.Context(), ProviderConfig{

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -56,7 +56,7 @@ func run() int {
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	defer ctxCancel()
 
-	instanceID := uuid.New().String()
+	instanceID := uuid.Must(uuid.NewV7()).String()
 	nodeID := env.GetNodeID()
 
 	// Setup telemetry

--- a/packages/dashboard-api/internal/handlers/sandbox_record_test.go
+++ b/packages/dashboard-api/internal/handlers/sandbox_record_test.go
@@ -47,7 +47,7 @@ func TestGetSandboxesSandboxIDRecordReturns404WhenRecordRetentionNotMet(t *testi
 	ctx, _ := gin.CreateTestContext(recorder)
 	ctx.Request = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/sandboxes/sbx_1/record", nil)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	auth.SetTeamInfoForTest(t, ctx, &authtypes.Team{
 		Team: &authqueries.Team{
 			ID: teamID,

--- a/packages/dashboard-api/internal/handlers/team_handlers_test.go
+++ b/packages/dashboard-api/internal/handlers/team_handlers_test.go
@@ -69,7 +69,7 @@ func TestRequireAuthedTeamMatchesPath_Success(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 
-	teamID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
 	auth.SetTeamInfoForTest(t, ctx, &authtypes.Team{
 		Team: &authqueries.Team{ID: teamID},
 	})
@@ -88,11 +88,11 @@ func TestRequireAuthedTeamMatchesPath_Mismatch(t *testing.T) {
 	ctx, _ := gin.CreateTestContext(recorder)
 
 	auth.SetTeamInfoForTest(t, ctx, &authtypes.Team{
-		Team: &authqueries.Team{ID: uuid.New()},
+		Team: &authqueries.Team{ID: uuid.Must(uuid.NewV7())},
 	})
 
 	store := &APIStore{}
-	_, ok := store.requireAuthedTeamMatchesPath(ctx, uuid.New())
+	_, ok := store.requireAuthedTeamMatchesPath(ctx, uuid.Must(uuid.NewV7()))
 	if ok {
 		t.Fatalf("expected team parity check to fail")
 	}
@@ -147,7 +147,7 @@ func TestPostTeamsTeamIDMembers_CreatesPublicUserAnchorForInvitee(t *testing.T) 
 	ctx := t.Context()
 
 	teamID := testutils.CreateTestTeam(t, testDB)
-	inviteeID := uuid.New()
+	inviteeID := uuid.Must(uuid.NewV7())
 	addedByUserID := createHandlerTestUser(t, testDB)
 	inviteeEmail := handlerTestUserEmail(inviteeID)
 
@@ -210,7 +210,7 @@ func TestDeleteTeamsTeamIDMembersUserId_NonMemberReturnsBadRequest(t *testing.T)
 	})
 
 	store := &APIStore{db: testDB.SqlcClient}
-	store.DeleteTeamsTeamIDMembersUserId(ginCtx, teamID, uuid.New())
+	store.DeleteTeamsTeamIDMembersUserId(ginCtx, teamID, uuid.Must(uuid.NewV7()))
 
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", recorder.Code)
@@ -345,7 +345,7 @@ func createHandlerTestUserAt(t *testing.T, db *testutils.Database, createdAt tim
 func createHandlerTestUserWithCreatedAt(t *testing.T, db *testutils.Database, createdAt *time.Time) uuid.UUID {
 	t.Helper()
 
-	userID := uuid.New()
+	userID := uuid.Must(uuid.NewV7())
 	email := handlerTestUserEmail(userID)
 
 	err := db.SupabaseDB.TestsRawSQL(t.Context(), `
@@ -573,7 +573,7 @@ func TestBootstrapAuthProviderUser_CreatesIdentityAndDefaultTeam(t *testing.T) {
 
 	input := oidcUserBootstrapInput{
 		OIDCIssuer:      "https://ory.example.test",
-		OIDCUserID:      uuid.NewString(),
+		OIDCUserID:      uuid.Must(uuid.NewV7()).String(),
 		OIDCUserEmail:   "ada@example.test",
 		OIDCUserName:    nil,
 		SignupIP:        "198.51.100.20",
@@ -655,7 +655,7 @@ func TestBootstrapOIDCUser_ConcurrentRequestsSingleIdentityAndTeam(t *testing.T)
 
 	input := oidcUserBootstrapInput{
 		OIDCIssuer:    "https://ory.example.test",
-		OIDCUserID:    uuid.NewString(),
+		OIDCUserID:    uuid.Must(uuid.NewV7()).String(),
 		OIDCUserEmail: "ada@example.test",
 		OIDCUserName:  nil,
 	}
@@ -768,7 +768,7 @@ func TestBootstrapOIDCUser_OryIssuerWithoutJWTConfigIsAccepted(t *testing.T) {
 
 	team, err := store.bootstrapOIDCUser(ctx, oidcUserBootstrapInput{
 		OIDCIssuer:    oryIssuer,
-		OIDCUserID:    uuid.NewString(),
+		OIDCUserID:    uuid.Must(uuid.NewV7()).String(),
 		OIDCUserEmail: "ada@example.test",
 		OIDCUserName:  nil,
 	})
@@ -808,7 +808,7 @@ func TestBootstrapOIDCUser_OryModeRejectsNonOryJWTIssuer(t *testing.T) {
 
 	_, err := store.bootstrapOIDCUser(ctx, oidcUserBootstrapInput{
 		OIDCIssuer:    otherIssuer,
-		OIDCUserID:    uuid.NewString(),
+		OIDCUserID:    uuid.Must(uuid.NewV7()).String(),
 		OIDCUserEmail: "ada@example.test",
 		OIDCUserName:  nil,
 	})
@@ -844,7 +844,7 @@ func TestBootstrapOIDCUser_UnknownIssuerReturnsBadRequest(t *testing.T) {
 
 	_, err := store.bootstrapOIDCUser(ctx, oidcUserBootstrapInput{
 		OIDCIssuer:    "https://attacker.example.test",
-		OIDCUserID:    uuid.NewString(),
+		OIDCUserID:    uuid.Must(uuid.NewV7()).String(),
 		OIDCUserEmail: "ada@example.test",
 		OIDCUserName:  nil,
 	})
@@ -886,7 +886,7 @@ func TestBootstrapOIDCUser_MultipleConfiguredIssuersIsolatesIdentities(t *testin
 		teamProvisionSink: sink,
 	}
 
-	sharedSubject := uuid.NewString()
+	sharedSubject := uuid.Must(uuid.NewV7()).String()
 
 	teamA, err := store.bootstrapOIDCUser(ctx, oidcUserBootstrapInput{
 		OIDCIssuer:    issuerA,
@@ -1000,7 +1000,7 @@ func TestPostUsersBootstrap_UnknownUserReturnsNotFound(t *testing.T) {
 
 	testDB := testutils.SetupDatabase(t)
 	ctx := t.Context()
-	userID := uuid.New()
+	userID := uuid.Must(uuid.NewV7())
 	sink := &fakeTeamProvisionSink{}
 
 	recorder := httptest.NewRecorder()

--- a/packages/dashboard-api/internal/handlers/templates_list_db_test.go
+++ b/packages/dashboard-api/internal/handlers/templates_list_db_test.go
@@ -145,7 +145,7 @@ func TestGetTemplates_DefaultGatingByCluster(t *testing.T) {
 	}
 
 	// Dedicated cluster -> defaults are omitted.
-	clusterID := uuid.New()
+	clusterID := uuid.Must(uuid.NewV7())
 	_, clusterResp := callGetTemplates(t, store, teamInfo(teamID, &clusterID), api.GetTemplatesParams{})
 	clusterIDs := templateIDSet(clusterResp)
 	assert.True(t, clusterIDs[owned], "team-owned template should still be listed on a cluster")

--- a/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
+++ b/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
@@ -111,7 +111,7 @@ func (s *APIStore) bootstrapOIDCUser(ctx context.Context, input oidcUserBootstra
 	}
 
 	profile := bootstrapUserProfile{
-		UserID:          uuid.New(),
+		UserID:          uuid.Must(uuid.NewV7()),
 		Email:           input.OIDCUserEmail,
 		DefaultTeamName: defaultTeamNameFromOIDCUserName(input.OIDCUserName),
 		CreatorContext:  creatorContextFromSignupMetadata(input.SignupIP, input.SignupUserAgent, teamprovision.AuthMethodSocial),

--- a/packages/dashboard-api/internal/teamprovision/http_sink_test.go
+++ b/packages/dashboard-api/internal/teamprovision/http_sink_test.go
@@ -87,10 +87,10 @@ func TestHTTPProvisionSink_RetriesRequestTimeoutWithinOverallBudget(t *testing.T
 
 func testProvisionRequest() sharedteamprovision.TeamBillingProvisionRequestedV1 {
 	return sharedteamprovision.TeamBillingProvisionRequestedV1{
-		TeamID:        uuid.New(),
+		TeamID:        uuid.Must(uuid.NewV7()),
 		TeamName:      "Acme",
 		TeamEmail:     "acme@example.com",
-		CreatorUserID: uuid.New(),
+		CreatorUserID: uuid.Must(uuid.NewV7()),
 		Reason:        sharedteamprovision.ReasonAdditionalTeam,
 	}
 }

--- a/packages/dashboard-api/internal/userprofile/ory_test.go
+++ b/packages/dashboard-api/internal/userprofile/ory_test.go
@@ -13,7 +13,7 @@ import (
 func TestProfileFromOryIdentity(t *testing.T) {
 	t.Parallel()
 
-	userID := uuid.New()
+	userID := uuid.Must(uuid.NewV7())
 
 	tests := []struct {
 		name           string
@@ -111,7 +111,7 @@ func TestProfileFromOryIdentity(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			identity := ory.Identity{Id: uuid.NewString(), Traits: tt.traits, MetadataPublic: tt.metadataPublic, Credentials: tt.credentials}
+			identity := ory.Identity{Id: uuid.Must(uuid.NewV7()).String(), Traits: tt.traits, MetadataPublic: tt.metadataPublic, Credentials: tt.credentials}
 			got := profileFromOryIdentity(userID, identity)
 			if got.UserID != userID {
 				t.Fatalf("UserID = %s, want %s", got.UserID, userID)
@@ -143,7 +143,7 @@ func TestCreatorContextFromOryIdentityUsesMetadataAdmin(t *testing.T) {
 		},
 	}
 	identity := ory.Identity{
-		Id: uuid.NewString(),
+		Id: uuid.Must(uuid.NewV7()).String(),
 		MetadataAdmin: map[string]any{
 			"signup_ip":         "198.51.100.20",
 			"signup_user_agent": "Dashboard/1.0",

--- a/packages/dashboard-api/internal/userprofile/supabase_test.go
+++ b/packages/dashboard-api/internal/userprofile/supabase_test.go
@@ -21,7 +21,7 @@ func TestProfileFromAuthUserNamePrecedence(t *testing.T) {
 		{
 			name: "first and last name",
 			user: supabasequeries.AuthUser{
-				ID:              uuid.New(),
+				ID:              uuid.Must(uuid.NewV7()),
 				Email:           "fallback@example.com",
 				RawUserMetaData: []byte(`{"first_name":"ada","last_name":"lovelace","username":"fallback user"}`),
 			},
@@ -30,7 +30,7 @@ func TestProfileFromAuthUserNamePrecedence(t *testing.T) {
 		{
 			name: "full name fallback",
 			user: supabasequeries.AuthUser{
-				ID:              uuid.New(),
+				ID:              uuid.Must(uuid.NewV7()),
 				Email:           "fallback@example.com",
 				RawUserMetaData: []byte(`{"full_name":"grace hopper"}`),
 			},
@@ -39,7 +39,7 @@ func TestProfileFromAuthUserNamePrecedence(t *testing.T) {
 		{
 			name: "username is not profile name",
 			user: supabasequeries.AuthUser{
-				ID:              uuid.New(),
+				ID:              uuid.Must(uuid.NewV7()),
 				Email:           "fallback@example.com",
 				RawUserMetaData: []byte(`{"username":"john doe"}`),
 			},
@@ -63,7 +63,7 @@ func TestProfileFromAuthUserProviders(t *testing.T) {
 	t.Parallel()
 
 	user := supabasequeries.AuthUser{
-		ID:             uuid.New(),
+		ID:             uuid.Must(uuid.NewV7()),
 		Email:          "ada@example.com",
 		RawAppMetaData: []byte(`{"providers":["github"," email ","GOOGLE","apple","github"],"provider":"google"}`),
 	}

--- a/packages/dashboard-api/main.go
+++ b/packages/dashboard-api/main.go
@@ -66,7 +66,7 @@ func run() int {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	serviceInstanceID := uuid.New().String()
+	serviceInstanceID := uuid.Must(uuid.NewV7()).String()
 	nodeID := e2benv.GetNodeID()
 
 	tel, err := telemetry.New(ctx, nodeID, serviceName, commitSHA, serviceVersion, serviceInstanceID)

--- a/packages/db/migrations/20260617120000_uuidv7_defaults.sql
+++ b/packages/db/migrations/20260617120000_uuidv7_defaults.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.uuidv7() RETURNS uuid AS $func$
+DECLARE
+    unix_ms bigint;
+    rand text;
+BEGIN
+    unix_ms := floor(extract(epoch FROM clock_timestamp()) * 1000);
+    rand := replace(gen_random_uuid()::text, '-', '');
+
+    RETURN (
+        lpad(to_hex(unix_ms), 12, '0') ||
+        '7' ||
+        substr(rand, 14, 3) ||
+        substr('89ab', (get_byte(decode(substr(rand, 17, 2), 'hex'), 0) % 4) + 1, 1) ||
+        substr(rand, 18, 15)
+    )::uuid;
+END;
+$func$ LANGUAGE plpgsql VOLATILE;
+
+CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid AS $func$
+BEGIN
+    RETURN uuidv7();
+END;
+$func$ LANGUAGE plpgsql;
+
+ALTER TABLE IF EXISTS auth.users ALTER COLUMN id SET DEFAULT uuidv7();
+ALTER TABLE IF EXISTS public.teams ALTER COLUMN id SET DEFAULT uuidv7();
+ALTER TABLE IF EXISTS public.env_builds ALTER COLUMN id SET DEFAULT uuidv7();
+ALTER TABLE IF EXISTS public.snapshots ALTER COLUMN id SET DEFAULT uuidv7();
+ALTER TABLE IF EXISTS public.team_api_keys ALTER COLUMN id SET DEFAULT uuidv7();
+ALTER TABLE IF EXISTS public.access_tokens ALTER COLUMN id SET DEFAULT uuidv7();
+ALTER TABLE IF EXISTS public.clusters ALTER COLUMN id SET DEFAULT uuidv7();
+ALTER TABLE IF EXISTS public.env_aliases ALTER COLUMN id SET DEFAULT uuidv7();
+ALTER TABLE IF EXISTS public.users_teams ALTER COLUMN uuid_id SET DEFAULT uuidv7();
+ALTER TABLE IF EXISTS public.volumes ALTER COLUMN id SET DEFAULT uuidv7();
+ALTER TABLE IF EXISTS public.addons ALTER COLUMN id SET DEFAULT uuidv7();
+ALTER TABLE IF EXISTS public.env_build_assignments ALTER COLUMN id SET DEFAULT uuidv7();
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- +goose StatementEnd

--- a/packages/db/pkg/tests/builds/active_template_builds_test.go
+++ b/packages/db/pkg/tests/builds/active_template_builds_test.go
@@ -22,7 +22,7 @@ func TestGetInProgressTemplateBuildsByTeam_ExcludesSameTemplateWithOverlappingTa
 	otherTemplateID := testutils.CreateTestTemplate(t, db, teamID)
 
 	err := db.SqlcClient.CreateActiveTemplateBuild(ctx, queries.CreateActiveTemplateBuildParams{
-		BuildID:    uuid.New(),
+		BuildID:    uuid.Must(uuid.NewV7()),
 		TeamID:     teamID,
 		TemplateID: templateID,
 		Tags:       []string{"latest", "prod"},
@@ -30,7 +30,7 @@ func TestGetInProgressTemplateBuildsByTeam_ExcludesSameTemplateWithOverlappingTa
 	require.NoError(t, err)
 
 	err = db.SqlcClient.CreateActiveTemplateBuild(ctx, queries.CreateActiveTemplateBuildParams{
-		BuildID:    uuid.New(),
+		BuildID:    uuid.Must(uuid.NewV7()),
 		TeamID:     teamID,
 		TemplateID: templateID,
 		Tags:       []string{"staging"},
@@ -38,7 +38,7 @@ func TestGetInProgressTemplateBuildsByTeam_ExcludesSameTemplateWithOverlappingTa
 	require.NoError(t, err)
 
 	err = db.SqlcClient.CreateActiveTemplateBuild(ctx, queries.CreateActiveTemplateBuildParams{
-		BuildID:    uuid.New(),
+		BuildID:    uuid.Must(uuid.NewV7()),
 		TeamID:     teamID,
 		TemplateID: otherTemplateID,
 		Tags:       []string{"latest"},
@@ -63,7 +63,7 @@ func TestGetInProgressTemplateBuildsByTeam_IgnoresRowsOlderThanDay(t *testing.T)
 
 	teamID := testutils.CreateTestTeam(t, db)
 	templateID := testutils.CreateTestTemplate(t, db, teamID)
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 
 	err := db.SqlcClient.CreateActiveTemplateBuild(ctx, queries.CreateActiveTemplateBuildParams{
 		BuildID:    buildID,
@@ -99,7 +99,7 @@ func TestDeleteActiveTemplateBuild_RemovesActiveBuild(t *testing.T) {
 
 	teamID := testutils.CreateTestTeam(t, db)
 	templateID := testutils.CreateTestTemplate(t, db, teamID)
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 
 	err := db.SqlcClient.CreateActiveTemplateBuild(ctx, queries.CreateActiveTemplateBuildParams{
 		BuildID:    buildID,

--- a/packages/db/pkg/tests/snapshots/snapshot_latest_assignment_test.go
+++ b/packages/db/pkg/tests/snapshots/snapshot_latest_assignment_test.go
@@ -26,8 +26,8 @@ func TestGetLastSnapshot_ReturnsLatestAssignment(t *testing.T) {
 	baseTemplateID := testutils.CreateTestTemplate(t, db, teamID)
 
 	// Create first snapshot (creates template, build, and assignment)
-	sandboxID := "sandbox-" + uuid.New().String()
-	snapshotTemplateID := "snapshot-template-" + uuid.New().String()
+	sandboxID := "sandbox-" + uuid.Must(uuid.NewV7()).String()
+	snapshotTemplateID := "snapshot-template-" + uuid.Must(uuid.NewV7()).String()
 
 	result1 := testutils.UpsertTestSnapshot(t, ctx, db, snapshotTemplateID, sandboxID, teamID, baseTemplateID)
 	build1ID := result1.BuildID
@@ -61,8 +61,8 @@ func TestGetLastSnapshot_OnlyReturnsSuccessBuilds(t *testing.T) {
 	teamID := testutils.CreateTestTeam(t, db)
 	baseTemplateID := testutils.CreateTestTemplate(t, db, teamID)
 
-	sandboxID := "sandbox-" + uuid.New().String()
-	snapshotTemplateID := "snapshot-template-" + uuid.New().String()
+	sandboxID := "sandbox-" + uuid.Must(uuid.NewV7()).String()
+	snapshotTemplateID := "snapshot-template-" + uuid.Must(uuid.NewV7()).String()
 
 	// Create first snapshot with success status
 	result1 := testutils.UpsertTestSnapshot(t, ctx, db, snapshotTemplateID, sandboxID, teamID, baseTemplateID)
@@ -92,8 +92,8 @@ func TestGetSnapshotsWithCursor_ReturnsLatestAssignment(t *testing.T) {
 	teamID := testutils.CreateTestTeam(t, db)
 	baseTemplateID := testutils.CreateTestTemplate(t, db, teamID)
 
-	sandboxID := "sandbox-" + uuid.New().String()
-	snapshotTemplateID := "snapshot-template-" + uuid.New().String()
+	sandboxID := "sandbox-" + uuid.Must(uuid.NewV7()).String()
+	snapshotTemplateID := "snapshot-template-" + uuid.Must(uuid.NewV7()).String()
 
 	// Create first snapshot
 	testutils.UpsertTestSnapshot(t, ctx, db, snapshotTemplateID, sandboxID, teamID, baseTemplateID)
@@ -131,8 +131,8 @@ func TestGetLastSnapshot_BuildSharedWithOtherTemplate(t *testing.T) {
 	baseTemplateID := testutils.CreateTestTemplate(t, db, teamID)
 
 	// Create snapshot with first build
-	sandboxID := "sandbox-" + uuid.New().String()
-	snapshotTemplateID := "snapshot-template-" + uuid.New().String()
+	sandboxID := "sandbox-" + uuid.Must(uuid.NewV7()).String()
+	snapshotTemplateID := "snapshot-template-" + uuid.Must(uuid.NewV7()).String()
 	result1 := testutils.UpsertTestSnapshot(t, ctx, db, snapshotTemplateID, sandboxID, teamID, baseTemplateID)
 	build1ID := result1.BuildID
 
@@ -168,8 +168,8 @@ func TestGetLastSnapshot_IgnoresNonDefaultTags(t *testing.T) {
 	baseTemplateID := testutils.CreateTestTemplate(t, db, teamID)
 
 	// Create snapshot (creates build with 'default' tag)
-	sandboxID := "sandbox-" + uuid.New().String()
-	snapshotTemplateID := "snapshot-template-" + uuid.New().String()
+	sandboxID := "sandbox-" + uuid.Must(uuid.NewV7()).String()
+	snapshotTemplateID := "snapshot-template-" + uuid.Must(uuid.NewV7()).String()
 	result1 := testutils.UpsertTestSnapshot(t, ctx, db, snapshotTemplateID, sandboxID, teamID, baseTemplateID)
 	defaultBuildID := result1.BuildID
 
@@ -215,7 +215,7 @@ func TestGetLastSnapshot_AssignmentOrderDifferentFromBuildOrder(t *testing.T) {
 	testutils.CreateTestBuildAssignment(t, ctx, db, snapshotTemplateID, build1ID, "default")
 
 	// Create snapshot record
-	sandboxID := "sandbox-" + uuid.New().String()
+	sandboxID := "sandbox-" + uuid.Must(uuid.NewV7()).String()
 	testutils.CreateSnapshotRecord(t, ctx, db, snapshotTemplateID, sandboxID, teamID, baseTemplateID)
 
 	// GetLastSnapshot should return build1 (latest assignment), not build2 (latest build)

--- a/packages/db/pkg/tests/snapshots/upsert_snapshot_test.go
+++ b/packages/db/pkg/tests/snapshots/upsert_snapshot_test.go
@@ -28,8 +28,8 @@ func TestUpsertSnapshot_NewSnapshot(t *testing.T) {
 	sourceBuildID := testutils.CreateTestBuild(t, ctx, client, baseTemplateID, "uploaded")
 
 	// Prepare test data for a new snapshot
-	templateID := "test-template-" + uuid.New().String()
-	sandboxID := "sandbox-" + uuid.New().String()
+	templateID := "test-template-" + uuid.Must(uuid.NewV7()).String()
+	sandboxID := "sandbox-" + uuid.Must(uuid.NewV7()).String()
 	originNodeID := "node-1"
 	envdVersion := "v1.0.0"
 	kernelVersion := "6.1.0"
@@ -115,8 +115,8 @@ func TestUpsertSnapshot_ExistingSnapshot(t *testing.T) {
 	sourceBuildID := testutils.CreateTestBuild(t, ctx, client, baseTemplateID, "uploaded")
 
 	// Prepare test data for the first snapshot creation
-	templateID := "test-template-" + uuid.New().String()
-	sandboxID := "sandbox-" + uuid.New().String()
+	templateID := "test-template-" + uuid.Must(uuid.NewV7()).String()
+	sandboxID := "sandbox-" + uuid.Must(uuid.NewV7()).String()
 	originNodeID := "node-1"
 	envdVersion := "v1.0.0"
 	kernelVersion := "6.1.0"

--- a/packages/db/pkg/tests/templates/list_team_templates_test.go
+++ b/packages/db/pkg/tests/templates/list_team_templates_test.go
@@ -32,7 +32,7 @@ func setupDashboardSchema(t *testing.T, ctx context.Context, db *testutils.Datab
 // resources and a default-tag assignment created at the given offset from now.
 func createReadyBuildWithAssignment(t *testing.T, ctx context.Context, db *testutils.Database, templateID string, vcpu, ramMb int64, assignmentAge time.Duration) uuid.UUID {
 	t.Helper()
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 
 	err := db.SqlcClient.TestsRawSQL(ctx,
 		`INSERT INTO public.env_builds

--- a/packages/db/pkg/testutils/queries.go
+++ b/packages/db/pkg/testutils/queries.go
@@ -19,9 +19,9 @@ import (
 // Uses the default tier 'base_v1' that is created in migrations.
 func CreateTestTeam(t *testing.T, db *Database) uuid.UUID {
 	t.Helper()
-	teamID := uuid.New()
-	// Generate a unique slug from the team ID (first 8 chars)
-	slug := "test-team-" + teamID.String()[:8]
+	teamID := uuid.Must(uuid.NewV7())
+	// Generate a unique slug from the team ID random suffix.
+	slug := "test-team-" + teamID.String()[28:]
 
 	err := db.TestQueries.InsertTestTeam(t.Context(), testqueries.InsertTestTeamParams{
 		ID:    teamID,
@@ -39,7 +39,7 @@ func CreateTestTeam(t *testing.T, db *Database) uuid.UUID {
 // (required by foreign key constraints in subsequent test inserts).
 func CreateTestTemplate(t *testing.T, db *Database, teamID uuid.UUID) string {
 	t.Helper()
-	envID := "base-env-" + uuid.New().String()
+	envID := "base-env-" + uuid.Must(uuid.NewV7()).String()
 
 	err := db.TestQueries.InsertTestEnv(t.Context(), testqueries.InsertTestEnvParams{
 		ID:     envID,
@@ -54,7 +54,7 @@ func CreateTestTemplate(t *testing.T, db *Database, teamID uuid.UUID) string {
 
 func CreateTestTemplateAlias(t *testing.T, db *Database, templateID string) string {
 	t.Helper()
-	alias := "alias-" + uuid.New().String()
+	alias := "alias-" + uuid.Must(uuid.NewV7()).String()
 
 	// Insert alias without namespace (legacy behavior / promoted templates)
 	err := db.SqlcClient.TestsRawSQL(t.Context(),
@@ -69,7 +69,7 @@ func CreateTestTemplateAlias(t *testing.T, db *Database, templateID string) stri
 // CreateTestTemplateAliasWithNamespace creates an alias with a specific namespace
 func CreateTestTemplateAliasWithNamespace(t *testing.T, db *Database, templateID string, namespace *string) string {
 	t.Helper()
-	alias := "alias-" + uuid.New().String()
+	alias := "alias-" + uuid.Must(uuid.NewV7()).String()
 
 	err := db.SqlcClient.TestsRawSQL(t.Context(),
 		"INSERT INTO public.env_aliases (alias, env_id, is_renamable, namespace) VALUES ($1, $2, $3, $4)",
@@ -124,7 +124,7 @@ func CreateTestTemplateWithAlias(t *testing.T, db *Database, teamID uuid.UUID) (
 // CreateTestBuild creates a build for a template with the given status
 func CreateTestBuild(t *testing.T, ctx context.Context, db *Database, templateID string, status string) uuid.UUID {
 	t.Helper()
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 
 	err := db.SqlcClient.TestsRawSQL(ctx,
 		`INSERT INTO public.env_builds 

--- a/packages/db/scripts/seed/postgres/seed-db.go
+++ b/packages/db/scripts/seed/postgres/seed-db.go
@@ -40,7 +40,7 @@ func main() {
 		return
 	}
 
-	teamUUID := uuid.New()
+	teamUUID := uuid.Must(uuid.NewV7())
 
 	accessToken, err := keys.GenerateKey(keys.AccessTokenPrefix)
 	if err != nil {
@@ -131,7 +131,7 @@ DELETE FROM auth.users WHERE email = $1
 		panic(err)
 	}
 
-	userID := uuid.New()
+	userID := uuid.Must(uuid.NewV7())
 	err = authDb.TestsRawSQL(ctx, `
 INSERT INTO auth.users (id, email)
 VALUES ($1, $2)
@@ -176,7 +176,7 @@ VALUES ($1, $2, $3)
 	}
 	_, err = authDb.Write.CreateAccessToken(
 		ctx, authqueries.CreateAccessTokenParams{
-			ID:                    uuid.New(),
+			ID:                    uuid.Must(uuid.NewV7()),
 			UserID:                userID,
 			AccessTokenHash:       accessTokenHash,
 			AccessTokenPrefix:     accessTokenMask.Prefix,

--- a/packages/docker-reverse-proxy/internal/auth/validate_test.go
+++ b/packages/docker-reverse-proxy/internal/auth/validate_test.go
@@ -22,7 +22,7 @@ func TestValidate(t *testing.T) {
 	accessToken, err := keys.GenerateKey(keys.AccessTokenPrefix)
 	require.NoError(t, err)
 
-	userID := uuid.New()
+	userID := uuid.Must(uuid.NewV7())
 	envID := "test-env-id"
 
 	testcases := []struct {
@@ -131,7 +131,7 @@ func setupValidateTest(tb testing.TB, db *testutils.Database, userID uuid.UUID, 
 
 	// Create access token
 	_, err = db.AuthDB.Write.CreateAccessToken(tb.Context(), authqueries.CreateAccessTokenParams{
-		ID:                    uuid.New(),
+		ID:                    uuid.Must(uuid.NewV7()),
 		UserID:                userID,
 		AccessTokenHash:       accessToken.HashedValue,
 		AccessTokenPrefix:     accessToken.Masked.Prefix,
@@ -150,7 +150,7 @@ func setupValidateTest(tb testing.TB, db *testutils.Database, userID uuid.UUID, 
 	require.NoError(tb, err)
 
 	// Create env_build
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 	var finishedAt *string
 	if createdEnvStatus == "uploaded" || createdEnvStatus == "success" || createdEnvStatus == "ready" {
 		now := time.Now().Format(time.RFC3339)

--- a/packages/envd/internal/api/compose.go
+++ b/packages/envd/internal/api/compose.go
@@ -116,7 +116,7 @@ func (a *API) PostFilesCompose(w http.ResponseWriter, r *http.Request) {
 
 	// Write to a temporary file and rename on success to avoid destroying
 	// any pre-existing file at destPath if assembly fails midway.
-	tmpPath := destPath + ".e2b-compose." + uuid.New().String() + ".tmp"
+	tmpPath := destPath + ".e2b-compose." + uuid.Must(uuid.NewV7()).String() + ".tmp"
 
 	destFile, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o666)
 	if err != nil {

--- a/packages/envd/internal/services/filesystem/dir_test.go
+++ b/packages/envd/internal/services/filesystem/dir_test.go
@@ -131,7 +131,7 @@ func TestListDirRelativePath(t *testing.T) {
 	require.NoError(t, err)
 
 	// Setup directory structure
-	testRelativePath := fmt.Sprintf("test-%s", uuid.New())
+	testRelativePath := fmt.Sprintf("test-%s", uuid.Must(uuid.NewV7()))
 	testFolderPath := filepath.Join(u.HomeDir, testRelativePath)
 	filePath := filepath.Join(testFolderPath, "file.txt")
 	require.NoError(t, os.MkdirAll(testFolderPath, 0o755))

--- a/packages/envd/internal/services/filesystem/move_test.go
+++ b/packages/envd/internal/services/filesystem/move_test.go
@@ -185,7 +185,7 @@ func TestMoveRelativePath(t *testing.T) {
 	require.NoError(t, err)
 
 	// Setup directory structure with unique name to avoid conflicts
-	testRelativePath := fmt.Sprintf("test-move-%s", uuid.New())
+	testRelativePath := fmt.Sprintf("test-move-%s", uuid.Must(uuid.NewV7()))
 	testFolderPath := filepath.Join(u.HomeDir, testRelativePath)
 	require.NoError(t, os.MkdirAll(testFolderPath, 0o755))
 
@@ -195,7 +195,7 @@ func TestMoveRelativePath(t *testing.T) {
 	require.NoError(t, os.WriteFile(sourceFile, testContent, 0o644))
 
 	// Destination file path (also relative)
-	destRelativePath := fmt.Sprintf("test-move-dest-%s", uuid.New())
+	destRelativePath := fmt.Sprintf("test-move-dest-%s", uuid.Must(uuid.NewV7()))
 	destFolderPath := filepath.Join(u.HomeDir, destRelativePath)
 	require.NoError(t, os.MkdirAll(destFolderPath, 0o755))
 	destFile := filepath.Join(destFolderPath, "moved-file.txt")

--- a/packages/orchestrator/benchmarks/concurrent_benchmark_test.go
+++ b/packages/orchestrator/benchmarks/concurrent_benchmark_test.go
@@ -359,7 +359,7 @@ func BenchmarkConcurrentResume(b *testing.B) {
 	b.Log("warming up: creating one sandbox to prime caches...")
 	warmupRuntime := sandbox.RuntimeMetadata{
 		TemplateID:  templateID,
-		SandboxID:   "warmup-" + uuid.NewString()[:8],
+		SandboxID:   "warmup-" + uuid.Must(uuid.NewV7()).String()[28:],
 		ExecutionID: "warmup-exec",
 		TeamID:      "bench-team",
 	}
@@ -429,7 +429,7 @@ func runConcurrentResume(
 		wg.Go(func() {
 			runtime := sandbox.RuntimeMetadata{
 				TemplateID:  templateID,
-				SandboxID:   fmt.Sprintf("bench-%d-%s", i, uuid.NewString()[:8]),
+				SandboxID:   fmt.Sprintf("bench-%d-%s", i, uuid.Must(uuid.NewV7()).String()[28:]),
 				ExecutionID: fmt.Sprintf("bench-exec-%d", i),
 				TeamID:      "bench-team",
 			}

--- a/packages/orchestrator/cmd/clean-nfs-cache/main.go
+++ b/packages/orchestrator/cmd/clean-nfs-cache/main.go
@@ -221,7 +221,7 @@ func preRun(ctx context.Context) (cleaner.Options, logger.Logger, telemetry.LogP
 
 func newOtelCore(ctx context.Context, endpoint string) (zapcore.Core, telemetry.LogProvider, error) {
 	nodeID := env.GetNodeID()
-	serviceInstanceID := uuid.NewString()
+	serviceInstanceID := uuid.Must(uuid.NewV7()).String()
 
 	resource, err := telemetry.GetResource(ctx, nodeID, serviceName, commitSHA, serviceVersion, serviceInstanceID)
 	if err != nil {

--- a/packages/orchestrator/cmd/dummy-orchestrator/main.go
+++ b/packages/orchestrator/cmd/dummy-orchestrator/main.go
@@ -76,7 +76,7 @@ func main() {
 	orchestrator.RegisterChunkServiceServer(srv, &orchestrator.UnimplementedChunkServiceServer{})
 	orchestrator.RegisterVolumeServiceServer(srv, &orchestrator.UnimplementedVolumeServiceServer{})
 
-	serviceID := uuid.NewString()
+	serviceID := uuid.Must(uuid.NewV7()).String()
 	orchestratorinfo.RegisterInfoServiceServer(srv, dummyserver.NewInfo(nodeID, serviceID, version, commit, labels))
 
 	healthSrv := health.NewServer()

--- a/packages/orchestrator/cmd/inspect-build/report_test.go
+++ b/packages/orchestrator/cmd/inspect-build/report_test.go
@@ -26,7 +26,7 @@ func testMapping(t *testing.T, chunkSize uint64, maps []header.BuildMap) header.
 func TestRoleOf(t *testing.T) {
 	t.Parallel()
 
-	cur, par, anc := uuid.New(), uuid.New(), uuid.New()
+	cur, par, anc := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
 	meta := &header.Metadata{BuildId: cur, BaseBuildId: par}
 
 	require.Equal(t, roleCurrent, roleOf(cur, meta))
@@ -87,7 +87,7 @@ func TestFilteredFrames(t *testing.T) {
 func TestGatherMappings(t *testing.T) {
 	t.Parallel()
 
-	cur, anc := uuid.New(), uuid.New()
+	cur, anc := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
 	h := &header.Header{
 		Metadata: &header.Metadata{BuildId: cur, BaseBuildId: cur},
 		Mapping: testMapping(t, 50, []header.BuildMap{
@@ -121,7 +121,7 @@ func TestGatherMappings(t *testing.T) {
 func TestAncestorIDs(t *testing.T) {
 	t.Parallel()
 
-	self, par, anc := uuid.New(), uuid.New(), uuid.New()
+	self, par, anc := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
 	r := &report{
 		Image: imageInfo{BuildID: self, BaseBuildID: par},
 		Mappings: mappingsSection{ByBuild: []buildExtent{
@@ -144,7 +144,7 @@ func TestAncestorIDs(t *testing.T) {
 func TestBuildInfoFor(t *testing.T) {
 	t.Parallel()
 
-	a, b := uuid.New(), uuid.New()
+	a, b := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
 	r := &report{Builds: []buildInfo{{BuildID: a, Role: roleCurrent}}}
 
 	got, ok := r.buildInfoFor(a)
@@ -172,7 +172,7 @@ func TestJSONValue(t *testing.T) {
 func TestAncestorUsageOf(t *testing.T) {
 	t.Parallel()
 
-	anc := uuid.New()
+	anc := uuid.Must(uuid.NewV7())
 	ancestor := &report{
 		Image: imageInfo{BuildID: anc},
 		Data: dataSection{
@@ -186,7 +186,7 @@ func TestAncestorUsageOf(t *testing.T) {
 	}
 	head := &report{Mappings: mappingsSection{List: []mapping{
 		{Offset: 0, Length: 1 * miB, BuildID: anc, StorageOffset: 0},
-		{Offset: 1 * miB, Length: 1 * miB, BuildID: uuid.New()}, // a different build
+		{Offset: 1 * miB, Length: 1 * miB, BuildID: uuid.Must(uuid.NewV7())}, // a different build
 		{Offset: 2 * miB, Length: 0x1000, BuildID: anc, StorageOffset: 3 * miB},
 	}}}
 
@@ -213,7 +213,7 @@ func TestGatherFetchmap(t *testing.T) {
 		bs   = 2 * miB
 		page = 4096
 	)
-	buildA, buildB := uuid.New(), uuid.New()
+	buildA, buildB := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
 
 	// frames(perFrameU): builds a FrameTable with consecutive frames of the
 	// given U-sizes, dummy 1 KiB compressed size each.
@@ -430,7 +430,7 @@ func TestCompressionPerChunk(t *testing.T) {
 		bs   = 2 * miB
 		page = 4096
 	)
-	selfID, ancestorID := uuid.New(), uuid.New()
+	selfID, ancestorID := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
 
 	hdr := func(t *testing.T, size uint64, maps []header.BuildMap) *header.Header {
 		t.Helper()
@@ -523,7 +523,7 @@ func TestFramesInRange(t *testing.T) {
 	t.Parallel()
 
 	const bs = 2 * miB
-	selfID := uuid.New()
+	selfID := uuid.Must(uuid.NewV7())
 
 	frames := []frameInfo{
 		{StartU: 0, EndU: bs},

--- a/packages/orchestrator/cmd/inspect-build/validate_test.go
+++ b/packages/orchestrator/cmd/inspect-build/validate_test.go
@@ -45,7 +45,7 @@ func TestIntersectsAny(t *testing.T) {
 func TestValidateFrameTable(t *testing.T) {
 	t.Parallel()
 
-	cur := uuid.New()
+	cur := uuid.Must(uuid.NewV7())
 	ft := storage.NewFullFrameTable(storage.CompressionZstd, []storage.FrameSize{
 		{U: 2 * miB, C: 1},
 		{U: 2 * miB, C: 1},

--- a/packages/orchestrator/cmd/mount-build-rootfs/main.go
+++ b/packages/orchestrator/cmd/mount-build-rootfs/main.go
@@ -95,7 +95,7 @@ func main() {
 }
 
 func runEmpty(ctx, nbdContext context.Context, featureFlags *featureflags.Client, size int64, blockSize int64) error {
-	cowCachePath := filepath.Join(os.TempDir(), fmt.Sprintf("rootfs.ext4.cow.cache-%s", uuid.New().String()))
+	cowCachePath := filepath.Join(os.TempDir(), fmt.Sprintf("rootfs.ext4.cow.cache-%s", uuid.Must(uuid.NewV7()).String()))
 
 	emptyDevice, err := testutils.NewZeroDevice(size, blockSize)
 	if err != nil {
@@ -141,7 +141,7 @@ func run(ctx, nbdContext context.Context, featureFlags *featureflags.Client, bui
 		return fmt.Errorf("failed to get template rootfs: %w", err)
 	}
 
-	cowCachePath := filepath.Join(os.TempDir(), fmt.Sprintf("%s-rootfs.ext4.cow.cache-%s", buildID, uuid.New().String()))
+	cowCachePath := filepath.Join(os.TempDir(), fmt.Sprintf("%s-rootfs.ext4.cow.cache-%s", buildID, uuid.Must(uuid.NewV7()).String()))
 
 	defer os.RemoveAll(cowCachePath)
 

--- a/packages/orchestrator/cmd/resume-build/fph_bench.go
+++ b/packages/orchestrator/cmd/resume-build/fph_bench.go
@@ -113,7 +113,7 @@ func (r *runner) fphBenchOnce(ctx context.Context, opts fphBenchOptions, withFph
 		featureflags.NewJSONFlag("free-page-hinting-config", ldvalue.Null())
 	}
 
-	buildID := uuid.New().String()
+	buildID := uuid.Must(uuid.NewV7()).String()
 	defer cleanupLocalBuild(buildID)
 
 	runtime := sandbox.RuntimeMetadata{

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -182,7 +182,7 @@ func main() {
 	// Generate new build ID if not specified and pause mode is enabled
 	outputBuildID := *toBuild
 	if isPauseMode && outputBuildID == "" {
-		outputBuildID = uuid.New().String()
+		outputBuildID = uuid.Must(uuid.NewV7()).String()
 	}
 
 	if err := setupEnv(*storagePath, *sandboxDir); err != nil {
@@ -787,7 +787,7 @@ func (r *runner) pauseBenchmark(ctx context.Context, opts pauseOptions) error {
 
 		// Generate unique build ID for each iteration (not saved)
 		iterOpts := opts
-		iterOpts.newBuildID = uuid.New().String()
+		iterOpts.newBuildID = uuid.Must(uuid.NewV7()).String()
 
 		fmt.Printf("\r[%d/%d] Running...    ", i+1, opts.iterations)
 		timings, _ := r.pauseOnce(ctx, iterOpts, false)

--- a/packages/orchestrator/cmd/smoketest/smoke_test.go
+++ b/packages/orchestrator/cmd/smoketest/smoke_test.go
@@ -74,7 +74,7 @@ func TestSmokeAllFCVersions(t *testing.T) { //nolint:paralleltest // subtests sh
 
 	for fcMajor, fcVersion := range featureflags.FirecrackerVersionMap { //nolint:paralleltest // sequential by design
 		t.Run("fc-"+fcMajor, func(t *testing.T) {
-			buildID := uuid.New().String()
+			buildID := uuid.Must(uuid.NewV7()).String()
 
 			// Phase 1: create build
 			t.Logf("creating build %s with FC %s", buildID, fcVersion)
@@ -131,7 +131,7 @@ func TestSmokeAllFCVersions(t *testing.T) { //nolint:paralleltest // subtests sh
 					TemplateID:  "smoke-" + fcMajor,
 					TeamID:      "smoke",
 					SandboxID:   fmt.Sprintf("sbx-smoke-%s-%d", fcMajor, time.Now().UnixNano()),
-					ExecutionID: uuid.NewString(),
+					ExecutionID: uuid.Must(uuid.NewV7()).String(),
 				},
 				t0,
 				t0.Add(10*time.Minute),

--- a/packages/orchestrator/pkg/dummyserver/sandbox.go
+++ b/packages/orchestrator/pkg/dummyserver/sandbox.go
@@ -38,7 +38,7 @@ type SandboxServer struct {
 // api side can route follow-up calls back to this orchestrator.
 func NewSandbox() *SandboxServer {
 	return &SandboxServer{
-		clientID:  uuid.NewString(),
+		clientID:  uuid.Must(uuid.NewV7()).String(),
 		sandboxes: make(map[string]*orchestrator.RunningSandbox),
 	}
 }

--- a/packages/orchestrator/pkg/factories/run.go
+++ b/packages/orchestrator/pkg/factories/run.go
@@ -214,7 +214,7 @@ func run(config cfg.Config, opts Options) (success bool) {
 
 	nodeID := env.GetNodeID()
 	serviceName := cfg.GetServiceName(services)
-	serviceInstanceID := uuid.NewString()
+	serviceInstanceID := uuid.Must(uuid.NewV7()).String()
 
 	// Detect CPU platform for orchestrator pool matching
 	machineInfo, err := machineinfo.Detect()

--- a/packages/orchestrator/pkg/nfsproxy/e2e_test.go
+++ b/packages/orchestrator/pkg/nfsproxy/e2e_test.go
@@ -104,11 +104,11 @@ func TestIntegrationTest(t *testing.T) {
 	localIP := getLocalIP(t)
 	slot := &network.Slot{Key: "abc", HostIP: localIP}
 
-	sandboxID := uuid.NewString()
-	teamID := uuid.New()
+	sandboxID := uuid.Must(uuid.NewV7()).String()
+	teamID := uuid.Must(uuid.NewV7())
 	volumeType := "volume-type-1"
 	volumeName := "test-volume-1"
-	volumeID := uuid.New()
+	volumeID := uuid.Must(uuid.NewV7())
 	sandboxes := sandbox.NewSandboxesMap()
 	sandboxes.AssignNetwork(t.Context(), &sandbox.Sandbox{
 		Metadata: &sandbox.Metadata{

--- a/packages/orchestrator/pkg/nfsproxy/logged/util.go
+++ b/packages/orchestrator/pkg/nfsproxy/logged/util.go
@@ -13,7 +13,7 @@ import (
 
 func logStart(ctx context.Context, s string, args ...any) func(context.Context, error, ...any) {
 	start := time.Now()
-	requestID := uuid.NewString()
+	requestID := uuid.Must(uuid.NewV7()).String()
 
 	l := logger.L().With(zap.String("requestID", requestID))
 	l.Debug(ctx, fmt.Sprintf("[nfs proxy] %s: start", s), zap.String("operation", s))

--- a/packages/orchestrator/pkg/nfsproxy/proxy_test.go
+++ b/packages/orchestrator/pkg/nfsproxy/proxy_test.go
@@ -56,13 +56,13 @@ func TestRoundTrip(t *testing.T) {
 	zap.ReplaceGlobals(log)
 
 	// setup data
-	sandboxID := uuid.NewString()
-	teamID := uuid.New()
+	sandboxID := uuid.Must(uuid.NewV7()).String()
+	teamID := uuid.Must(uuid.NewV7())
 	volPath1 := t.TempDir()
 	volType1 := "volume-type-1"
-	volID1 := uuid.New()
+	volID1 := uuid.Must(uuid.NewV7())
 	volName1 := "volume-1"
-	volID2 := uuid.New()
+	volID2 := uuid.Must(uuid.NewV7())
 	volName2 := "volume-2"
 	volType2 := "volume-type-2"
 
@@ -207,7 +207,7 @@ func TestRoundTrip(t *testing.T) {
 	t.Run("mkdir", func(t *testing.T) {
 		t.Parallel()
 
-		path := uuid.NewString()
+		path := uuid.Must(uuid.NewV7()).String()
 		fh, err := target.Mkdir(path, 0o755)
 		require.NoError(t, err)
 		assert.NotNil(t, fh)
@@ -217,7 +217,7 @@ func TestRoundTrip(t *testing.T) {
 		t.Parallel()
 
 		// setup root dir, to prevent collisions
-		path := uuid.NewString()
+		path := uuid.Must(uuid.NewV7()).String()
 		mkdir(t, target, path, 0o755)
 
 		// write files
@@ -243,7 +243,7 @@ func TestRoundTrip(t *testing.T) {
 	t.Run("access", func(t *testing.T) {
 		t.Parallel()
 
-		path := uuid.NewString()
+		path := uuid.Must(uuid.NewV7()).String()
 		mkdir(t, target, path, 0o755)
 		writeFile(t, target, filepath.Join(path, "file.txt"), "file.txt contents", 0o644)
 		mode, err := target.Access(filepath.Join(path, "file.txt"), 0o644)
@@ -255,7 +255,7 @@ func TestRoundTrip(t *testing.T) {
 		t.Parallel()
 
 		// verify that file can be read with getattr
-		path := uuid.NewString()
+		path := uuid.Must(uuid.NewV7()).String()
 		stat1, fh1, err := target.Lookup(path)
 		require.ErrorIs(t, err, os.ErrNotExist)
 		assert.Nil(t, fh1)

--- a/packages/orchestrator/pkg/sandbox/block/cache_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/cache_test.go
@@ -289,14 +289,14 @@ func TestCacheExportToDiff_ZeroBlockMapsToEmpty(t *testing.T) {
 	diffMetadata, err := cache.ExportToDiff(t.Context(), out)
 	require.NoError(t, err)
 
-	baseBuildID := uuid.New()
+	baseBuildID := uuid.Must(uuid.NewV7())
 	originalHeader, err := header.NewHeader(
 		header.NewTemplateMetadata(baseBuildID, uint64(blockSize), uint64(blockSize)),
 		nil,
 	)
 	require.NoError(t, err)
 
-	diffHeader, err := diffMetadata.ToDiffHeader(t.Context(), originalHeader, uuid.New())
+	diffHeader, err := diffMetadata.ToDiffHeader(t.Context(), originalHeader, uuid.Must(uuid.NewV7()))
 	require.NoError(t, err)
 
 	mapped, err := diffHeader.GetShiftedMapping(t.Context(), 0)
@@ -336,14 +336,14 @@ func TestCacheExportToDiff_MixedZeroBlockSplitsIntoEmptyAndDirty(t *testing.T) {
 	require.True(t, diffMetadata.Empty.Contains(0))
 	require.True(t, diffMetadata.Dirty.Contains(1))
 
-	baseBuildID := uuid.New()
+	baseBuildID := uuid.Must(uuid.NewV7())
 	originalHeader, err := header.NewHeader(
 		header.NewTemplateMetadata(baseBuildID, uint64(blockSize), uint64(size)),
 		nil,
 	)
 	require.NoError(t, err)
 
-	snapshotBuildID := uuid.New()
+	snapshotBuildID := uuid.Must(uuid.NewV7())
 	diffHeader, err := diffMetadata.ToDiffHeader(t.Context(), originalHeader, snapshotBuildID)
 	require.NoError(t, err)
 

--- a/packages/orchestrator/pkg/sandbox/block/dedup_sim_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/dedup_sim_test.go
@@ -434,7 +434,7 @@ func runSimChain(t *testing.T, cfg simConfig, s simScenario) simResult {
 		meta, _ := s.planner(t, mem, parent, hdr, dirty, cycle)
 		storedPages += int64(meta.Dirty.GetCardinality())
 
-		hdr, err = meta.ToDiffHeader(context.Background(), hdr, uuid.New())
+		hdr, err = meta.ToDiffHeader(context.Background(), hdr, uuid.Must(uuid.NewV7()))
 		require.NoError(t, err)
 		copy(parent, mem)
 	}
@@ -534,7 +534,7 @@ func TestDedupRandomChain_NoCorruption(t *testing.T) {
 			}
 			parent := slices.Clone(mem)
 
-			templateBuild := uuid.New()
+			templateBuild := uuid.Must(uuid.NewV7())
 			hdr, err := header.NewHeader(header.NewTemplateMetadata(templateBuild, uint64(simPageSize), uint64(cfg.size())), nil)
 			require.NoError(t, err)
 			layers := map[uuid.UUID][]byte{templateBuild: slices.Clone(mem)}
@@ -562,7 +562,7 @@ func TestDedupRandomChain_NoCorruption(t *testing.T) {
 					p := int64(it.Next())
 					payload = append(payload, mem[p*simPageSize:(p+1)*simPageSize]...)
 				}
-				build := uuid.New()
+				build := uuid.Must(uuid.NewV7())
 				layers[build] = payload
 
 				hdr, err = meta.ToDiffHeader(context.Background(), hdr, build)

--- a/packages/orchestrator/pkg/sandbox/block/dedup_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/dedup_test.go
@@ -51,7 +51,7 @@ func TestCacheDedup_FetchRunBudgetPromotesSmallParentRun(t *testing.T) {
 func TestDedupPlanPromoteCheapFrames(t *testing.T) {
 	t.Parallel()
 
-	buildA, buildB := uuid.New(), uuid.New()
+	buildA, buildB := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
 	newPlan := func() *dedupPlan { return &dedupPlan{pageDirty: roaring.New(), pageEmpty: roaring.New()} }
 
 	t.Run("frames at or under the price threshold", func(t *testing.T) {
@@ -173,7 +173,7 @@ func TestCacheDedup_ExternallyReferencedFrameNotPromoted(t *testing.T) {
 	copy(srcData, baseData)
 	srcData[0] ^= 0xFF // page 0 differs; pages 1-3 match base
 
-	build := uuid.New()
+	build := uuid.Must(uuid.NewV7())
 	hdr, err := header.NewHeader(
 		header.NewTemplateMetadata(build, uint64(blockSize), uint64(size)),
 		nil,
@@ -199,7 +199,7 @@ func TestCacheDedup_ExternallyReferencedFrameNotPromoted(t *testing.T) {
 func TestParentFetchKey_UsesBuildFrameTable(t *testing.T) {
 	t.Parallel()
 
-	build := uuid.New()
+	build := uuid.Must(uuid.NewV7())
 	frameU := int32(1 << 20) // 1 MiB frames, half the default window
 	ft := storage.NewFullFrameTable(storage.CompressionZstd, []storage.FrameSize{
 		{U: frameU, C: 100}, {U: frameU, C: 100}, {U: frameU, C: 100},
@@ -221,7 +221,7 @@ func TestParentFetchKey_UsesBuildFrameTable(t *testing.T) {
 	require.NotEqual(t, key(uint64(frameU)), key(uint64(2*frameU)))
 
 	// Builds without frame data fall back to configured-window bucketing.
-	other := uuid.New()
+	other := uuid.Must(uuid.NewV7())
 	fallback := func(storageOff uint64) dedupFetchKey {
 		return parentFetchKey(hdr, header.BuildMap{BuildId: other, Offset: storageOff}, true, 0, windowBytes)
 	}
@@ -240,7 +240,7 @@ func TestFetchWindowerCompact(t *testing.T) {
 	t.Parallel()
 
 	current := dedupPageInfo{kind: dedupPageCurrent}
-	buildA, buildB, buildC := uuid.New(), uuid.New(), uuid.New()
+	buildA, buildB, buildC := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
 
 	t.Run("zero-benefit promotion is not committed", func(t *testing.T) {
 		t.Parallel()

--- a/packages/orchestrator/pkg/sandbox/build/cache_test.go
+++ b/packages/orchestrator/pkg/sandbox/build/cache_test.go
@@ -561,7 +561,7 @@ func TestFileIsCached_UninitializedChunkerReportsUncached(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	parentBuildID := uuid.New()
+	parentBuildID := uuid.Must(uuid.NewV7())
 	const size = 4096
 	hdr, err := header.NewHeader(
 		header.NewTemplateMetadata(parentBuildID, size, size),

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff_test.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff_test.go
@@ -36,7 +36,7 @@ func TestStorageDiff_LoadsOwnHeaderWhenParentHasNoEntry(t *testing.T) {
 	)
 
 	ctx := t.Context()
-	aID := uuid.New()
+	aID := uuid.Must(uuid.NewV7())
 	payload := bytes.Repeat([]byte("ancestor-payload-"), payloadSize/len("ancestor-payload-")+1)[:payloadSize]
 
 	aFrameTable, compressed, _, err := storage.CompressBytes(ctx, payload, storage.CompressConfig{
@@ -55,7 +55,7 @@ func TestStorageDiff_LoadsOwnHeaderWhenParentHasNoEntry(t *testing.T) {
 	aHeaderBytes, err := header.SerializeHeader(aHeader)
 	require.NoError(t, err)
 
-	bHeader := buildHeader(t, uuid.New(), payloadSize, aID)
+	bHeader := buildHeader(t, uuid.Must(uuid.NewV7()), payloadSize, aID)
 	bHeader.IncompletePendingUpload = true
 
 	aPaths := storage.Paths{BuildID: aID.String()}
@@ -104,7 +104,7 @@ func TestStorageDiff_SwapsHeaderOnSelfMatch(t *testing.T) {
 	)
 
 	ctx := t.Context()
-	selfID := uuid.New()
+	selfID := uuid.Must(uuid.NewV7())
 	payload := bytes.Repeat([]byte("self-payload-"), payloadSize/len("self-payload-")+1)[:payloadSize]
 
 	frameTable, compressed, _, err := storage.CompressBytes(ctx, payload, storage.CompressConfig{
@@ -176,10 +176,10 @@ func TestStorageDiff_NoRefreshOnFinalizedHeader(t *testing.T) {
 		readLen     = blockSize
 	)
 
-	aID := uuid.New()
+	aID := uuid.Must(uuid.NewV7())
 	payload := bytes.Repeat([]byte("uncompressed-A-"), payloadSize/len("uncompressed-A-")+1)[:payloadSize]
 
-	bHeader := buildHeader(t, uuid.New(), payloadSize, aID)
+	bHeader := buildHeader(t, uuid.Must(uuid.NewV7()), payloadSize, aID)
 	bHeader.SetBuild(aID, header.BuildData{Size: int64(payloadSize), FrameData: nil})
 
 	uncompressedPath := storage.Paths{BuildID: aID.String()}.DataFile(storage.MemfileName, storage.CompressionNone)
@@ -216,12 +216,12 @@ func TestStorageDiff_SkipsHeaderRefreshWhenPeerActive(t *testing.T) {
 		readLen     = blockSize
 	)
 
-	aID := uuid.New()
+	aID := uuid.Must(uuid.NewV7())
 	payload := bytes.Repeat([]byte("p2p-served-"), payloadSize/len("p2p-served-")+1)[:payloadSize]
 
 	// Parent has no Builds[aID] entry — would normally trigger the proactive
 	// refresh path.
-	bHeader := buildHeader(t, uuid.New(), payloadSize, aID)
+	bHeader := buildHeader(t, uuid.Must(uuid.NewV7()), payloadSize, aID)
 
 	aPaths := storage.Paths{BuildID: aID.String()}
 	provider := storage.NewMockStorageProvider(t)
@@ -256,7 +256,7 @@ func TestStorageDiff_V3AncestorFallsBackToUncompressed(t *testing.T) {
 	const payloadSize = 256 * 1024
 	readLen := testBlockSize
 
-	aID := uuid.New()
+	aID := uuid.Must(uuid.NewV7())
 	payload := bytes.Repeat([]byte("v3-ancestor-data-"), payloadSize/len("v3-ancestor-data-")+1)[:payloadSize]
 
 	// A's header on storage: V3 (no Builds map).
@@ -270,7 +270,7 @@ func TestStorageDiff_V3AncestorFallsBackToUncompressed(t *testing.T) {
 	require.NoError(t, err)
 
 	// Current header: complete V4, maps to A, no Builds entry for A.
-	bHeader := buildHeader(t, uuid.New(), payloadSize, aID)
+	bHeader := buildHeader(t, uuid.Must(uuid.NewV7()), payloadSize, aID)
 
 	aPaths := storage.Paths{BuildID: aID.String()}
 	provider := storage.NewMockStorageProvider(t)
@@ -321,7 +321,7 @@ func TestStorageDiff_ReloadSourceLatchesV3AsUncompressed(t *testing.T) {
 	const payloadSize = 64 * 1024
 	readLen := testBlockSize
 
-	aID := uuid.New()
+	aID := uuid.Must(uuid.NewV7())
 	payload := bytes.Repeat([]byte("v3-reload-data-"), payloadSize/len("v3-reload-data-")+1)[:payloadSize]
 
 	aMeta := header.NewTemplateMetadata(aID, uint64(testBlockSize), uint64(payloadSize))

--- a/packages/orchestrator/pkg/sandbox/build_upload_test.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_test.go
@@ -104,10 +104,10 @@ func TestAppendAncestorBuilds_V3AncestorSynthesizesEntry(t *testing.T) {
 	t.Parallel()
 
 	uploads, cache := newUploads(t)
-	ancestorID := uuid.New()
+	ancestorID := uuid.Must(uuid.NewV7())
 	putV3Header(t, cache, ancestorID, build.Memfile, 512*1024*1024)
 
-	u := &Upload{buildID: uuid.New(), uploads: uploads}
+	u := &Upload{buildID: uuid.Must(uuid.NewV7()), uploads: uploads}
 	dst := map[uuid.UUID]headers.BuildData{}
 
 	err := u.appendAncestorBuilds(t.Context(), dst, mappingTo(t, 4096, ancestorID, 4096), build.Memfile)
@@ -124,10 +124,10 @@ func TestAppendAncestorBuilds_V4AncestorCopiesEntry(t *testing.T) {
 	t.Parallel()
 
 	uploads, cache := newUploads(t)
-	ancestorID := uuid.New()
+	ancestorID := uuid.Must(uuid.NewV7())
 	putHeader(t, cache, ancestorID, build.Memfile, false)
 
-	u := &Upload{buildID: uuid.New(), uploads: uploads}
+	u := &Upload{buildID: uuid.Must(uuid.NewV7()), uploads: uploads}
 	dst := map[uuid.UUID]headers.BuildData{}
 
 	err := u.appendAncestorBuilds(t.Context(), dst, mappingTo(t, 4096, ancestorID, 4096), build.Memfile)
@@ -143,10 +143,10 @@ func TestAppendAncestorBuilds_NilDstSkipsSynthesis(t *testing.T) {
 	t.Parallel()
 
 	uploads, cache := newUploads(t)
-	ancestorID := uuid.New()
+	ancestorID := uuid.Must(uuid.NewV7())
 	putV3Header(t, cache, ancestorID, build.Memfile, 1024)
 
-	u := &Upload{buildID: uuid.New(), uploads: uploads}
+	u := &Upload{buildID: uuid.Must(uuid.NewV7()), uploads: uploads}
 	err := u.appendAncestorBuilds(t.Context(), nil, mappingTo(t, 4096, ancestorID, 4096), build.Memfile)
 	require.NoError(t, err)
 }
@@ -164,7 +164,7 @@ func TestNewUpload_FilesystemSnapshotSkipsMemfileCompressConfig(t *testing.T) {
 	t.Run("filesystem-only snapshot with zero memfile block size succeeds", func(t *testing.T) {
 		t.Parallel()
 		snap := &Snapshot{
-			BuildID:            uuid.New(),
+			BuildID:            uuid.Must(uuid.NewV7()),
 			FilesystemSnapshot: true,
 			RootfsBlockSize:    4096,
 		}
@@ -177,7 +177,7 @@ func TestNewUpload_FilesystemSnapshotSkipsMemfileCompressConfig(t *testing.T) {
 	t.Run("memory snapshot with zero memfile block size still errors", func(t *testing.T) {
 		t.Parallel()
 		snap := &Snapshot{
-			BuildID:            uuid.New(),
+			BuildID:            uuid.Must(uuid.NewV7()),
 			FilesystemSnapshot: false,
 			RootfsBlockSize:    4096,
 		}

--- a/packages/orchestrator/pkg/sandbox/nbd/path_direct_slow_test.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/path_direct_slow_test.go
@@ -90,7 +90,7 @@ func TestSlowBackend_ShortTimeout(t *testing.T) {
 	// Backend delays every read by 8 seconds — longer than the kernel timeout below.
 	slow := newSlowDevice(emptyDevice, 8*time.Second)
 
-	cowCachePath := filepath.Join(os.TempDir(), fmt.Sprintf("test-slow-timeout-%s", uuid.New().String()))
+	cowCachePath := filepath.Join(os.TempDir(), fmt.Sprintf("test-slow-timeout-%s", uuid.Must(uuid.NewV7()).String()))
 	t.Cleanup(func() { os.RemoveAll(cowCachePath) })
 
 	cache, err := block.NewCache(size, blockSize, cowCachePath, false)
@@ -143,7 +143,7 @@ func TestSlowBackend_SufficientTimeout(t *testing.T) {
 	// Backend delays every read by 3 seconds.
 	slow := newSlowDevice(emptyDevice, 3*time.Second)
 
-	cowCachePath := filepath.Join(os.TempDir(), fmt.Sprintf("test-slow-ok-%s", uuid.New().String()))
+	cowCachePath := filepath.Join(os.TempDir(), fmt.Sprintf("test-slow-ok-%s", uuid.Must(uuid.NewV7()).String()))
 	t.Cleanup(func() { os.RemoveAll(cowCachePath) })
 
 	cache, err := block.NewCache(size, blockSize, cowCachePath, false)

--- a/packages/orchestrator/pkg/sandbox/nbd/path_direct_test.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/path_direct_test.go
@@ -250,7 +250,7 @@ func setupNBDDevice(t *testing.T, featureFlags *featureflags.Client, size int64,
 	emptyDevice, err := testutils.NewZeroDevice(size, blockSize)
 	require.NoError(t, err, "failed to create zero device")
 
-	cowCachePath := filepath.Join(os.TempDir(), fmt.Sprintf("test-rootfs.ext4.cow.cache-%s", uuid.New().String()))
+	cowCachePath := filepath.Join(os.TempDir(), fmt.Sprintf("test-rootfs.ext4.cow.cache-%s", uuid.Must(uuid.NewV7()).String()))
 	t.Cleanup(func() {
 		os.RemoveAll(cowCachePath)
 	})

--- a/packages/orchestrator/pkg/sandbox/nbd/testutils/template_rootfs.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/testutils/template_rootfs.go
@@ -67,7 +67,7 @@ func TemplateRootfs(ctx context.Context, buildID string) (*BuildDevice, *Cleaner
 		}
 	}
 
-	diffCacheDir := filepath.Join(os.TempDir(), fmt.Sprintf("%s-rootfs.diff.cache-%s", buildID, uuid.New().String()))
+	diffCacheDir := filepath.Join(os.TempDir(), fmt.Sprintf("%s-rootfs.diff.cache-%s", buildID, uuid.Must(uuid.NewV7()).String()))
 
 	err = os.MkdirAll(diffCacheDir, 0o755)
 	if err != nil {

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -401,7 +401,7 @@ func (f *Factory) CreateSandbox(
 		}
 	}()
 
-	lifecycleID := uuid.NewString()
+	lifecycleID := uuid.Must(uuid.NewV7()).String()
 
 	ipsPromise := getNetworkSlot(ctx, f.networkPool, cleanup, config.Network, f.Sandboxes.NetworkReleased)
 
@@ -655,7 +655,7 @@ func (f *Factory) ResumeSandbox(
 		}
 	}()
 
-	lifecycleID := uuid.NewString()
+	lifecycleID := uuid.Must(uuid.NewV7()).String()
 
 	sandboxFiles := t.Files().NewSandboxFiles(runtime.SandboxID)
 	cleanup.Add(ctx, cleanupFiles(f.config, sandboxFiles))
@@ -1088,7 +1088,7 @@ func (s *Sandbox) Shutdown(ctx context.Context) error {
 
 	// This is required because the FC API doesn't support passing /dev/null
 	cachePaths, err := storage.Paths{
-		BuildID: uuid.New().String(),
+		BuildID: uuid.Must(uuid.NewV7()).String(),
 	}.Cache(s.config.StorageConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create cache paths: %w", err)

--- a/packages/orchestrator/pkg/sandbox/template/header_metrics_test.go
+++ b/packages/orchestrator/pkg/sandbox/template/header_metrics_test.go
@@ -29,8 +29,8 @@ func TestMaxEntriesPerBlock(t *testing.T) {
 		page  = uint64(header.PageSize)
 		block = uint64(header.HugepageSize)
 	)
-	buildA := uuid.New()
-	buildB := uuid.New()
+	buildA := uuid.Must(uuid.NewV7())
+	buildB := uuid.Must(uuid.NewV7())
 
 	tests := []struct {
 		name string

--- a/packages/orchestrator/pkg/sandbox/uploads_test.go
+++ b/packages/orchestrator/pkg/sandbox/uploads_test.go
@@ -91,8 +91,8 @@ func TestUploads_BeginDistinctIDsAreIndependent(t *testing.T) {
 	t.Parallel()
 	c, _ := newUploads(t)
 
-	a := uuid.New()
-	b := uuid.New()
+	a := uuid.Must(uuid.NewV7())
+	b := uuid.Must(uuid.NewV7())
 
 	futA, err := c.Start(a)
 	require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestUploads_Wait_BlocksUntilSet(t *testing.T) {
 	t.Parallel()
 	c, cache := newUploads(t)
 
-	id := uuid.New()
+	id := uuid.Must(uuid.NewV7())
 	// Pending header → Wait reaches the future-wait branch instead of
 	// short-circuiting on the cleared bit.
 	putPendingHeader(t, cache, id, build.Memfile)
@@ -145,7 +145,7 @@ func TestUploads_Wait_PropagatesUploadError(t *testing.T) {
 	t.Parallel()
 	c, cache := newUploads(t)
 
-	id := uuid.New()
+	id := uuid.Must(uuid.NewV7())
 	putPendingHeader(t, cache, id, build.Memfile)
 	fut, err := c.Start(id)
 	require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestUploads_Wait_ContextCancellation(t *testing.T) {
 	t.Parallel()
 	c, _ := newUploads(t)
 
-	id := uuid.New()
+	id := uuid.Must(uuid.NewV7())
 	_, err := c.Start(id) // never signaled
 	require.NoError(t, err)
 
@@ -187,7 +187,7 @@ func TestUploads_Wait_NoFuture_ReadsFromCache(t *testing.T) {
 	t.Parallel()
 	c, cache := newUploads(t)
 
-	id := uuid.New()
+	id := uuid.Must(uuid.NewV7())
 	want := &headers.Header{
 		Metadata: &headers.Metadata{Version: headers.MetadataVersionV4},
 		Builds:   map[uuid.UUID]headers.BuildData{id: {}},
@@ -213,7 +213,7 @@ func TestUploads_ConcurrentBeginsAndWaits(t *testing.T) {
 	ids := make([]uuid.UUID, n)
 	futs := make([]*utils.ErrorOnce, n)
 	for i := range n {
-		ids[i] = uuid.New()
+		ids[i] = uuid.Must(uuid.NewV7())
 		putPendingHeader(t, cache, ids[i], build.Memfile)
 		fut, err := c.Start(ids[i])
 		require.NoError(t, err)

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -271,7 +271,7 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 		teamID,
 		events.SandboxEvent{
 			Version:   events.StructureVersionV2,
-			ID:        uuid.New(),
+			ID:        uuid.Must(uuid.NewV7()),
 			Type:      eventType.Type,
 			Timestamp: time.Now().UTC(),
 
@@ -418,7 +418,7 @@ func (s *Server) Update(ctx context.Context, req *orchestrator.SandboxUpdateRequ
 			teamID,
 			events.SandboxEvent{
 				Version:   events.StructureVersionV2,
-				ID:        uuid.New(),
+				ID:        uuid.Must(uuid.NewV7()),
 				Type:      events.SandboxUpdatedEventPair.Type,
 				Timestamp: time.Now().UTC(),
 
@@ -540,7 +540,7 @@ func (s *Server) Delete(ctxConn context.Context, in *orchestrator.SandboxDeleteR
 		teamID,
 		events.SandboxEvent{
 			Version:   events.StructureVersionV2,
-			ID:        uuid.New(),
+			ID:        uuid.Must(uuid.NewV7()),
 			Type:      eventType.Type,
 			Timestamp: time.Now().UTC(),
 
@@ -640,7 +640,7 @@ func (s *Server) Pause(ctx context.Context, in *orchestrator.SandboxPauseRequest
 		teamID,
 		events.SandboxEvent{
 			Version:   events.StructureVersionV2,
-			ID:        uuid.New(),
+			ID:        uuid.Must(uuid.NewV7()),
 			Type:      eventType.Type,
 			Timestamp: time.Now().UTC(),
 
@@ -1026,7 +1026,7 @@ func (s *Server) publishSandboxEvent(ctx context.Context, sbx *sandbox.Sandbox, 
 		teamID,
 		events.SandboxEvent{
 			Version:   events.StructureVersionV2,
-			ID:        uuid.New(),
+			ID:        uuid.Must(uuid.NewV7()),
 			Type:      eventType,
 			Timestamp: time.Now().UTC(),
 

--- a/packages/orchestrator/pkg/template/build/layer/create_sandbox.go
+++ b/packages/orchestrator/pkg/template/build/layer/create_sandbox.go
@@ -137,7 +137,7 @@ func (cs *CreateSandbox) Sandbox(
 		sandbox.RuntimeMetadata{
 			TemplateID:  layerExecutor.Config.TemplateID,
 			SandboxID:   config.InstanceBuildPrefix + id.Generate(),
-			ExecutionID: uuid.NewString(),
+			ExecutionID: uuid.Must(uuid.NewV7()).String(),
 			TeamID:      layerExecutor.Config.TeamID,
 			BuildID:     layerExecutor.Template.BuildID,
 			SandboxType: sandbox.SandboxTypeBuild,

--- a/packages/orchestrator/pkg/template/build/layer/resume_sandbox.go
+++ b/packages/orchestrator/pkg/template/build/layer/resume_sandbox.go
@@ -40,7 +40,7 @@ func (rs *ResumeSandbox) Sandbox(
 		sandbox.RuntimeMetadata{
 			TemplateID:  layerExecutor.Config.TemplateID,
 			SandboxID:   config.InstanceBuildPrefix + id.Generate(),
-			ExecutionID: uuid.NewString(),
+			ExecutionID: uuid.Must(uuid.NewV7()).String(),
 			TeamID:      layerExecutor.Config.TeamID,
 			BuildID:     layerExecutor.Template.BuildID,
 			SandboxType: sandbox.SandboxTypeBuild,

--- a/packages/orchestrator/pkg/template/build/phases/base/builder.go
+++ b/packages/orchestrator/pkg/template/build/phases/base/builder.go
@@ -223,7 +223,7 @@ func (bb *BaseBuilder) buildLayerFromOCI(
 		sandbox.RuntimeMetadata{
 			TemplateID:  bb.Config.TemplateID,
 			SandboxID:   config.InstanceBuildPrefix + id.Generate(),
-			ExecutionID: uuid.NewString(),
+			ExecutionID: uuid.Must(uuid.NewV7()).String(),
 			TeamID:      bb.Config.TeamID,
 			BuildID:     bb.Template.BuildID,
 			SandboxType: sandbox.SandboxTypeBuild,
@@ -352,7 +352,7 @@ func (bb *BaseBuilder) Layer(
 		meta := metadata.Template{
 			Version: metadata.CurrentVersion,
 			Template: metadata.TemplateMetadata{
-				BuildID:            uuid.New().String(),
+				BuildID:            uuid.Must(uuid.NewV7()).String(),
 				KernelVersion:      bb.Config.KernelVersion,
 				FirecrackerVersion: bb.Config.FirecrackerVersion,
 			},

--- a/packages/orchestrator/pkg/template/build/phases/steps/builder.go
+++ b/packages/orchestrator/pkg/template/build/phases/steps/builder.go
@@ -136,7 +136,7 @@ func (sb *StepBuilder) Layer(
 
 	finalMetadata := sourceLayer.Metadata
 	finalMetadata.Template = metadata.TemplateMetadata{
-		BuildID:            uuid.NewString(),
+		BuildID:            uuid.Must(uuid.NewV7()).String(),
 		KernelVersion:      sb.Config.KernelVersion,
 		FirecrackerVersion: sb.Config.FirecrackerVersion,
 	}

--- a/packages/orchestrator/pkg/template/server/template_status_test.go
+++ b/packages/orchestrator/pkg/template/server/template_status_test.go
@@ -88,7 +88,7 @@ func newTestServerStore(t *testing.T, logLines []testLogLine) (*ServerStore, str
 	writeTestBuildLogs(t, buildLogs, logLines)
 
 	buildCache := templatecache.NewBuildCache(t.Context(), noop.NewMeterProvider())
-	buildID := uuid.NewString()
+	buildID := uuid.Must(uuid.NewV7()).String()
 
 	_, err := buildCache.Create("team-id", buildID, buildLogs)
 	require.NoError(t, err)

--- a/packages/orchestrator/pkg/volumes/service_test.go
+++ b/packages/orchestrator/pkg/volumes/service_test.go
@@ -23,8 +23,8 @@ func TestGetVolumeRootPath(t *testing.T) {
 
 	const goodVolumeType = "good-vol"
 	const goodVolumeTypePath = "/mnt/shared"
-	teamID := uuid.NewString()
-	volumeID := uuid.NewString()
+	teamID := uuid.Must(uuid.NewV7()).String()
+	volumeID := uuid.Must(uuid.NewV7()).String()
 	goodVolumeBasePath := filepath.Join(
 		goodVolumeTypePath,
 		fmt.Sprintf("team-%s", teamID),

--- a/packages/orchestrator/pkg/volumes/utils_test.go
+++ b/packages/orchestrator/pkg/volumes/utils_test.go
@@ -30,8 +30,8 @@ func setupTestService(t *testing.T) (*Service, string, *orchestrator.VolumeInfo)
 	}
 
 	tmpDir := t.TempDir()
-	teamID := uuid.New()
-	volumeID := uuid.New()
+	teamID := uuid.Must(uuid.NewV7())
+	volumeID := uuid.Must(uuid.NewV7())
 
 	config := cfg.Config{
 		PersistentVolumeMounts: map[string]string{

--- a/packages/shared/pkg/proxy/tracking/connection.go
+++ b/packages/shared/pkg/proxy/tracking/connection.go
@@ -29,7 +29,7 @@ func NewConnection(conn net.Conn, counter *atomic.Int64, m *smap.Map[*Connection
 	}
 
 	if m != nil {
-		c.key = uuid.New().String()
+		c.key = uuid.Must(uuid.NewV7()).String()
 
 		m.Insert(c.key, c)
 	}

--- a/packages/shared/pkg/storage/header/compact_test.go
+++ b/packages/shared/pkg/storage/header/compact_test.go
@@ -17,8 +17,8 @@ func TestNewHeader_PageGranularMappingUnderHugepageBlockSize(t *testing.T) {
 	t.Parallel()
 
 	const hugepage = uint64(2 << 20) // 2 MiB memory block size
-	a := uuid.New()
-	b := uuid.New()
+	a := uuid.Must(uuid.NewV7())
+	b := uuid.Must(uuid.NewV7())
 
 	// Page-granular (4 KiB) mappings, NOT aligned to the 2 MiB block size.
 	mappings := []BuildMap{
@@ -42,8 +42,8 @@ func TestNewMapping_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	bs := uint64(4096)
-	a := uuid.New()
-	b := uuid.New()
+	a := uuid.Must(uuid.NewV7())
+	b := uuid.Must(uuid.NewV7())
 	src := []BuildMap{
 		{Offset: 0, Length: 2 * bs, BuildId: a, BuildStorageOffset: 0},
 		{Offset: 2 * bs, Length: bs, BuildId: b, BuildStorageOffset: 0},
@@ -67,7 +67,7 @@ func TestNewMapping_RejectsUnaligned(t *testing.T) {
 	t.Parallel()
 
 	bs := uint64(4096)
-	id := uuid.New()
+	id := uuid.Must(uuid.NewV7())
 
 	_, err := NewMapping(bs, []BuildMap{{Offset: 123, Length: bs, BuildId: id}})
 	require.ErrorContains(t, err, "offset")
@@ -86,7 +86,7 @@ func TestMapping_SearchOffset(t *testing.T) {
 	t.Parallel()
 
 	bs := uint64(4096)
-	id := uuid.New()
+	id := uuid.Must(uuid.NewV7())
 	src := []BuildMap{
 		{Offset: 0, Length: 2 * bs, BuildId: id},
 		{Offset: 2 * bs, Length: 2 * bs, BuildId: id, BuildStorageOffset: 2 * bs},
@@ -115,7 +115,7 @@ func TestMapping_Validate(t *testing.T) {
 	t.Parallel()
 
 	bs := uint64(4096)
-	id := uuid.New()
+	id := uuid.Must(uuid.NewV7())
 	size := 4 * bs
 	m, err := NewMapping(bs, []BuildMap{
 		{Offset: 0, Length: 2 * bs, BuildId: id},

--- a/packages/shared/pkg/storage/header/mapping_test.go
+++ b/packages/shared/pkg/storage/header/mapping_test.go
@@ -10,8 +10,8 @@ import (
 
 var (
 	ignoreID = uuid.Nil
-	baseID   = uuid.New()
-	diffID   = uuid.New()
+	baseID   = uuid.Must(uuid.NewV7())
+	diffID   = uuid.Must(uuid.NewV7())
 )
 
 var blockSize = uint64(2 << 20)
@@ -325,9 +325,9 @@ func TestNormalizeMappingsSingleMapping(t *testing.T) {
 
 func TestNormalizeMappingsNoAdjacentSameBuildId(t *testing.T) {
 	t.Parallel()
-	id1 := uuid.New()
-	id2 := uuid.New()
-	id3 := uuid.New()
+	id1 := uuid.Must(uuid.NewV7())
+	id2 := uuid.Must(uuid.NewV7())
+	id3 := uuid.Must(uuid.NewV7())
 
 	input := []BuildMap{
 		{
@@ -433,8 +433,8 @@ func TestNormalizeMappingsAllSameBuildId(t *testing.T) {
 
 func TestNormalizeMappingsMultipleGroupsSameBuildId(t *testing.T) {
 	t.Parallel()
-	id1 := uuid.New()
-	id2 := uuid.New()
+	id1 := uuid.Must(uuid.NewV7())
+	id2 := uuid.Must(uuid.NewV7())
 
 	input := []BuildMap{
 		{
@@ -479,8 +479,8 @@ func TestNormalizeMappingsMultipleGroupsSameBuildId(t *testing.T) {
 
 func TestNormalizeMappingsAlternatingBuildIds(t *testing.T) {
 	t.Parallel()
-	id1 := uuid.New()
-	id2 := uuid.New()
+	id1 := uuid.Must(uuid.NewV7())
+	id2 := uuid.Must(uuid.NewV7())
 
 	input := []BuildMap{
 		{
@@ -559,9 +559,9 @@ func TestNormalizeMappingsThreeConsecutiveSameBuildId(t *testing.T) {
 
 func TestNormalizeMappingsMixedPattern(t *testing.T) {
 	t.Parallel()
-	id1 := uuid.New()
-	id2 := uuid.New()
-	id3 := uuid.New()
+	id1 := uuid.Must(uuid.NewV7())
+	id2 := uuid.Must(uuid.NewV7())
+	id3 := uuid.Must(uuid.NewV7())
 
 	input := []BuildMap{
 		{
@@ -715,9 +715,9 @@ func TestNormalizeMappingsDoesNotModifyInput(t *testing.T) {
 func TestMergeMappings_Splits(t *testing.T) {
 	t.Parallel()
 
-	compBaseID := uuid.New()
-	compDiffID := uuid.New()
-	plainID := uuid.New()
+	compBaseID := uuid.Must(uuid.NewV7())
+	compDiffID := uuid.Must(uuid.NewV7())
+	plainID := uuid.Must(uuid.NewV7())
 
 	tests := map[string]struct {
 		base     []BuildMap
@@ -829,9 +829,9 @@ func TestMergeMappings_Splits(t *testing.T) {
 
 		"multi-layer base — diff splits middle build": {
 			base: func() []BuildMap {
-				buildA := uuid.New()
+				buildA := uuid.Must(uuid.NewV7())
 				buildB := compBaseID
-				buildC := uuid.New()
+				buildC := uuid.Must(uuid.NewV7())
 
 				return []BuildMap{
 					{

--- a/packages/shared/pkg/storage/header/serialization_test.go
+++ b/packages/shared/pkg/storage/header/serialization_test.go
@@ -17,7 +17,7 @@ import (
 func fragmentedHeader(t *testing.T, n int) *Header {
 	t.Helper()
 	bs := uint64(4096)
-	a, b := uuid.New(), uuid.New()
+	a, b := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
 	mappings := make([]BuildMap, n)
 	var off, sa, sb uint64
 	for i := range mappings {
@@ -87,8 +87,8 @@ func mustMapping(t *testing.T, blockSize uint64, src []BuildMap) Mapping {
 func TestSerializeDeserialize_V3_RoundTrip(t *testing.T) {
 	t.Parallel()
 
-	buildID := uuid.New()
-	baseID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
+	baseID := uuid.Must(uuid.NewV7())
 	metadata := &Metadata{
 		Version:     3,
 		BlockSize:   4096,
@@ -151,8 +151,8 @@ func TestSerializeDeserialize_EmptyMappings_Defaults(t *testing.T) {
 		BlockSize:   4096,
 		Size:        8192,
 		Generation:  0,
-		BuildId:     uuid.New(),
-		BaseBuildId: uuid.New(),
+		BuildId:     uuid.Must(uuid.NewV7()),
+		BaseBuildId: uuid.Must(uuid.NewV7()),
 	}
 
 	data, err := serializeV3(metadata, Mapping{})
@@ -176,8 +176,8 @@ func TestDeserialize_BlockSizeZero(t *testing.T) {
 		BlockSize:   0,
 		Size:        4096,
 		Generation:  0,
-		BuildId:     uuid.New(),
-		BaseBuildId: uuid.New(),
+		BuildId:     uuid.Must(uuid.NewV7()),
+		BaseBuildId: uuid.Must(uuid.NewV7()),
 	}
 
 	data, err := serializeV3(metadata, Mapping{})
@@ -191,8 +191,8 @@ func TestDeserialize_BlockSizeZero(t *testing.T) {
 func TestSerializeDeserialize_V4_WithFrameTable(t *testing.T) {
 	t.Parallel()
 
-	buildID := uuid.New()
-	baseID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
+	baseID := uuid.Must(uuid.NewV7())
 	metadata := &Metadata{
 		Version:     4,
 		BlockSize:   4096,
@@ -272,7 +272,7 @@ func TestSerializeDeserialize_V4_WithFrameTable(t *testing.T) {
 func TestSerializeDeserialize_V4_Zstd(t *testing.T) {
 	t.Parallel()
 
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 	metadata := &Metadata{
 		Version:     4,
 		BlockSize:   4096,
@@ -328,8 +328,8 @@ func TestSerializeDeserialize_V4_Zstd(t *testing.T) {
 func TestSerializeDeserialize_V4_NoFrames(t *testing.T) {
 	t.Parallel()
 
-	buildID := uuid.New()
-	baseID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
+	baseID := uuid.Must(uuid.NewV7())
 	metadata := &Metadata{
 		Version:     4,
 		BlockSize:   4096,
@@ -370,7 +370,7 @@ func TestSerializeDeserialize_V4_NoFrames(t *testing.T) {
 func TestSerializeDeserialize_V4_ManyFrames(t *testing.T) {
 	t.Parallel()
 
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 	const numFrames = 1000
 	frames := make([]storage.FrameSize, numFrames)
 	for i := range frames {
@@ -426,7 +426,7 @@ func TestSerializeDeserialize_V4_ManyFrames(t *testing.T) {
 func TestSerializeDeserialize_V4_NoBuilds(t *testing.T) {
 	t.Parallel()
 
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 	metadata := &Metadata{
 		Version:     4,
 		BlockSize:   4096,
@@ -482,8 +482,8 @@ func TestDeserializeV4_RejectsOversizedMappingCount(t *testing.T) {
 		Version:     MetadataVersionV4,
 		BlockSize:   4096,
 		Size:        4096,
-		BuildId:     uuid.New(),
-		BaseBuildId: uuid.New(),
+		BuildId:     uuid.Must(uuid.NewV7()),
+		BaseBuildId: uuid.Must(uuid.NewV7()),
 	}
 	var meta bytes.Buffer
 	require.NoError(t, binary.Write(&meta, binary.LittleEndian, metadata))
@@ -499,8 +499,8 @@ func TestDeserializeV4_RejectsOversizedMappingCount(t *testing.T) {
 func TestSerializeDeserialize_V4_MultiBuild_LocateCompressed(t *testing.T) {
 	t.Parallel()
 
-	buildA := uuid.New()
-	buildB := uuid.New()
+	buildA := uuid.Must(uuid.NewV7())
+	buildB := uuid.Must(uuid.NewV7())
 
 	// Build A: 3 frames, each 4096 uncompressed.
 	//   Frame 0: U=[0,4096)   C=[0,1000)
@@ -615,7 +615,7 @@ func TestSerializeDeserialize_V4_MultiBuild_LocateCompressed(t *testing.T) {
 func TestSerializeDeserialize_V4_TrimmedOffsets_Error(t *testing.T) {
 	t.Parallel()
 
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 
 	// 4 frames, each 4096 uncompressed.
 	ft := storage.NewFullFrameTable(storage.CompressionZstd, []storage.FrameSize{
@@ -747,8 +747,8 @@ func TestFrameTable_LocateUncompressed(t *testing.T) {
 func TestSerializeDeserialize_V4_SparseTrimming(t *testing.T) {
 	t.Parallel()
 
-	buildID := uuid.New()
-	otherID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
+	otherID := uuid.Must(uuid.NewV7())
 
 	ft := storage.NewFullFrameTable(storage.CompressionLZ4, []storage.FrameSize{
 		{U: 4096, C: 2000},
@@ -810,7 +810,7 @@ func TestSerializeDeserialize_V4_SparseTrimming(t *testing.T) {
 func TestSerializeDeserialize_V4_Uncompressed_SelfEntry(t *testing.T) {
 	t.Parallel()
 
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 	metadata := &Metadata{
 		Version:     MetadataVersionV4,
 		BlockSize:   4096,
@@ -848,11 +848,11 @@ func TestSerializeDeserialize_V4_Uncompressed_SelfEntry(t *testing.T) {
 func TestSerializeDeserialize_V4_MixedChain(t *testing.T) {
 	t.Parallel()
 
-	selfID := uuid.New()
-	midID := uuid.New()
-	olderID := uuid.New()
-	v3aID := uuid.New()
-	v3bID := uuid.New()
+	selfID := uuid.Must(uuid.NewV7())
+	midID := uuid.Must(uuid.NewV7())
+	olderID := uuid.Must(uuid.NewV7())
+	v3aID := uuid.Must(uuid.NewV7())
+	v3bID := uuid.Must(uuid.NewV7())
 
 	midFT := storage.NewFullFrameTable(storage.CompressionZstd, []storage.FrameSize{
 		{U: 4096, C: 1234},
@@ -920,11 +920,11 @@ func TestSerializeDeserialize_V4_MixedChain(t *testing.T) {
 func TestSerializeDeserialize_V4_CompressedSelfChain(t *testing.T) {
 	t.Parallel()
 
-	selfID := uuid.New()
-	midID := uuid.New()
-	olderID := uuid.New()
-	v3aID := uuid.New()
-	v3bID := uuid.New()
+	selfID := uuid.Must(uuid.NewV7())
+	midID := uuid.Must(uuid.NewV7())
+	olderID := uuid.Must(uuid.NewV7())
+	v3aID := uuid.Must(uuid.NewV7())
+	v3bID := uuid.Must(uuid.NewV7())
 
 	selfFT := storage.NewFullFrameTable(storage.CompressionZstd, []storage.FrameSize{
 		{U: 4096, C: 1100},
@@ -1008,7 +1008,7 @@ func TestSerializeDeserialize_V4_CompressedSelfChain(t *testing.T) {
 func TestDeserialize_V3_StaysV3(t *testing.T) {
 	t.Parallel()
 
-	buildID := uuid.New()
+	buildID := uuid.Must(uuid.NewV7())
 	metadata := &Metadata{
 		Version:     3,
 		BlockSize:   4096,
@@ -1033,10 +1033,10 @@ func TestDeserialize_V3_StaysV3(t *testing.T) {
 func TestFillMissingBuildsAsSentinels(t *testing.T) {
 	t.Parallel()
 
-	selfID := uuid.New()
-	v3aID := uuid.New()
-	v3bID := uuid.New()
-	knownID := uuid.New()
+	selfID := uuid.Must(uuid.NewV7())
+	v3aID := uuid.Must(uuid.NewV7())
+	v3bID := uuid.Must(uuid.NewV7())
+	knownID := uuid.Must(uuid.NewV7())
 
 	knownFT := storage.NewFullFrameTable(storage.CompressionZstd, []storage.FrameSize{{U: 4096, C: 1024}})
 
@@ -1067,7 +1067,7 @@ func TestFillMissingBuildsAsSentinels(t *testing.T) {
 func TestFillMissingBuildsAsSentinels_NilBuilds(t *testing.T) {
 	t.Parallel()
 
-	selfID := uuid.New()
+	selfID := uuid.Must(uuid.NewV7())
 	meta := &Metadata{
 		Version: MetadataVersionV5, BlockSize: 4096, Size: 4096,
 		BuildId: selfID, BaseBuildId: selfID,

--- a/packages/shared/pkg/storage/header/serialization_v5_test.go
+++ b/packages/shared/pkg/storage/header/serialization_v5_test.go
@@ -28,7 +28,7 @@ func TestV5_PageGranularUnderHugepage(t *testing.T) {
 	t.Parallel()
 
 	const hugepage = uint64(2 << 20)
-	a, b := uuid.New(), uuid.New()
+	a, b := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
 	mappings := []BuildMap{
 		{Offset: 0, Length: PageSize, BuildId: a, BuildStorageOffset: 0},
 		{Offset: PageSize, Length: PageSize, BuildId: b, BuildStorageOffset: 0},
@@ -50,8 +50,8 @@ func TestV5_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	bs := uint64(4096)
-	a := uuid.New()
-	b := uuid.New()
+	a := uuid.Must(uuid.NewV7())
+	b := uuid.Must(uuid.NewV7())
 	metadata := &Metadata{BlockSize: bs, Size: 6 * bs, Generation: 3, BuildId: a, BaseBuildId: b}
 	mappings := []BuildMap{
 		{Offset: 0, Length: 2 * bs, BuildId: a, BuildStorageOffset: 0},
@@ -88,7 +88,7 @@ func TestV5_RoundTripNonAlignedSize(t *testing.T) {
 	t.Parallel()
 
 	bs := uint64(4096)
-	id := uuid.New()
+	id := uuid.Must(uuid.NewV7())
 	metadata := &Metadata{BlockSize: bs, Size: bs + 1, BuildId: id, BaseBuildId: id}
 
 	h := v5Header(t, metadata, nil, nil)
@@ -107,9 +107,9 @@ func TestV5_MatchesV4Semantics(t *testing.T) {
 	t.Parallel()
 
 	bs := uint64(4096)
-	a := uuid.New()
-	b := uuid.New()
-	c := uuid.New()
+	a := uuid.Must(uuid.NewV7())
+	b := uuid.Must(uuid.NewV7())
+	c := uuid.Must(uuid.NewV7())
 	mappings := []BuildMap{
 		{Offset: 0, Length: bs, BuildId: a, BuildStorageOffset: 0},
 		{Offset: bs, Length: bs, BuildId: b, BuildStorageOffset: 0},
@@ -146,8 +146,8 @@ func TestV5_SmallerThanV4(t *testing.T) {
 	t.Parallel()
 
 	bs := uint64(4096)
-	a := uuid.New()
-	b := uuid.New()
+	a := uuid.Must(uuid.NewV7())
+	b := uuid.Must(uuid.NewV7())
 	const runs = 50_000
 	mappings := make([]BuildMap, 0, runs)
 	var off, sa, sb uint64
@@ -196,7 +196,7 @@ func TestV5_ReconstructedColumnsExactlySized(t *testing.T) {
 	t.Parallel()
 
 	bs := uint64(4096)
-	a := uuid.New()
+	a := uuid.Must(uuid.NewV7())
 	mappings := []BuildMap{
 		{Offset: 0, Length: bs, BuildId: uuid.Nil},
 		{Offset: bs, Length: bs, BuildId: a, BuildStorageOffset: 0},
@@ -222,7 +222,7 @@ func TestV5_RejectsOversizePrefix(t *testing.T) {
 	t.Parallel()
 
 	bs := uint64(4096)
-	id := uuid.New()
+	id := uuid.Must(uuid.NewV7())
 	meta := &Metadata{Version: MetadataVersionV5, BlockSize: bs, Size: bs, BuildId: id, BaseBuildId: id}
 	h, err := NewHeader(meta, nil)
 	require.NoError(t, err)

--- a/packages/shared/pkg/storage/lock/atomic_file.go
+++ b/packages/shared/pkg/storage/lock/atomic_file.go
@@ -34,7 +34,7 @@ func OpenFile(ctx context.Context, filename string) (*AtomicImmutableFile, error
 		return nil, err
 	}
 
-	tempFilename := fmt.Sprintf("%s.temp.%s", filename, uuid.NewString())
+	tempFilename := fmt.Sprintf("%s.temp.%s", filename, uuid.Must(uuid.NewV7()).String())
 	tempFile, err := os.OpenFile(tempFilename, os.O_WRONLY|os.O_CREATE, 0o600)
 	if err != nil {
 		utils.Cleanup(ctx, "failed to release lock",

--- a/packages/shared/pkg/storage/paths_cache.go
+++ b/packages/shared/pkg/storage/paths_cache.go
@@ -18,7 +18,7 @@ type CachePaths struct {
 }
 
 func (p Paths) Cache(config Config) (CachePaths, error) {
-	identifier, err := uuid.NewRandom()
+	identifier, err := uuid.NewV7()
 	if err != nil {
 		return CachePaths{}, fmt.Errorf("failed to generate identifier: %w", err)
 	}

--- a/packages/shared/pkg/storage/storage_cache_seekable.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable.go
@@ -383,7 +383,7 @@ func (c *cachedSeekable) makeChunkFilename(offset int64) string {
 }
 
 func (c *cachedSeekable) makeTempFilename(path string) string {
-	return path + ".tmp." + uuid.NewString()
+	return path + ".tmp." + uuid.Must(uuid.NewV7()).String()
 }
 
 func (c *cachedSeekable) sizeFilename() string {
@@ -488,7 +488,7 @@ func (c *cachedSeekable) writeLocalSize(ctx context.Context, size int64) error {
 		}
 	}()
 
-	tempFilename := filepath.Join(c.path, fmt.Sprintf(".size.bin.%s", uuid.NewString()))
+	tempFilename := filepath.Join(c.path, fmt.Sprintf(".size.bin.%s", uuid.Must(uuid.NewV7()).String()))
 
 	if err := os.WriteFile(tempFilename, fmt.Appendf(nil, "%d", size), cacheFilePermissions); err != nil {
 		go safelyRemoveFile(ctx, tempFilename)

--- a/packages/shared/pkg/telemetry/main.go
+++ b/packages/shared/pkg/telemetry/main.go
@@ -107,7 +107,7 @@ func NewAnonymous(ctx context.Context, serviceName string) (*Client, error) {
 		nodeID = "unknown"
 	}
 
-	return New(ctx, nodeID, serviceName, "unknown", "dev", uuid.NewString())
+	return New(ctx, nodeID, serviceName, "unknown", "dev", uuid.Must(uuid.NewV7()).String())
 }
 
 func (t *Client) Shutdown(ctx context.Context) error {

--- a/tests/integration/internal/tests/api/access_token_test.go
+++ b/tests/integration/internal/tests/api/access_token_test.go
@@ -61,7 +61,7 @@ func TestDeleteAccessToken(t *testing.T) {
 
 	t.Run("id does not exist", func(t *testing.T) {
 		t.Parallel()
-		respD, err := c.DeleteAccessTokensAccessTokenIDWithResponse(ctx, uuid.New().String(), setup.WithSupabaseToken(t))
+		respD, err := c.DeleteAccessTokensAccessTokenIDWithResponse(ctx, uuid.Must(uuid.NewV7()).String(), setup.WithSupabaseToken(t))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tests/integration/internal/tests/api/apikey_test.go
+++ b/tests/integration/internal/tests/api/apikey_test.go
@@ -105,7 +105,7 @@ func TestDeleteAPIKey(t *testing.T) {
 
 	t.Run("id does not exist", func(t *testing.T) {
 		t.Parallel()
-		respD, err := c.DeleteApiKeysApiKeyIDWithResponse(ctx, uuid.New().String(), setup.WithSupabaseToken(t), setup.WithSupabaseTeam(t))
+		respD, err := c.DeleteApiKeysApiKeyIDWithResponse(ctx, uuid.Must(uuid.NewV7()).String(), setup.WithSupabaseToken(t), setup.WithSupabaseTeam(t))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -247,7 +247,7 @@ func TestPatchAPIKey(t *testing.T) {
 
 	t.Run("id does not exist", func(t *testing.T) {
 		t.Parallel()
-		respP, err := c.PatchApiKeysApiKeyIDWithResponse(ctx, uuid.New().String(), api.PatchApiKeysApiKeyIDJSONRequestBody{
+		respP, err := c.PatchApiKeysApiKeyIDWithResponse(ctx, uuid.Must(uuid.NewV7()).String(), api.PatchApiKeysApiKeyIDJSONRequestBody{
 			Name: "test-patch-3",
 		}, setup.WithSupabaseToken(t), setup.WithSupabaseTeam(t))
 		if err != nil {

--- a/tests/integration/internal/tests/api/volumes/crud_test.go
+++ b/tests/integration/internal/tests/api/volumes/crud_test.go
@@ -23,7 +23,7 @@ import (
 func TestVolumeRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	volumeName := uuid.NewString()
+	volumeName := uuid.Must(uuid.NewV7()).String()
 
 	client := setup.GetAPIClient()
 

--- a/tests/integration/internal/utils/team.go
+++ b/tests/integration/internal/utils/team.go
@@ -25,8 +25,8 @@ func CreateTeamWithUser(
 ) uuid.UUID {
 	t.Helper()
 
-	teamID := uuid.New()
-	slug := fmt.Sprintf("test-%s", teamID.String()[:8])
+	teamID := uuid.Must(uuid.NewV7())
+	slug := fmt.Sprintf("test-%s", teamID.String()[28:])
 
 	err := db.AuthDb.TestsRawSQL(t.Context(), `
 INSERT INTO teams (id, email, name, tier, is_blocked, slug)
@@ -70,7 +70,7 @@ func CreateAPIKey(t *testing.T, ctx context.Context, c *api.ClientWithResponses,
 	t.Helper()
 
 	apiKey, err := c.PostApiKeysWithResponse(ctx, api.PostApiKeysJSONRequestBody{
-		Name: uuid.New().String(),
+		Name: uuid.Must(uuid.NewV7()).String(),
 	}, setup.WithSupabaseToken(t, userID), setup.WithSupabaseTeam(t, teamID.String()))
 	require.NoError(t, err)
 	require.NotNil(t, apiKey.JSON201)

--- a/tests/integration/internal/utils/user.go
+++ b/tests/integration/internal/utils/user.go
@@ -17,7 +17,7 @@ import (
 func CreateUser(t *testing.T, db *setup.Database) uuid.UUID {
 	t.Helper()
 
-	userID := uuid.New()
+	userID := uuid.Must(uuid.NewV7())
 
 	err := db.AuthDb.TestsRawSQL(t.Context(), `
 INSERT INTO auth.users (id, email)
@@ -54,7 +54,7 @@ func CreateAccessToken(t *testing.T, db *setup.Database, userID uuid.UUID) strin
 	require.NoError(t, err)
 
 	_, err = db.AuthDb.Write.CreateAccessToken(t.Context(), authqueries.CreateAccessTokenParams{
-		ID:                    uuid.New(),
+		ID:                    uuid.Must(uuid.NewV7()),
 		UserID:                userID,
 		AccessTokenHash:       accessTokenHash,
 		AccessTokenPrefix:     accessTokenMask.Prefix,

--- a/tests/integration/seed.go
+++ b/tests/integration/seed.go
@@ -117,7 +117,7 @@ VALUES ($1, $2)
 	}
 
 	_, err = authdb.Write.CreateAccessToken(ctx, authqueries.CreateAccessTokenParams{
-		ID:                    uuid.New(),
+		ID:                    uuid.Must(uuid.NewV7()),
 		UserID:                data.UserID,
 		AccessTokenHash:       accessTokenHash,
 		AccessTokenPrefix:     accessTokenMask.Prefix,
@@ -204,7 +204,7 @@ VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP, 'template')
 	builds := []buildData{
 		// An older build, so we have multiple builds - inserted FIRST
 		{
-			id:        uuid.New(),
+			id:        uuid.Must(uuid.NewV7()),
 			createdAt: &oldBuildTime,
 		},
 		// Primary build - inserted LAST so it has the latest assignment timestamp

--- a/tests/periodic-test/bun.lock
+++ b/tests/periodic-test/bun.lock
@@ -8,6 +8,7 @@
         "@e2b/cli": "^2.7.3",
         "@e2b/code-interpreter": "^2.4.0",
         "e2b": "^2.21.0",
+        "uuid": "^14.0.0",
       },
       "devDependencies": {
         "@types/bun": "^1.3.2",
@@ -436,6 +437,8 @@
     "untildify": ["untildify@4.0.0", "", {}, "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="],
 
     "update-notifier": ["update-notifier@6.0.2", "", { "dependencies": { "boxen": "^7.0.0", "chalk": "^5.0.1", "configstore": "^6.0.0", "has-yarn": "^3.0.0", "import-lazy": "^4.0.0", "is-ci": "^3.0.1", "is-installed-globally": "^0.4.0", "is-npm": "^6.0.0", "is-yarn-global": "^0.4.0", "latest-version": "^7.0.0", "pupa": "^3.1.0", "semver": "^7.3.7", "semver-diff": "^4.0.0", "xdg-basedir": "^5.1.0" } }, "sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og=="],
+
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
 

--- a/tests/periodic-test/package.json
+++ b/tests/periodic-test/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "@e2b/cli": "^2.7.3",
     "@e2b/code-interpreter": "^2.4.0",
-    "e2b": "^2.21.0"
+    "e2b": "^2.21.0",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@types/bun": "^1.3.2"

--- a/tests/periodic-test/time-is-synchronized/index.ts
+++ b/tests/periodic-test/time-is-synchronized/index.ts
@@ -1,9 +1,10 @@
 import Sandbox from "e2b";
 import { readFile, rm } from "fs/promises";
+import { v7 as uuidv7 } from "uuid";
 
 import { DEBUG_TIMEOUT_MS, log, runTestWithSandbox } from "../utils.ts";
 
-const uniqueID = crypto.randomUUID();
+const uniqueID = uuidv7();
 const templateName = `test-template-${uniqueID}`;
 
 console.log(`Building template ${templateName}...`);


### PR DESCRIPTION
## Summary
Replace application-side UUID generation with UUID v7 across Go services, tests, and the periodic Bun test, using the `uuid` package for TypeScript.
Add a forward DB migration that introduces `uuidv7()` and updates existing UUID defaults without rewriting historical migrations.
Short IDs now use the random tail of UUID v7 values to avoid timestamp-prefix collisions.

## Validation
Ran focused Go package sweeps for shared, db, api, auth, dashboard-api, envd, clickhouse, client-proxy, and docker-reverse-proxy; integration compile-only with dummy env vars; `git diff --check`; and a Bun `uuid.v7()` import/version check.
The full orchestrator sweep is still blocked locally on macOS by existing Linux-only build constraints in `pkg/sandbox/block`.
