### PR TITLE
Rp reverse proxy

### DIFF
--- a/.env.aws.template
+++ b/.env.aws.template
@@ -26,7 +26,7 @@ TERRAFORM_ENVIRONMENT=dev
 # registry instead of building it from source. When set, `make build-and-upload`
 # pulls this version and mirrors it into your own core repo (caching it locally).
 # Leave empty to build from source. Example: v0.1.0
-REVERSE_PROXY_VERSION=
+DOCKER_REVERSE_PROXY_VERSION=
 
 # Sandbox firewall: comma-separated CIDRs to allow through the private-range deny list
 # ALLOW_SANDBOX_INTERNAL_CIDRS=

--- a/.env.aws.template
+++ b/.env.aws.template
@@ -22,5 +22,11 @@ TERRAFORM_ENVIRONMENT=dev
 # ------------------------------------------- Optional block -----------------------------------------------------------
 # Following variables are optional and doesn't have to be set
 
+# Pull a released, prebuilt docker-reverse-proxy image from E2B's artifact
+# registry instead of building it from source. When set, `make build-and-upload`
+# pulls this version and mirrors it into your own core repo (caching it locally).
+# Leave empty to build from source. Example: v0.1.0
+REVERSE_PROXY_VERSION=
+
 # Sandbox firewall: comma-separated CIDRs to allow through the private-range deny list
 # ALLOW_SANDBOX_INTERNAL_CIDRS=

--- a/.env.gcp.template
+++ b/.env.gcp.template
@@ -74,6 +74,12 @@ CLICKHOUSE_CLUSTER_SIZE=1
 # ------------------------------------------- Optional block -----------------------------------------------------------
 # Following variables are optional and doesn't have to be set
 
+# Pull a released, prebuilt docker-reverse-proxy image from E2B's artifact
+# registry instead of building it from source. When set, `make build-and-upload`
+# pulls this version and mirrors it into your own core repo (caching it locally).
+# Leave empty to build from source. Example: v0.1.0
+REVERSE_PROXY_VERSION=
+
 # Dashboard API instance count (default: 0)
 DASHBOARD_API_COUNT=
 

--- a/.env.gcp.template
+++ b/.env.gcp.template
@@ -78,7 +78,7 @@ CLICKHOUSE_CLUSTER_SIZE=1
 # registry instead of building it from source. When set, `make build-and-upload`
 # pulls this version and mirrors it into your own core repo (caching it locally).
 # Leave empty to build from source. Example: v0.1.0
-REVERSE_PROXY_VERSION=
+DOCKER_REVERSE_PROXY_VERSION=
 
 # Dashboard API instance count (default: 0)
 DASHBOARD_API_COUNT=

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -93,7 +93,7 @@ jobs:
         #
         # Notes:
         #  - Tag is v-prefixed (v${VERSION}) to match what customers pin via
-        #    REVERSE_PROXY_VERSION and the manual publish convention.
+        #    DOCKER_REVERSE_PROXY_VERSION and the manual publish convention.
         #  - No :latest tag: the e2b-artifacts repo has immutableTags=true, so a
         #    reused tag would fail on the second release. Customers pin exact
         #    versions anyway.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,96 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    name: Create / update release PRs
