### PR TITLE
fix(envd): fix process lookup by tag and nil panic in Wait()

### DIFF
--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -450,7 +450,9 @@ func (p *Handler) Wait() {
 
 	err := p.cmd.Wait()
 
-	p.tty.Close()
+	if p.tty != nil {
+		p.tty.Close()
+	}
 
 	var errMsg *string
 

--- a/packages/envd/internal/services/process/service.go
+++ b/packages/envd/internal/services/process/service.go
@@ -66,10 +66,10 @@ func (s *Service) getProcess(selector *rpc.ProcessSelector) (*handler.Handler, e
 			if *value.Tag == tag {
 				proc = value
 
-				return true
+				return false
 			}
 
-			return false
+			return true
 		})
 
 		if proc == nil {


### PR DESCRIPTION
Two bugs in the process service:

1. getProcess Range callback return values were inverted:
   - Returned true (continue) on match — should return false (stop)
   - Returned false (stop) on non-match — should return true (continue) This caused tag-based process lookup to fail randomly: it would stop at the first non-matching tagged process instead of continuing to search, and would keep iterating after finding a match.

2. Handler.Wait() unconditionally called p.tty.Close(), but p.tty is nil for non-PTY processes (those started via cmd.Start() at line 429). Every non-PTY process exit would panic with a nil pointer dereference.

/cc @jakubno @dobrac @ValentaTomas Would appreciate your review on this change, thanks!