### PR TITLE
feat(orchestrator/oci): restrict base image pull egress

### DIFF
--- a/packages/orchestrator/pkg/cfg/model.go
+++ b/packages/orchestrator/pkg/cfg/model.go
@@ -36,6 +36,13 @@ type BuilderConfig struct {
 
 	Provider string `env:"PROVIDER" envDefault:"gcp"`
 
+	// ImagePullEgressAllowlist lists IPs/CIDRs and/or domain patterns that are
+	// exempt from the internal-egress denylist applied to base image pulls.
+	// Domain patterns support exact, "*", and "*.suffix" forms. If an HTTP(S)
+	// proxy is configured for the builder, pulls go through it and it takes
+	// precedence over this allowlist.
+	ImagePullEgressAllowlist []string `env:"IMAGE_PULL_EGRESS_ALLOWLIST" envSeparator:","`
+
 	StorageConfig storage.Config
 	NetworkConfig network.Config
 }

--- a/packages/orchestrator/pkg/template/build/core/oci/egress/egress.go
+++ b/packages/orchestrator/pkg/template/build/core/oci/egress/egress.go
@@ -1,0 +1,214 @@
+// Package egress provides an HTTP transport whose dialer blocks connections to
+// internal/private IP addresses, with an allowlist override. It borrows the
+// internal-address denylist from the sandbox-network package but is otherwise
+// independent of sandbox networking.
+package egress
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+
+	sandbox_network "github.com/e2b-dev/infra/packages/shared/pkg/sandbox-network"
+)
+
+// ErrBlocked is wrapped into the dial error when a connection targets an
+// internal/private address that is not covered by the allowlist, so callers can
+// detect it with errors.Is.
+var ErrBlocked = errors.New("connection to an internal or private address is not allowed")
+
+// dialTimeout and dialKeepAlive match go-containerregistry's default transport
+// so replacing the dialer does not change connection behaviour.
+const (
+	dialTimeout   = 30 * time.Second
+	dialKeepAlive = 30 * time.Second
+)
+
+// Allowlist holds parsed allowlist entries: IP prefixes matched against the
+// resolved connection IP, and domain patterns matched against the dialed
+// hostname (exact, "*", or "*.suffix").
+type Allowlist struct {
+	prefixes []netip.Prefix
+	domains  []string
+}
+
+// ParseAllowlist classifies each entry as an IP/CIDR or a domain pattern. A bare
+// IP becomes a single-host prefix. Entries that are neither a valid IP nor CIDR
+// are treated as domain patterns.
+func ParseAllowlist(entries []string) Allowlist {
+	var allow Allowlist
+
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		if prefix, err := netip.ParsePrefix(entry); err == nil {
+			allow.prefixes = append(allow.prefixes, prefix.Masked())
+
+			continue
+		}
+
+		if addr, err := netip.ParseAddr(entry); err == nil {
+			allow.prefixes = append(allow.prefixes, netip.PrefixFrom(addr, addr.BitLen()))
+
+			continue
+		}
+
+		allow.domains = append(allow.domains, entry)
+	}
+
+	return allow
+}
+
+// permitsIP reports whether a connection to the resolved addr is allowed: either
+// the IP is explicitly allowlisted, or it is not in the internal-address
+// denylist. Allowlist entries take precedence, so an operator can re-enable an
+// otherwise-denied range (e.g. 127.0.0.0/8 for local development).
+func (a Allowlist) permitsIP(addr netip.Addr) bool {
+	addr = addr.Unmap()
+
+	for _, prefix := range a.prefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+
+	// Use the 16-byte representation for a consistent net.IP regardless of
+	// address family.
+	ip16 := addr.As16()
+
+	return !sandbox_network.IsIPInDeniedSandboxCIDRs(net.IP(ip16[:]))
+}
+
+// permitsHost reports whether the dialed hostname matches an allowlisted domain
+// pattern.
+func (a Allowlist) permitsHost(host string) bool {
+	for _, pattern := range a.domains {
+		if matchDomain(host, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchDomain reports whether hostname matches a domain pattern: an exact
+// (case-insensitive) match, "*", or a "*.suffix" wildcard.
+func matchDomain(hostname, pattern string) bool {
+	switch {
+	case pattern == "":
+		return false
+	case pattern == "*":
+		return true
+	case strings.EqualFold(pattern, hostname):
+		return true
+	case strings.HasPrefix(pattern, "*."):
+		suffix := pattern[1:] // ".suffix"
+
+		return strings.HasSuffix(strings.ToLower(hostname), strings.ToLower(suffix))
+	}
+
+	return false
+}
+
+// NewTransport returns a clone of base whose dialer rejects connections to
+// internal/private IPs unless allowed by allow. A connection is permitted when
+// the dialed hostname matches an allowlisted domain pattern, or when the
+// resolved IP passes the allowlist/denylist check. The IP check runs in the
+// dialer's ControlContext callback, after DNS resolution but before the TCP
+// connect() syscall. onBlocked, when set, is invoked with the blocked IP for
+// telemetry.
+//
+// base preserves the caller's transport tuning (TLS, proxy, idle-connection
+// settings); only the DialContext is replaced. A nil base falls back to
+// http.DefaultTransport.
+//
+// If a proxy applies to registryHost (e.g. via HTTP_PROXY/HTTPS_PROXY, honoring
+// NO_PROXY), connections are routed through it and the guard is not applied: a
+// configured proxy takes precedence over the allowlist/denylist.
+func NewTransport(base *http.Transport, registryHost string, allow Allowlist, onBlocked func(netip.Addr)) *http.Transport {
+	if base == nil {
+		dt, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			dt = &http.Transport{}
+		}
+
+		base = dt
+	}
+
+	t := base.Clone()
+
+	// A proxy that applies to the registry takes precedence: connections are
+	// tunneled through it, so the dialer never sees the registry's IP and the
+	// guard does not apply.
+	if proxyConfigured(t.Proxy, registryHost) {
+		return t
+	}
+
+	t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+
+		dialer := &net.Dialer{
+			Timeout:   dialTimeout,
+			KeepAlive: dialKeepAlive,
+			// ControlContext runs after DNS resolution but before connect(); the
+			// address argument is the resolved IP:port.
+			ControlContext: func(_ context.Context, _, address string, _ syscall.RawConn) error {
+				if allow.permitsHost(host) {
+					return nil
+				}
+
+				addrPort, err := netip.ParseAddrPort(address)
+				if err != nil {
+					return fmt.Errorf("failed to parse resolved address %q: %w", address, err)
+				}
+
+				resolved := addrPort.Addr()
+				if allow.permitsIP(resolved) {
+					return nil
+				}
+
+				blocked := resolved.Unmap()
+				if onBlocked != nil {
+					onBlocked(blocked)
+				}
+
+				return fmt.Errorf("%w: %s", ErrBlocked, blocked)
+			},
+		}
+
+		return dialer.DialContext(ctx, network, addr)
+	}
+
+	return t
+}
+
+// proxyConfigured reports whether proxy resolves to a proxy URL for a request to
+// registryHost, i.e. whether an HTTP(S) proxy applies to that host (honoring
+// NO_PROXY). registryHost may be empty, in which case a representative host is
+// used to detect whether any proxy is configured.
+func proxyConfigured(proxy func(*http.Request) (*url.URL, error), registryHost string) bool {
+	if proxy == nil {
+		return false
+	}
+
+	if registryHost == "" {
+		registryHost = "example.invalid"
+	}
+
+	u, err := proxy(&http.Request{URL: &url.URL{Scheme: "https", Host: registryHost}})
+
+	return err == nil && u != nil
+}

--- a/packages/orchestrator/pkg/template/build/core/oci/egress/egress_test.go
+++ b/packages/orchestrator/pkg/template/build/core/oci/egress/egress_test.go
@@ -1,0 +1,253 @@
+package egress
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAllowlist(t *testing.T) {
+	t.Parallel()
+
+	t.Run("classifies CIDRs, bare IPs, domains, skips empties", func(t *testing.T) {
+		t.Parallel()
+
+		allow := ParseAllowlist([]string{"127.0.0.0/8", " 10.20.0.5 ", "", "192.168.5.0/24", "::1", "registry.corp.internal", "*.example.com", "*"})
+		require.Len(t, allow.prefixes, 4)
+		require.Equal(t, []string{"registry.corp.internal", "*.example.com", "*"}, allow.domains)
+
+		assert.True(t, allow.prefixes[0].Contains(netip.MustParseAddr("127.5.5.5")))
+		assert.True(t, allow.prefixes[1].Contains(netip.MustParseAddr("10.20.0.5")))
+		assert.False(t, allow.prefixes[1].Contains(netip.MustParseAddr("10.20.0.6")))
+		assert.True(t, allow.prefixes[2].Contains(netip.MustParseAddr("192.168.5.42")))
+		assert.True(t, allow.prefixes[3].Contains(netip.MustParseAddr("::1")))
+	})
+
+	t.Run("empty input yields nothing", func(t *testing.T) {
+		t.Parallel()
+
+		allow := ParseAllowlist(nil)
+		assert.Empty(t, allow.prefixes)
+		assert.Empty(t, allow.domains)
+	})
+
+	t.Run("malformed CIDR is fail-safe (not a prefix)", func(t *testing.T) {
+		t.Parallel()
+
+		// "1.2.3.4/33" is an invalid prefix; it is kept as a never-matching
+		// domain rather than becoming an IP prefix.
+		allow := ParseAllowlist([]string{"10.0.0.0/8", "1.2.3.4/33"})
+		require.Len(t, allow.prefixes, 1)
+		assert.True(t, allow.prefixes[0].Contains(netip.MustParseAddr("10.1.2.3")))
+		assert.Equal(t, []string{"1.2.3.4/33"}, allow.domains)
+	})
+}
+
+func TestMatchDomain(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		hostname string
+		pattern  string
+		want     bool
+	}{
+		{"registry.example.com", "registry.example.com", true},
+		{"Registry.Example.com", "registry.example.com", true},
+		{"registry.example.com", "*", true},
+		{"a.corp.internal", "*.corp.internal", true},
+		{"a.b.corp.internal", "*.corp.internal", true},
+		{"evilcorp.internal", "*.corp.internal", false},
+		{"corp.internal", "*.corp.internal", false},
+		{"registry.example.com", "example.com", false},
+		{"anything", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hostname+"|"+tt.pattern, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, matchDomain(tt.hostname, tt.pattern))
+		})
+	}
+}
+
+func TestAllowlistPermitsIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		ip    string
+		allow Allowlist
+		want  bool
+	}{
+		{name: "public IP allowed with empty allowlist", ip: "1.1.1.1", want: true},
+		{name: "private 10/8 blocked", ip: "10.0.0.5", want: false},
+		{name: "private 192.168 blocked", ip: "192.168.1.1", want: false},
+		{name: "cloud metadata blocked", ip: "169.254.169.254", want: false},
+		{name: "loopback blocked", ip: "127.0.0.1", want: false},
+		{name: "ipv6 loopback blocked", ip: "::1", want: false},
+		{name: "ipv4-mapped private blocked", ip: "::ffff:10.0.0.1", want: false},
+		{name: "loopback allowlisted via CIDR", ip: "127.0.0.1", allow: ParseAllowlist([]string{"127.0.0.0/8"}), want: true},
+		{name: "single private IP allowlisted", ip: "10.20.0.5", allow: ParseAllowlist([]string{"10.20.0.5"}), want: true},
+		{name: "non-listed private still blocked", ip: "10.20.0.6", allow: ParseAllowlist([]string{"10.20.0.5"}), want: false},
+		{name: "allow-all disables guard", ip: "169.254.169.254", allow: ParseAllowlist([]string{"0.0.0.0/0"}), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, tt.allow.permitsIP(netip.MustParseAddr(tt.ip)))
+		})
+	}
+}
+
+func TestNewTransport(t *testing.T) {
+	t.Parallel()
+
+	// noProxyBase keeps the tests deterministic regardless of the runner's
+	// HTTP_PROXY environment: with no proxy the guard is always installed.
+	noProxyBase := func() *http.Transport { return &http.Transport{} }
+
+	t.Run("blocks denied IP and records it", func(t *testing.T) {
+		t.Parallel()
+
+		var blocked netip.Addr
+		tr := NewTransport(noProxyBase(), "registry.example.com", Allowlist{}, func(ip netip.Addr) { blocked = ip })
+
+		_, err := tr.DialContext(t.Context(), "tcp", "10.0.0.5:443")
+		require.ErrorIs(t, err, ErrBlocked)
+		assert.Equal(t, "10.0.0.5", blocked.String())
+	})
+
+	t.Run("IP allowlist overrides denylist", func(t *testing.T) {
+		t.Parallel()
+
+		// Start a loopback listener; the guard must permit the dial because
+		// 127.0.0.0/8 is allowlisted even though it is in the denylist.
+		ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer ln.Close()
+
+		tr := NewTransport(noProxyBase(), "registry.example.com", ParseAllowlist([]string{"127.0.0.0/8"}), nil)
+		conn, err := tr.DialContext(t.Context(), "tcp", ln.Addr().String())
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+	})
+
+	t.Run("domain allowlist permits internal host by name", func(t *testing.T) {
+		t.Parallel()
+
+		ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer ln.Close()
+
+		_, port, err := net.SplitHostPort(ln.Addr().String())
+		require.NoError(t, err)
+
+		// "localhost" resolves to loopback (denied) but is allowlisted by name,
+		// so the dial must be permitted.
+		tr := NewTransport(noProxyBase(), "registry.example.com", ParseAllowlist([]string{"localhost"}), nil)
+		conn, err := tr.DialContext(t.Context(), "tcp", net.JoinHostPort("localhost", port))
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+	})
+
+	t.Run("blocks loopback hostname when not allowlisted", func(t *testing.T) {
+		t.Parallel()
+
+		ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer ln.Close()
+
+		_, port, err := net.SplitHostPort(ln.Addr().String())
+		require.NoError(t, err)
+
+		tr := NewTransport(noProxyBase(), "registry.example.com", Allowlist{}, nil)
+		_, err = tr.DialContext(t.Context(), "tcp", net.JoinHostPort("localhost", port))
+		require.ErrorIs(t, err, ErrBlocked)
+	})
+
+	t.Run("skips guard when a proxy is configured", func(t *testing.T) {
+		t.Parallel()
+
+		ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer ln.Close()
+
+		// A configured proxy takes precedence: the guard must not be installed,
+		// so an otherwise-denied IP is not blocked. The stub DialContext stands
+		// in for the proxy connection.
+		base := &http.Transport{
+			Proxy: func(*http.Request) (*url.URL, error) {
+				return url.Parse("http://proxy.internal:8080")
+			},
+			DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, network, ln.Addr().String())
+			},
+		}
+
+		tr := NewTransport(base, "registry.example.com", Allowlist{}, nil)
+		conn, err := tr.DialContext(t.Context(), "tcp", "10.0.0.5:443")
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+	})
+
+	t.Run("nil base falls back to a usable transport", func(t *testing.T) {
+		t.Parallel()
+
+		require.NotNil(t, NewTransport(nil, "registry.example.com", Allowlist{}, nil))
+	})
+}
+
+func TestProxyConfigured(t *testing.T) {
+	t.Parallel()
+
+	// proxyUnless returns a proxy for every host except skip, simulating NO_PROXY.
+	proxyUnless := func(skip string) func(*http.Request) (*url.URL, error) {
+		return func(r *http.Request) (*url.URL, error) {
+			if r.URL.Host == skip {
+				return nil, nil
+			}
+
+			return url.Parse("http://proxy.internal:8080")
+		}
+	}
+
+	tests := []struct {
+		name  string
+		proxy func(*http.Request) (*url.URL, error)
+		host  string
+		want  bool
+	}{
+		{name: "nil proxy func", proxy: nil, host: "registry.example.com", want: false},
+		{
+			name:  "func returns no proxy",
+			proxy: func(*http.Request) (*url.URL, error) { return nil, nil },
+			host:  "registry.example.com",
+			want:  false,
+		},
+		{
+			name:  "func returns a proxy",
+			proxy: func(*http.Request) (*url.URL, error) { return url.Parse("http://proxy.internal:8080") },
+			host:  "registry.example.com",
+			want:  true,
+		},
+		{name: "proxy applies to host", proxy: proxyUnless("direct.example.com"), host: "registry.example.com", want: true},
+		{name: "NO_PROXY excludes host", proxy: proxyUnless("direct.example.com"), host: "direct.example.com", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, proxyConfigured(tt.proxy, tt.host))
+		})
+	}
+}