+    runs-on: ubuntu-24.04
+    outputs:
+      # Per-package outputs are keyed by the package path. Add more here as more
+      # packages are onboarded to release-please.
+      reverse_proxy_released: ${{ steps.release.outputs['packages/docker-reverse-proxy--release_created'] }}
+      reverse_proxy_tag: ${{ steps.release.outputs['packages/docker-reverse-proxy--tag_name'] }}
+      reverse_proxy_version: ${{ steps.release.outputs['packages/docker-reverse-proxy--version'] }}
+    steps:
+      - name: Run release-please
+        id: release
+        uses: googleapis/release-please-action@v4
+        with:
+          # Uses the default GITHUB_TOKEN. Because the publish job lives in this
+          # same workflow run, we don't need a PAT/app token to re-trigger on the
+          # release event.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+
+  publish-reverse-proxy:
+    name: Publish docker-reverse-proxy to e2b-artifacts
+    needs: release-please
+    if: ${{ needs.release-please.outputs.reverse_proxy_released == 'true' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      # <host>/<project>/<repository>/<image>
+      IMAGE: us-docker.pkg.dev/e2b-artifacts/reverse-proxy/reverse-proxy
+      VERSION: ${{ needs.release-please.outputs.reverse_proxy_version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Authenticate to the e2b-artifacts project
+        uses: google-github-actions/auth@v3
+        with:
+          # Workload Identity Federation provider + service account for the
+          # e2b-artifacts project. Provisioned out-of-repo (separate Terraform
+          # modules / live repo); wired here via GitHub repo variables.
+          workload_identity_provider: ${{ vars.E2B_ARTIFACTS_WIF_PROVIDER }}
+          service_account: ${{ vars.E2B_ARTIFACTS_PUBLISH_SA }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Configure Docker auth
+        run: gcloud auth configure-docker us-docker.pkg.dev --quiet
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push released image
+        # The Dockerfile lives in packages/docker-reverse-proxy but its build
+        # context is the packages/ directory (it needs shared/ and db/).
+        #
+        # Notes:
+        #  - Tag is v-prefixed (v${VERSION}) to match what customers pin via
+        #    REVERSE_PROXY_VERSION and the manual publish convention.
+        #  - No :latest tag: the e2b-artifacts repo has immutableTags=true, so a
+        #    reused tag would fail on the second release. Customers pin exact
+        #    versions anyway.
+        #  - --provenance=false --sbom=false: Artifact Registry rejects buildx's
+        #    default OCI attestation manifest list (HTTP 400).
+        run: |
+          IMAGE_TAG="v${VERSION}"
+          docker buildx build \
+            --platform linux/amd64 \
+            --provenance=false \
+            --sbom=false \
+            --build-arg COMMIT_SHA="${GITHUB_SHA::7}" \
+            --build-arg VERSION="${IMAGE_TAG}" \
+            --tag "${IMAGE}:${IMAGE_TAG}" \
+            --push \
+            -f packages/docker-reverse-proxy/Dockerfile \
+            packages

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,14 +22,31 @@ jobs:
       reverse_proxy_tag: ${{ steps.release.outputs['packages/docker-reverse-proxy--tag_name'] }}
       reverse_proxy_version: ${{ steps.release.outputs['packages/docker-reverse-proxy--version'] }}
     steps:
+      # Mint a short-lived token from a GitHub App so the release PR is opened as
+      # the App (not the default GITHUB_TOKEN). This is required when `main` has
+      # required status checks: PRs opened by GITHUB_TOKEN don't trigger
+      # `pull_request` workflows, so the release PR would be unmergeable.
+      #
+      # Requires a GitHub App (Contents: write, Pull requests: write) installed on
+      # this repo, with its App ID in the RELEASE_APP_ID variable and private key
+      # in the RELEASE_APP_PRIVATE_KEY secret.
+      #
+      # Falls back to GITHUB_TOKEN if the App isn't configured yet, so the
+      # workflow still runs (the release PR just won't trigger required checks
+      # until the App is set up).
+      - name: Generate GitHub App token
+        id: app-token
+        if: ${{ vars.RELEASE_APP_ID != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Run release-please
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          # Uses the default GITHUB_TOKEN. Because the publish job lives in this
-          # same workflow run, we don't need a PAT/app token to re-trigger on the
-          # release event.
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,7 +43,7 @@ jobs:
       id-token: write
     env:
       # <host>/<project>/<repository>/<image>
-      IMAGE: us-docker.pkg.dev/e2b-artifacts/reverse-proxy/reverse-proxy
+      IMAGE: us-docker.pkg.dev/e2b-artifacts/reverse-proxy/docker-reverse-proxy
       VERSION: ${{ needs.release-please.outputs.reverse_proxy_version }}
     steps:
       - name: Checkout repository

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "packages/docker-reverse-proxy": "0.1.0"
+}

--- a/packages/docker-reverse-proxy/Dockerfile
+++ b/packages/docker-reverse-proxy/Dockerfile
@@ -33,7 +33,8 @@ COPY ./docker-reverse-proxy/Makefile ./docker-reverse-proxy/Makefile
 WORKDIR /build/docker-reverse-proxy
 
 ARG COMMIT_SHA
-RUN --mount=type=cache,target=/root/.cache/go-build make build COMMIT_SHA=${COMMIT_SHA}
+ARG VERSION=dev
+RUN --mount=type=cache,target=/root/.cache/go-build make build COMMIT_SHA=${COMMIT_SHA} VERSION=${VERSION}
 
 RUN chmod +x /build/docker-reverse-proxy/bin/docker-reverse-proxy
 

--- a/packages/docker-reverse-proxy/Makefile
+++ b/packages/docker-reverse-proxy/Makefile
@@ -8,11 +8,32 @@ else
 	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)core/docker-reverse-proxy
 endif
 
+# E2B-hosted registry that holds released, prebuilt reverse-proxy images.
+# Published to by the release-please workflow on tagging a release.
+E2B_ARTIFACTS_REGISTRY ?= us-docker.pkg.dev/e2b-artifacts/reverse-proxy/reverse-proxy
+
+# Optional version "hook" for the released-image flow.
+# When empty (default), build-and-upload builds from source and pushes to the
+# client's own core repo (the existing flow, unchanged).
+# When set (e.g. REVERSE_PROXY_VERSION=v0.1.0), skip building: pull the released
+# image from $(E2B_ARTIFACTS_REGISTRY) and retag/push it into the client's core
+# repo, so the Terraform `docker-reverse-proxy:latest` lookup keeps working.
+#
+# Set it either on the command line (make ... REVERSE_PROXY_VERSION=v0.1.0) or in
+# the active .env.${ENV} file (REVERSE_PROXY_VERSION=v0.1.0), which is included
+# above. Quotes are stripped so both `=v0.1.0` and `="v0.1.0"` work; a
+# command-line value always wins over the env file.
+REVERSE_PROXY_VERSION := $(strip $(subst ",,$(REVERSE_PROXY_VERSION)))
+
+# Stamped into the binary via -ldflags. Defaults to "dev" for source builds;
+# the release build passes the release tag as VERSION.
+VERSION ?= dev
+
 .PHONY: build
 build:
 	# Allow for passing commit sha directly for docker builds
 	$(eval COMMIT_SHA ?= $(shell git rev-parse --short HEAD))
-	CGO_ENABLED=0 go build -o bin/docker-reverse-proxy -ldflags "-X=main.commitSHA=$(COMMIT_SHA)" .
+	CGO_ENABLED=0 go build -o bin/docker-reverse-proxy -ldflags "-X=main.commitSHA=$(COMMIT_SHA) -X=main.version=$(VERSION)" .
 
 .PHONY: build-debug
 build-debug:
@@ -20,8 +41,20 @@ build-debug:
 
 .PHONY: build-and-upload
 build-and-upload:
+ifeq ($(strip $(REVERSE_PROXY_VERSION)),)
+	# Existing flow: build from source and push to the client's own core repo.
 	$(eval COMMIT_SHA := $(shell git rev-parse --short HEAD))
 	@docker buildx build --platform linux/amd64 --tag $(IMAGE_REGISTRY) --tag $(IMAGE_REGISTRY):$(COMMIT_SHA) --push --build-arg COMMIT_SHA="$(COMMIT_SHA)" -f ./Dockerfile ..
+else
+	# Released-image flow: pull the prebuilt, versioned image from the E2B
+	# artifacts registry and retag/push it into the client's own core repo.
+	@echo "Using released docker-reverse-proxy $(REVERSE_PROXY_VERSION) from $(E2B_ARTIFACTS_REGISTRY)"
+	docker pull --platform linux/amd64 $(E2B_ARTIFACTS_REGISTRY):$(REVERSE_PROXY_VERSION)
+	docker tag $(E2B_ARTIFACTS_REGISTRY):$(REVERSE_PROXY_VERSION) $(IMAGE_REGISTRY):latest
+	docker tag $(E2B_ARTIFACTS_REGISTRY):$(REVERSE_PROXY_VERSION) $(IMAGE_REGISTRY):$(REVERSE_PROXY_VERSION)
+	docker push $(IMAGE_REGISTRY):latest
+	docker push $(IMAGE_REGISTRY):$(REVERSE_PROXY_VERSION)
+endif
 
 .PHONY: test
 test:

--- a/packages/docker-reverse-proxy/Makefile
+++ b/packages/docker-reverse-proxy/Makefile
@@ -10,7 +10,7 @@ endif
 
 # E2B-hosted registry that holds released, prebuilt reverse-proxy images.
 # Published to by the release-please workflow on tagging a release.
-E2B_ARTIFACTS_REGISTRY ?= us-docker.pkg.dev/e2b-artifacts/reverse-proxy/reverse-proxy
+E2B_ARTIFACTS_REGISTRY ?= us-docker.pkg.dev/e2b-artifacts/reverse-proxy/docker-reverse-proxy
 
 # Optional version "hook" for the released-image flow.
 # When empty (default), build-and-upload builds from source and pushes to the

--- a/packages/docker-reverse-proxy/Makefile
+++ b/packages/docker-reverse-proxy/Makefile
@@ -15,15 +15,15 @@ E2B_ARTIFACTS_REGISTRY ?= us-docker.pkg.dev/e2b-artifacts/reverse-proxy/docker-r
 # Optional version "hook" for the released-image flow.
 # When empty (default), build-and-upload builds from source and pushes to the
 # client's own core repo (the existing flow, unchanged).
-# When set (e.g. REVERSE_PROXY_VERSION=v0.1.0), skip building: pull the released
+# When set (e.g. DOCKER_REVERSE_PROXY_VERSION=v0.1.0), skip building: pull the released
 # image from $(E2B_ARTIFACTS_REGISTRY) and retag/push it into the client's core
 # repo, so the Terraform `docker-reverse-proxy:latest` lookup keeps working.
 #
-# Set it either on the command line (make ... REVERSE_PROXY_VERSION=v0.1.0) or in
-# the active .env.${ENV} file (REVERSE_PROXY_VERSION=v0.1.0), which is included
+# Set it either on the command line (make ... DOCKER_REVERSE_PROXY_VERSION=v0.1.0) or in
+# the active .env.${ENV} file (DOCKER_REVERSE_PROXY_VERSION=v0.1.0), which is included
 # above. Quotes are stripped so both `=v0.1.0` and `="v0.1.0"` work; a
 # command-line value always wins over the env file.
-REVERSE_PROXY_VERSION := $(strip $(subst ",,$(REVERSE_PROXY_VERSION)))
+DOCKER_REVERSE_PROXY_VERSION := $(strip $(subst ",,$(DOCKER_REVERSE_PROXY_VERSION)))
 
 # Stamped into the binary via -ldflags. Defaults to "dev" for source builds;
 # the release build passes the release tag as VERSION.
@@ -41,19 +41,19 @@ build-debug:
 
 .PHONY: build-and-upload
 build-and-upload:
-ifeq ($(strip $(REVERSE_PROXY_VERSION)),)
+ifeq ($(strip $(DOCKER_REVERSE_PROXY_VERSION)),)
 	# Existing flow: build from source and push to the client's own core repo.
 	$(eval COMMIT_SHA := $(shell git rev-parse --short HEAD))
 	@docker buildx build --platform linux/amd64 --tag $(IMAGE_REGISTRY) --tag $(IMAGE_REGISTRY):$(COMMIT_SHA) --push --build-arg COMMIT_SHA="$(COMMIT_SHA)" -f ./Dockerfile ..
 else
 	# Released-image flow: pull the prebuilt, versioned image from the E2B
 	# artifacts registry and retag/push it into the client's own core repo.
-	@echo "Using released docker-reverse-proxy $(REVERSE_PROXY_VERSION) from $(E2B_ARTIFACTS_REGISTRY)"
-	docker pull --platform linux/amd64 $(E2B_ARTIFACTS_REGISTRY):$(REVERSE_PROXY_VERSION)
-	docker tag $(E2B_ARTIFACTS_REGISTRY):$(REVERSE_PROXY_VERSION) $(IMAGE_REGISTRY):latest
-	docker tag $(E2B_ARTIFACTS_REGISTRY):$(REVERSE_PROXY_VERSION) $(IMAGE_REGISTRY):$(REVERSE_PROXY_VERSION)
+	@echo "Using released docker-reverse-proxy $(DOCKER_REVERSE_PROXY_VERSION) from $(E2B_ARTIFACTS_REGISTRY)"
+	docker pull --platform linux/amd64 $(E2B_ARTIFACTS_REGISTRY):$(DOCKER_REVERSE_PROXY_VERSION)
+	docker tag $(E2B_ARTIFACTS_REGISTRY):$(DOCKER_REVERSE_PROXY_VERSION) $(IMAGE_REGISTRY):latest
+	docker tag $(E2B_ARTIFACTS_REGISTRY):$(DOCKER_REVERSE_PROXY_VERSION) $(IMAGE_REGISTRY):$(DOCKER_REVERSE_PROXY_VERSION)
 	docker push $(IMAGE_REGISTRY):latest
-	docker push $(IMAGE_REGISTRY):$(REVERSE_PROXY_VERSION)
+	docker push $(IMAGE_REGISTRY):$(DOCKER_REVERSE_PROXY_VERSION)
 endif
 
 .PHONY: test

--- a/packages/docker-reverse-proxy/main.go
+++ b/packages/docker-reverse-proxy/main.go
@@ -15,7 +15,12 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/httpserver"
 )
 
-var commitSHA string
+var (
+	commitSHA string
+	// version is stamped via -ldflags at build time from the release tag
+	// (see Makefile). Defaults to "dev" for local/source builds.
+	version = "dev"
+)
 
 func main() {
 	ctx := context.Background()
@@ -28,7 +33,7 @@ func main() {
 	port := flag.Int("port", 5000, "Port for test HTTP server")
 	flag.Parse()
 
-	log.Println("Starting docker reverse proxy", "commit", commitSHA)
+	log.Println("Starting docker reverse proxy", "version", version, "commit", commitSHA)
 
 	store := handlers.NewStore(ctx)
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "separate-pull-requests": true,
+  "include-component-in-tag": true,
+  "tag-separator": "-",
+  "packages": {
+    "packages/docker-reverse-proxy": {
+      "release-type": "go",
+      "component": "docker-reverse-proxy",
+      "include-v-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    }
+  }
+}


### PR DESCRIPTION
Set up release-please + versioned images for docker-reverse-proxy

Why

Right now, self-hosters build the docker-reverse-proxy image from source every time they deploy. This PR gives us a second option: publish official, versioned images from E2B and let people pull those instead. It also adds automated releases (versioning + changelog) for this package — the first one we're onboarding, set up so we can roll it out to the other packages later.

Nothing about the current build-from-source flow changes. This is purely additive.

How it works

There's a new optional setting, REVERSE_PROXY_VERSION.

If you leave it empty (the default), everything works exactly as it does today — the image is built from source and pushed to your own registry.

If you set it (e.g. REVERSE_PROXY_VERSION=v0.1.0), the build step is skipped. Instead, make build-and-upload pulls that released image from E2B's registry and copies it into your own core repo, tagged as both latest and the version you asked for. Because it lands in the same place with the same latest tag, Terraform picks it up with no changes.

So it's essentially a way to cache a known-good, versioned E2B image in your own project instead of rebuilding it.

Using it

Add the version to your .env file (it's documented in both .env.gcp.template and .env.aws.template):

REVERSE_PROXY_VERSION=v0.1.0

Then deploy as usual:

make build-and-upload/docker-reverse-proxy

That pulls us-docker.pkg.dev/e2b-artifacts/reverse-proxy/reverse-proxy:v0.1.0 and mirrors it into your registry. Delete or comment out the line to go back to building from source.

You can also set it on the command line for a one-off, which overrides the .env value.

How releases happen

1. Conventional-commit PRs that touch packages/docker-reverse-proxy/ land on main. (Only changes to this package count — unrelated PRs elsewhere in the monorepo are ignored.)
2. release-please keeps a "release PR" open that bumps the version and updates the changelog.
3. Merging that release PR tags the version and kicks off a job that builds the image and publishes it to E2B's e2b-artifacts registry.

The released version is baked into the binary and printed at startup.

Before this can publish (follow-up, not in this PR)

The publish job needs credentials to push to e2b-artifacts. That means creating a service account + OIDC connector in that project (handled in our Terraform, out of this repo) and setting two GitHub repo variables: E2B_ARTIFACTS_WIF_PROVIDER and E2B_ARTIFACTS_PUBLISH_SA. Until those exist, the release PR side works fine — only the image publish waits on them.

Notes

- Images are published version-only (no latest) because the E2B registry uses immutable tags, so customers always pin an exact version.
- The build passes --provenance=false --sbom=false — Artifact Registry rejects buildx's default attestation format.
- Seeded at 0.1.0, and I validated the whole round-trip end-to-end with a throwaway v0.0.1 image.
