### PR TITLE
Improve/archived object map aws error

### DIFF
--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -255,6 +255,12 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 			return nil, status.Errorf(codes.FailedPrecondition, "sandbox files for '%s' not found", req.GetSandbox().GetSandboxId())
 		}
 
+		if errors.Is(err, storage.ErrObjectArchived) {
+			telemetry.ReportError(ctx, "sandbox files archived", err, telemetry.WithSandboxID(req.GetSandbox().GetSandboxId()))
+
+			return nil, status.Errorf(codes.FailedPrecondition, "sandbox files for '%s' are archived and not directly accessible, please rebuild the template", req.GetSandbox().GetSandboxId())
+		}
+
 		err = errors.Join(err, context.Cause(ctx))
 		telemetry.ReportCriticalError(ctx, "failed to create sandbox", err)
 		logger.L().Error(ctx, "failed to create sandbox", zap.Error(err),

--- a/packages/shared/pkg/storage/metrics.go
+++ b/packages/shared/pkg/storage/metrics.go
@@ -38,6 +38,9 @@ const (
 	OutcomeErrIO        = "err_io"
 	OutcomeErrTimeout   = "err_timeout"
 	OutcomeTransitioned = "transitioned"
+	// OutcomeArchived means the object exists but is in an archived storage
+	// class that does not allow direct reads.
+	OutcomeArchived = "archived"
 	// OutcomeContended is a writeback skipped because another goroutine held the
 	// NFS chunk lock — normal cache dedup, nothing written.
 	OutcomeContended = "contended"
@@ -80,6 +83,8 @@ func Outcome(err error) string {
 		return OutcomeOK
 	case errors.Is(err, ErrObjectNotExist), errors.Is(err, fs.ErrNotExist):
 		return OutcomeNotFound
+	case errors.Is(err, ErrObjectArchived):
+		return OutcomeArchived
 	case errors.Is(err, context.Canceled):
 		return OutcomeErrCanceled
 	case errors.Is(err, context.DeadlineExceeded):

--- a/packages/shared/pkg/storage/storage.go
+++ b/packages/shared/pkg/storage/storage.go
@@ -24,6 +24,11 @@ var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/shared/pkg/storage")
 
 var ErrObjectNotExist = errors.New("object does not exist")
 
+// ErrObjectArchived means the object exists but is stored in an archived
+// storage class (e.g. GLACIER, ARCHIVE, COLD_ARCHIVE) that does not allow
+// direct reads. The object must be restored or rebuilt before it can be used.
+var ErrObjectArchived = errors.New("object is archived and not accessible")
+
 // ErrObjectRateLimited means per-object mutation rate limiting —
 // multiple concurrent writers racing to write the same content-addressed object.
 var ErrObjectRateLimited = errors.New("object access rate limited")

--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -168,6 +168,11 @@ func (o *awsObject) WriteTo(ctx context.Context, dst io.Writer) (n int64, err er
 			return 0, ErrObjectNotExist
 		}
 
+		var ios *types.InvalidObjectState
+		if errors.As(err, &ios) {
+			return 0, fmt.Errorf("object %q is in storage class that does not allow direct reads: %w", o.path, ErrObjectArchived)
+		}
+
 		return 0, err
 	}
 
@@ -277,6 +282,11 @@ func (o *awsObject) OpenRangeReader(ctx context.Context, off, length int64, fram
 			return nil, SourceAWS, ErrObjectNotExist
 		}
 
+		var ios *types.InvalidObjectState
+		if errors.As(err, &ios) {
+			return nil, SourceAWS, fmt.Errorf("object %q is in storage class that does not allow direct reads: %w", o.path, ErrObjectArchived)
+		}
+
 		return nil, SourceAWS, fmt.Errorf("failed to create S3 range reader for %q: %w", o.path, err)
 	}
 
@@ -297,6 +307,11 @@ func (o *awsObject) Size(ctx context.Context) (_ int64, err error) {
 		var nfd *types.NotFound
 		if errors.As(err, &nsk) || errors.As(err, &nfd) {
 			return 0, ErrObjectNotExist
+		}
+
+		var ios *types.InvalidObjectState
+		if errors.As(err, &ios) {
+			return 0, fmt.Errorf("object %q is in storage class that does not allow direct reads: %w", o.path, ErrObjectArchived)
 		}
 
 		return 0, err

--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -154,6 +154,26 @@ func (s *awsStorage) OpenBlob(_ context.Context, path string) (Blob, error) {
 	}, nil
 }
 
+// mapAWSError translates well-known AWS S3 errors into storage-layer sentinels.
+func mapAWSError(err error, path string) error {
+	if err == nil {
+		return nil
+	}
+
+	var nsk *types.NoSuchKey
+	var nfd *types.NotFound
+	var ios *types.InvalidObjectState
+
+	switch {
+	case errors.As(err, &nsk), errors.As(err, &nfd):
+		return fmt.Errorf("%q: %w", path, ErrObjectNotExist)
+	case errors.As(err, &ios):
+		return fmt.Errorf("%q: %w", path, ErrObjectArchived)
+	default:
+		return err
+	}
+}
+
 func (o *awsObject) WriteTo(ctx context.Context, dst io.Writer) (n int64, err error) {
 	start := time.Now()
 	defer func() { RecordReadBlob(ctx, time.Since(start), n, o.path, SourceAWS, err) }()
@@ -163,17 +183,7 @@ func (o *awsObject) WriteTo(ctx context.Context, dst io.Writer) (n int64, err er
 
 	resp, err := o.client.GetObject(ctx, &s3.GetObjectInput{Bucket: &o.bucketName, Key: &o.path})
 	if err != nil {
-		var nsk *types.NoSuchKey
-		if errors.As(err, &nsk) {
-			return 0, ErrObjectNotExist
-		}
-
-		var ios *types.InvalidObjectState
-		if errors.As(err, &ios) {
-			return 0, fmt.Errorf("object %q is in storage class that does not allow direct reads: %w", o.path, ErrObjectArchived)
-		}
-
-		return 0, err
+		return 0, mapAWSError(err, o.path)
 	}
 
 	defer resp.Body.Close()
@@ -277,17 +287,7 @@ func (o *awsObject) OpenRangeReader(ctx context.Context, off, length int64, fram
 		Range:  readRange,
 	})
 	if err != nil {
-		var nsk *types.NoSuchKey
-		if errors.As(err, &nsk) {
-			return nil, SourceAWS, ErrObjectNotExist
-		}
-
-		var ios *types.InvalidObjectState
-		if errors.As(err, &ios) {
-			return nil, SourceAWS, fmt.Errorf("object %q is in storage class that does not allow direct reads: %w", o.path, ErrObjectArchived)
-		}
-
-		return nil, SourceAWS, fmt.Errorf("failed to create S3 range reader for %q: %w", o.path, err)
+		return nil, SourceAWS, mapAWSError(err, o.path)
 	}
 
 	return NewRangeReader(resp.Body), SourceAWS, nil
@@ -303,18 +303,7 @@ func (o *awsObject) Size(ctx context.Context) (_ int64, err error) {
 
 	resp, err := o.client.HeadObject(ctx, &s3.HeadObjectInput{Bucket: &o.bucketName, Key: &o.path})
 	if err != nil {
-		var nsk *types.NoSuchKey
-		var nfd *types.NotFound
-		if errors.As(err, &nsk) || errors.As(err, &nfd) {
-			return 0, ErrObjectNotExist
-		}
-
-		var ios *types.InvalidObjectState
-		if errors.As(err, &ios) {
-			return 0, fmt.Errorf("object %q is in storage class that does not allow direct reads: %w", o.path, ErrObjectArchived)
-		}
-
-		return 0, err
+		return 0, mapAWSError(err, o.path)
 	}
 
 	return *resp.ContentLength, nil


### PR DESCRIPTION
refactor: extract mapAWSError helper to reduce duplication

Consolidate the duplicated AWS error → sentinel mapping across WriteTo, OpenRangeReader, and Size into a single [mapAWSError()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) helper function.

This also fixes an inconsistency where Size() checked types.NotFound but the other two methods did not.

Changes: 1 file, +23 -34 (net reduction of 11 lines)