--- a/packages/orchestrator/pkg/template/build/core/oci/oci.go
+++ b/packages/orchestrator/pkg/template/build/core/oci/oci.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,6 +27,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/core/filesystem"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/core/oci/auth"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/core/oci/egress"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/units"
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/dockerhub"
@@ -34,6 +37,19 @@ import (
 )
 
 var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/core/oci")
+
+// guardedImagePullTransport returns the registry transport with a dialer that
+// rejects connections to internal/private IPs (unless allowlisted).
+func guardedImagePullTransport(ctx context.Context, tag, registryHost string, egressAllowlist []string) *http.Transport {
+	base, _ := remote.DefaultTransport.(*http.Transport)
+
+	return egress.NewTransport(base, registryHost, egress.ParseAllowlist(egressAllowlist), func(ip netip.Addr) {
+		telemetry.ReportEvent(ctx, "blocked image pull egress to internal IP",
+			attribute.String("image.ref", tag),
+			attribute.String("blocked_ip", ip.String()),
+		)
+	})
+}
 
 // ImageTooLargeError is returned when the uncompressed Docker image exceeds the maximum filesystem size.
 type ImageTooLargeError struct {
@@ -67,9 +83,17 @@ func DefaultPlatform() containerregistry.Platform {
 }
 
 // wrapImagePullError converts technical Docker registry errors into user-friendly messages.
-func wrapImagePullError(err error, imageRef string) error {
+func wrapImagePullError(ctx context.Context, err error, imageRef string) error {
 	if err == nil {
 		return nil
+	}
+
+	// The registry host resolved to a disallowed internal/private address.
+	// Return a clean message; the underlying error is intentionally not wrapped.
+	if errors.Is(err, egress.ErrBlocked) {
+		logger.L().Warn(ctx, "image pull blocked due to disallowed internal address", zap.String("image_ref", imageRef), zap.Error(err))
+
+		return fmt.Errorf("cannot pull image '%s': its registry host resolved to a disallowed internal address", imageRef)
 	}
 
 	// Check for transport errors with specific error codes from the registry API
@@ -92,7 +116,7 @@ func wrapImagePullError(err error, imageRef string) error {
 	return fmt.Errorf("failed to pull image '%s': %w", imageRef, err)
 }
 
-func GetPublicImage(ctx context.Context, dockerhubRepository dockerhub.RemoteRepository, tag string, authProvider auth.RegistryAuthProvider) (containerregistry.Image, error) {
+func GetPublicImage(ctx context.Context, dockerhubRepository dockerhub.RemoteRepository, tag string, authProvider auth.RegistryAuthProvider, egressAllowlist []string) (containerregistry.Image, error) {
 	ctx, span := tracer.Start(ctx, "pull-public-docker-image")
 	defer span.End()
 
@@ -108,7 +132,7 @@ func GetPublicImage(ctx context.Context, dockerhubRepository dockerhub.RemoteRep
 	if authProvider == nil && ref.Context().RegistryStr() == name.DefaultRegistry {
 		img, err := dockerhubRepository.GetImage(ctx, tag, platform)
 		if err != nil {
-			return nil, wrapImagePullError(err, tag)
+			return nil, wrapImagePullError(ctx, err, tag)
 		}
 
 		telemetry.ReportEvent(ctx, "pulled public image through docker remote repository proxy")
@@ -121,8 +145,13 @@ func GetPublicImage(ctx context.Context, dockerhubRepository dockerhub.RemoteRep
 		return img, nil
 	}
 
-	// Build options
-	opts := []remote.Option{remote.WithPlatform(platform)}
+	// Build options.
+	// The custom transport applies the egress guard configured via
+	// cfg.BuilderConfig.ImagePullEgressAllowlist.
+	opts := []remote.Option{
+		remote.WithPlatform(platform),
+		remote.WithTransport(guardedImagePullTransport(ctx, tag, ref.Context().RegistryStr(), egressAllowlist)),
+	}
 
 	// Use the auth provider if provided
 	if authProvider != nil {
@@ -137,7 +166,7 @@ func GetPublicImage(ctx context.Context, dockerhubRepository dockerhub.RemoteRep
 
 	img, err := remote.Image(ref, opts...)
 	if err != nil {
-		return nil, wrapImagePullError(err, tag)
+		return nil, wrapImagePullError(ctx, err, tag)
 	}
 
 	telemetry.ReportEvent(ctx, "pulled public image")

--- a/packages/orchestrator/pkg/template/build/core/oci/oci_test.go
+++ b/packages/orchestrator/pkg/template/build/core/oci/oci_test.go
@@ -31,6 +31,11 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
+// loopbackEgressAllowlist permits loopback so the test registries (served over
+// 127.0.0.1) are not blocked by the image-pull egress guard, mirroring what a
+// local dev deployment sets via IMAGE_PULL_EGRESS_ALLOWLIST.
+var loopbackEgressAllowlist = []string{"127.0.0.0/8", "::1/128"}
+
 func createFileTar(t *testing.T, fileName string) *bytes.Buffer {
 	t.Helper()
 
@@ -277,7 +282,7 @@ func TestGetPublicImageWithGeneralAuth(t *testing.T) {
 		require.NotNil(t, authOption)
 
 		// Now test GetPublicImage
-		img, err := GetPublicImage(ctx, dockerhubRepository, imageRef, authProvider)
+		img, err := GetPublicImage(ctx, dockerhubRepository, imageRef, authProvider, loopbackEgressAllowlist)
 		require.NoError(t, err)
 		require.NotNil(t, img)
 
@@ -328,7 +333,7 @@ func TestGetPublicImageWithGeneralAuth(t *testing.T) {
 		require.NotNil(t, authOption)
 
 		// Now test GetPublicImage
-		img, err := GetPublicImage(ctx, dockerhubRepository, imageRef, authProvider)
+		img, err := GetPublicImage(ctx, dockerhubRepository, imageRef, authProvider, loopbackEgressAllowlist)
 		require.Error(t, err)
 		require.Nil(t, img)
 	})
@@ -354,7 +359,7 @@ func TestGetPublicImageWithGeneralAuth(t *testing.T) {
 		require.NoError(t, err)
 
 		// Get image without auth provider (nil)
-		img, err := GetPublicImage(ctx, dockerhubRepository, imageRef, nil)
+		img, err := GetPublicImage(ctx, dockerhubRepository, imageRef, nil, loopbackEgressAllowlist)
 		require.NoError(t, err)
 		require.NotNil(t, img)
 
@@ -363,4 +368,23 @@ func TestGetPublicImageWithGeneralAuth(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, layers, 1)
 	})
+}
+
+func TestGetPublicImageBlocksInternalEgress(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	dockerhubRepository := dockerhub.NewNoopRemoteRepository()
+	t.Cleanup(func() {
+		require.NoError(t, dockerhubRepository.Close())
+	})
+
+	// A reference whose registry host is an internal/private IP not present in
+	// the test allowlist (which only permits loopback).
+	imageRef := "10.255.255.1:5000/test/image:latest"
+
+	img, err := GetPublicImage(ctx, dockerhubRepository, imageRef, nil, nil)
+	require.Error(t, err)
+	require.Nil(t, img)
+	assert.Contains(t, err.Error(), "disallowed internal address")
 }

--- a/packages/orchestrator/pkg/template/build/core/rootfs/rootfs.go
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/rootfs.go
@@ -131,7 +131,7 @@ func (r *Rootfs) CreateExt4Filesystem(
 	var img containerregistry.Image
 	var err error
 	if template.FromImage != "" {
-		img, err = oci.GetPublicImage(childCtx, r.dockerhubRepository, template.FromImage, template.RegistryAuthProvider)
+		img, err = oci.GetPublicImage(childCtx, r.dockerhubRepository, template.FromImage, template.RegistryAuthProvider, r.buildContext.BuilderConfig.ImagePullEgressAllowlist)
 	} else {
 		img, err = oci.GetImage(childCtx, r.artifactRegistry, template.TemplateID, r.buildContext.Template.BuildID)
 	}


### PR DESCRIPTION
Restrict where base image pulls can connect: with an allowlist (IPs/CIDRs or domain patterns) via `IMAGE_PULL_EGRESS_ALLOWLIST` (`cfg.BuilderConfig`)