### PR TITLE
feat(dashboard-api): make team billing provisioning async on boostrap

### DIFF
--- a/packages/dashboard-api/internal/handlers/team_handlers_test.go
+++ b/packages/dashboard-api/internal/handlers/team_handlers_test.go
@@ -552,23 +552,24 @@ func TestBootstrapAuthProviderUser_CreatesIdentityAndDefaultTeam(t *testing.T) {
 		t.Fatalf("expected team email %q, got %q", "ada@example.test", defaultTeam.Email)
 	}
 
-	if len(sink.requests) != 1 {
-		t.Fatalf("expected one billing provisioning call, got %d", len(sink.requests))
+	reqs := sink.waitForRequests(t, 1)
+	if len(reqs) != 1 {
+		t.Fatalf("expected one billing provisioning call, got %d", len(reqs))
 	}
-	if sink.requests[0].CreatorUserID != userIdentity.UserID {
-		t.Fatalf("expected sink creator %s, got %s", userIdentity.UserID, sink.requests[0].CreatorUserID)
+	if reqs[0].CreatorUserID != userIdentity.UserID {
+		t.Fatalf("expected sink creator %s, got %s", userIdentity.UserID, reqs[0].CreatorUserID)
 	}
-	if sink.requests[0].CreatorContext == nil {
+	if reqs[0].CreatorContext == nil {
 		t.Fatal("expected sink creator context")
 	}
-	if sink.requests[0].CreatorContext.IPAddress != "198.51.100.20" {
-		t.Fatalf("expected sink creator ip %q, got %q", "198.51.100.20", sink.requests[0].CreatorContext.IPAddress)
+	if reqs[0].CreatorContext.IPAddress != "198.51.100.20" {
+		t.Fatalf("expected sink creator ip %q, got %q", "198.51.100.20", reqs[0].CreatorContext.IPAddress)
 	}
-	if sink.requests[0].CreatorContext.UserAgent != "Mozilla/5.0" {
-		t.Fatalf("expected sink creator user agent %q, got %q", "Mozilla/5.0", sink.requests[0].CreatorContext.UserAgent)
+	if reqs[0].CreatorContext.UserAgent != "Mozilla/5.0" {
+		t.Fatalf("expected sink creator user agent %q, got %q", "Mozilla/5.0", reqs[0].CreatorContext.UserAgent)
 	}
-	if sink.requests[0].CreatorContext.AuthMethod != teamprovision.AuthMethodSocial {
-		t.Fatalf("expected sink creator auth method %q, got %q", teamprovision.AuthMethodSocial, sink.requests[0].CreatorContext.AuthMethod)
+	if reqs[0].CreatorContext.AuthMethod != teamprovision.AuthMethodSocial {
+		t.Fatalf("expected sink creator auth method %q, got %q", teamprovision.AuthMethodSocial, reqs[0].CreatorContext.AuthMethod)
 	}
 }
 
@@ -615,6 +616,9 @@ func TestBootstrapOIDCUser_PopulatesOryExternalID(t *testing.T) {
 	if _, err := store.bootstrapOIDCUser(ctx, input); err != nil {
 		t.Fatalf("expected bootstrap to succeed: %v", err)
 	}
+
+	// Drain the background provisioning goroutine before asserting / teardown.
+	sink.waitForRequests(t, 1)
 
 	userIdentity, err := testDB.AuthDB.Read.GetUserIdentity(ctx, authqueries.GetUserIdentityParams{
 		OidcIss: input.OIDCIssuer,
@@ -696,6 +700,9 @@ func TestBootstrapOIDCUser_ConcurrentRequestsSingleIdentityAndTeam(t *testing.T)
 			t.Fatalf("expected bootstrap to succeed, got %v", err)
 		}
 	}
+
+	// All successful bootstraps provision in the background; drain them.
+	sink.waitForRequests(t, concurrency)
 
 	var teamIDs []uuid.UUID
 	for team := range results {
@@ -787,6 +794,9 @@ func TestBootstrapOIDCUser_OryIssuerWithoutJWTConfigIsAccepted(t *testing.T) {
 	if team.ID == uuid.Nil {
 		t.Fatal("expected provisioned team")
 	}
+
+	// Drain the background provisioning goroutine before teardown.
+	sink.waitForRequests(t, 1)
 }
 
 func TestBootstrapOIDCUser_OryModeRejectsNonOryJWTIssuer(t *testing.T) {
@@ -924,6 +934,9 @@ func TestBootstrapUser_ConcurrentRequestsCreateSingleDefaultTeam(t *testing.T) {
 			t.Fatalf("expected bootstrap to succeed, got %v", err)
 		}
 	}
+
+	// Both successful bootstraps provision in the background; drain them.
+	sink.waitForRequests(t, 2)
 
 	var teamIDs []uuid.UUID
 	for team := range results {
@@ -1361,6 +1374,32 @@ func (s *fakeTeamProvisionSink) ProvisionTeam(_ context.Context, req teamprovisi
 	s.requests = append(s.requests, req)
 
 	return s.err
+}
+
+// waitForRequests blocks until at least n provisioning calls have been recorded,
+// failing the test on timeout. The signup path provisions in a background
+// goroutine, so tests must wait for it before asserting or tearing down.
+func (s *fakeTeamProvisionSink) waitForRequests(t *testing.T, n int) []teamprovision.TeamBillingProvisionRequestedV1 {
+	t.Helper()
+
+	deadline := time.After(5 * time.Second)
+	for {
+		s.mu.Lock()
+		count := len(s.requests)
+		if count >= n {
+			out := append([]teamprovision.TeamBillingProvisionRequestedV1(nil), s.requests...)
+			s.mu.Unlock()
+
+			return out
+		}
+		s.mu.Unlock()
+
+		select {
+		case <-deadline:
+			t.Fatalf("expected at least %d provisioning calls, got %d", n, count)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
 }
 
 type noopAuthService struct{}

--- a/packages/dashboard-api/internal/handlers/team_handlers_test.go
+++ b/packages/dashboard-api/internal/handlers/team_handlers_test.go
@@ -1397,7 +1397,8 @@ func (s *fakeTeamProvisionSink) waitForRequests(t *testing.T, n int) []teamprovi
 		select {
 		case <-deadline:
 			t.Fatalf("expected at least %d provisioning calls, got %d", n, count)
-		case <-time.After(5 * time.Millisecond):
+		default:
+			time.Sleep(5 * time.Millisecond)
 		}
 	}
 }

--- a/packages/dashboard-api/internal/handlers/team_provision_async_test.go
+++ b/packages/dashboard-api/internal/handlers/team_provision_async_test.go
@@ -1,0 +1,128 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/teamprovision"
+)
+
+// channelProvisionSink records provisioning calls and can block until released,
+// so tests can prove the call happens off the request path.
+type channelProvisionSink struct {
+	called chan teamprovision.TeamBillingProvisionRequestedV1
+	block  chan struct{}
+	err    error
+}
+
+func (s *channelProvisionSink) ProvisionTeam(_ context.Context, req teamprovision.TeamBillingProvisionRequestedV1) error {
+	if s.block != nil {
+		<-s.block
+	}
+	s.called <- req
+
+	return s.err
+}
+
+func newTestProfile() bootstrapUserProfile {
+	return bootstrapUserProfile{
+		UserID:          uuid.New(),
+		Email:           "user@example.com",
+		DefaultTeamName: "User's Default Team",
+		CreatorContext: &teamprovision.CreatorContextV1{
+			IPAddress:  "1.2.3.4",
+			UserAgent:  "test-agent",
+			AuthMethod: teamprovision.AuthMethodSocial,
+		},
+	}
+}
+
+func newTestProvisionRequest() teamprovision.TeamBillingProvisionRequestedV1 {
+	return teamprovision.TeamBillingProvisionRequestedV1{
+		TeamID:        uuid.New(),
+		TeamName:      "User's Default Team",
+		TeamEmail:     "user@example.com",
+		CreatorUserID: uuid.New(),
+		Reason:        teamprovision.ReasonDefaultSignupTeam,
+	}
+}
+
+// provisioning runs in the background: the call returns before the (blocked)
+// sink completes, and the creator context is resolved off-path into the request.
+func TestProvisionTeamInBackgroundIsAsync(t *testing.T) {
+	t.Parallel()
+
+	sink := &channelProvisionSink{
+		called: make(chan teamprovision.TeamBillingProvisionRequestedV1, 1),
+		block:  make(chan struct{}),
+	}
+	store := &APIStore{teamProvisionSink: sink}
+
+	profile := newTestProfile()
+	req := newTestProvisionRequest()
+
+	store.provisionTeamInBackground(context.Background(), profile, req)
+
+	// The call returned while the sink is still blocked, so nothing provisioned yet.
+	select {
+	case <-sink.called:
+		t.Fatal("provisioning ran synchronously; expected it to wait on the background sink")
+	default:
+	}
+
+	close(sink.block)
+
+	select {
+	case got := <-sink.called:
+		require.Equal(t, req.TeamID, got.TeamID)
+		require.Equal(t, req.CreatorUserID, got.CreatorUserID)
+		require.Equal(t, req.Reason, got.Reason)
+		require.NotNil(t, got.CreatorContext, "creator context should be resolved in the background")
+		require.Equal(t, "1.2.3.4", got.CreatorContext.IPAddress)
+	case <-time.After(2 * time.Second):
+		t.Fatal("background provisioning never ran")
+	}
+}
+
+// The background work must survive cancellation of the originating request.
+func TestProvisionTeamInBackgroundDetachesCancellation(t *testing.T) {
+	t.Parallel()
+
+	sink := &channelProvisionSink{called: make(chan teamprovision.TeamBillingProvisionRequestedV1, 1)}
+	store := &APIStore{teamProvisionSink: sink}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // request context is already done before the goroutine runs
+
+	store.provisionTeamInBackground(ctx, newTestProfile(), newTestProvisionRequest())
+
+	select {
+	case <-sink.called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background provisioning did not run after the request context was cancelled")
+	}
+}
+
+// A failing sink is logged, not propagated, and must not crash the goroutine.
+func TestProvisionTeamInBackgroundSwallowsFailure(t *testing.T) {
+	t.Parallel()
+
+	sink := &channelProvisionSink{
+		called: make(chan teamprovision.TeamBillingProvisionRequestedV1, 1),
+		err:    errors.New("billing unavailable"),
+	}
+	store := &APIStore{teamProvisionSink: sink}
+
+	store.provisionTeamInBackground(context.Background(), newTestProfile(), newTestProvisionRequest())
+
+	select {
+	case <-sink.called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background provisioning never ran")
+	}
+}

--- a/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
+++ b/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
@@ -183,15 +183,13 @@ func (s *APIStore) bootstrapUserWithIdentity(ctx context.Context, profile bootst
 		}
 
 		if time.Since(existingTeam.CreatedAt) < bootstrapProvisionRetryAge {
-			req := teamprovision.TeamBillingProvisionRequestedV1{
-				TeamID:         existingTeam.ID,
-				TeamName:       existingTeam.Name,
-				TeamEmail:      existingTeam.Email,
-				CreatorUserID:  profile.UserID,
-				CreatorContext: s.teamCreatorContextForProvisioning(ctx, profile),
-				Reason:         teamprovision.ReasonDefaultSignupTeam,
-			}
-			_ = s.teamProvisionSink.ProvisionTeam(ctx, req)
+			s.provisionTeamInBackground(ctx, profile, teamprovision.TeamBillingProvisionRequestedV1{
+				TeamID:        existingTeam.ID,
+				TeamName:      existingTeam.Name,
+				TeamEmail:     existingTeam.Email,
+				CreatorUserID: profile.UserID,
+				Reason:        teamprovision.ReasonDefaultSignupTeam,
+			})
 		}
 
 		return provisionedTeam{
@@ -231,15 +229,13 @@ func (s *APIStore) bootstrapUserWithIdentity(ctx context.Context, profile bootst
 		return provisionedTeam{}, fmt.Errorf("commit user bootstrap transaction: %w", err)
 	}
 
-	req := teamprovision.TeamBillingProvisionRequestedV1{
-		TeamID:         team.ID,
-		TeamName:       team.Name,
-		TeamEmail:      team.Email,
-		CreatorUserID:  profile.UserID,
-		CreatorContext: s.teamCreatorContextForProvisioning(ctx, profile),
-		Reason:         teamprovision.ReasonDefaultSignupTeam,
-	}
-	_ = s.teamProvisionSink.ProvisionTeam(ctx, req)
+	s.provisionTeamInBackground(ctx, profile, teamprovision.TeamBillingProvisionRequestedV1{
+		TeamID:        team.ID,
+		TeamName:      team.Name,
+		TeamEmail:     team.Email,
+		CreatorUserID: profile.UserID,
+		Reason:        teamprovision.ReasonDefaultSignupTeam,
+	})
 
 	return provisionedTeam{
 		ID:            team.ID,
@@ -249,6 +245,39 @@ func (s *APIStore) bootstrapUserWithIdentity(ctx context.Context, profile bootst
 		IsBlocked:     team.IsBlocked,
 		BlockedReason: team.BlockedReason,
 	}, nil
+}
+
+// provisionTeamInBackground resolves the billing creator context and provisions
+// the team out of band. Both are slow Ory/billing round-trips the signup
+// response must not wait for, and the result was always discarded by the caller,
+// so a failure is logged rather than propagated. WithoutCancel detaches the
+// request's cancellation while keeping its trace context, so the provision spans
+// stay on the same trace — the same pattern as the IdP cleanup in
+// admin_users_delete.go.
+func (s *APIStore) provisionTeamInBackground(ctx context.Context, profile bootstrapUserProfile, req teamprovision.TeamBillingProvisionRequestedV1) {
+	bgCtx := context.WithoutCancel(ctx)
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				logger.L().Error(bgCtx, "panic while provisioning team in background",
+					logger.WithTeamID(req.TeamID.String()),
+					logger.WithUserID(req.CreatorUserID.String()),
+					zap.Any("panic", r),
+				)
+			}
+		}()
+
+		req.CreatorContext = s.teamCreatorContextForProvisioning(bgCtx, profile)
+
+		if err := s.teamProvisionSink.ProvisionTeam(bgCtx, req); err != nil {
+			logger.L().Error(bgCtx, "background team provisioning failed",
+				logger.WithTeamID(req.TeamID.String()),
+				logger.WithUserID(req.CreatorUserID.String()),
+				zap.Error(err),
+			)
+		}
+	}()
 }
 
 // setOIDCIdentityExternalID stores the canonical public.users id on the Ory

--- a/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
+++ b/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
@@ -31,7 +31,7 @@ const (
 	bootstrapProvisionRetryAge   = 30 * time.Second
 	teamProvisionRollbackTimeout = 5 * time.Second
 	creatorContextResolveTimeout = 2 * time.Second
-	backgroundProvisionTimeout = 45 * time.Second
+	backgroundProvisionTimeout   = 45 * time.Second
 )
 
 type provisionedTeam struct {

--- a/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
+++ b/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
@@ -31,6 +31,7 @@ const (
 	bootstrapProvisionRetryAge   = 30 * time.Second
 	teamProvisionRollbackTimeout = 5 * time.Second
 	creatorContextResolveTimeout = 2 * time.Second
+	backgroundProvisionTimeout = 45 * time.Second
 )
 
 type provisionedTeam struct {
@@ -255,9 +256,10 @@ func (s *APIStore) bootstrapUserWithIdentity(ctx context.Context, profile bootst
 // stay on the same trace — the same pattern as the IdP cleanup in
 // admin_users_delete.go.
 func (s *APIStore) provisionTeamInBackground(ctx context.Context, profile bootstrapUserProfile, req teamprovision.TeamBillingProvisionRequestedV1) {
-	bgCtx := context.WithoutCancel(ctx)
+	bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), backgroundProvisionTimeout)
 
 	go func() {
+		defer cancel()
 		defer func() {
 			if r := recover(); r != nil {
 				logger.L().Error(bgCtx, "panic while provisioning team in background",


### PR DESCRIPTION
## Summary
The OAuth signup callback blocked on `POST /admin/users/bootstrap`, which synchronously made two slow Ory/billing round-trips *after* the DB commit —whose results were already discarded. This defers that tail to a background goroutine, cutting first-signup latency with no change to what gets provisioned.

## What changed
- `bootstrapUserWithIdentity` runs the post-commit tail (creator-context lookup + `ProvisionTeam`) in a detached goroutine (`context.WithoutCancel`, matching the existing `admin_users_delete.go` cleanup idiom; trace context preserved).
- User, team, and membership are still created and **committed synchronously** — only the billing-side provisioning is deferred.
- Failures are logged (the billing sink already reports them to telemetry); a panic in the goroutine is recovered.

Returning logins are unaffected — they already skip bootstrap via the `external_id` gate on FE.