### PR TITLE
perf(clickhouse): reduce ingestion overhead

### DIFF
--- a/iac/modules/job-otel-collector/configs/otel-collector.yaml
+++ b/iac/modules/job-otel-collector/configs/otel-collector.yaml
@@ -204,8 +204,9 @@ processors:
     timeout: 5s
 
   batch/clickhouse:
-    timeout: 5s
+    timeout: 15s
     send_batch_size: 50000
+    send_batch_max_size: 100000
 
 %{ if provider_name == "gcp" && enable_gcp_telemetry_metrics }
   batch/gcp_telemetry:
@@ -270,7 +271,9 @@ processors:
       include:
         match_type: regexp
         metric_names:
-          - "e2b.*"
+          # Keep only external e2b metrics consumed by downstream pipelines
+          # today. New e2b.* namespaces must be added here intentionally.
+          - "^e2b\\.(sandbox|team)\\..*$"
 
   metricstransform/single_cpu:
     transforms:

--- a/packages/clickhouse/migrations/20260708220300_optimize_timeseries_codecs.sql
+++ b/packages/clickhouse/migrations/20260708220300_optimize_timeseries_codecs.sql
@@ -1,0 +1,63 @@
+-- Optimize storage codecs for time-series columns.
+--
+-- Timestamps and monotonic cumulative counters compress well with Delta+ZSTD;
+-- Float64 metric values compress well with Gorilla+ZSTD. Codecs only apply to
+-- newly written/merged parts, so this is a metadata-only change on the storage
+-- (_local) tables and does not rewrite existing data. Codec-only MODIFY COLUMN
+-- (no type/default repeated) avoids drift with the original definitions.
+
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE team_metrics_gauge_local
+    MODIFY COLUMN timestamp CODEC (Delta, ZSTD(1)),
+    MODIFY COLUMN value CODEC (Gorilla, ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE team_metrics_sum_local
+    MODIFY COLUMN timestamp CODEC (Delta, ZSTD(1)),
+    MODIFY COLUMN value CODEC (Gorilla, ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE sandbox_metrics_gauge_local
+    MODIFY COLUMN timestamp CODEC (Delta, ZSTD(1)),
+    MODIFY COLUMN value CODEC (Gorilla, ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE sandbox_host_stats_local
+    MODIFY COLUMN firecracker_cpu_user_time CODEC (Gorilla, ZSTD(1)),
+    MODIFY COLUMN firecracker_cpu_system_time CODEC (Gorilla, ZSTD(1)),
+    MODIFY COLUMN cgroup_cpu_usage_usec CODEC (Delta, ZSTD(1)),
+    MODIFY COLUMN cgroup_cpu_user_usec CODEC (Delta, ZSTD(1)),
+    MODIFY COLUMN cgroup_cpu_system_usec CODEC (Delta, ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE team_metrics_gauge_local
+    MODIFY COLUMN timestamp CODEC (ZSTD(1)),
+    MODIFY COLUMN value CODEC (ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE team_metrics_sum_local
+    MODIFY COLUMN timestamp CODEC (ZSTD(1)),
+    MODIFY COLUMN value CODEC (ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE sandbox_metrics_gauge_local
+    MODIFY COLUMN timestamp CODEC (ZSTD(1)),
+    MODIFY COLUMN value CODEC (ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE sandbox_host_stats_local
+    MODIFY COLUMN firecracker_cpu_user_time CODEC (ZSTD(1)),
+    MODIFY COLUMN firecracker_cpu_system_time CODEC (ZSTD(1)),
+    MODIFY COLUMN cgroup_cpu_usage_usec CODEC (ZSTD(1)),
+    MODIFY COLUMN cgroup_cpu_user_usec CODEC (ZSTD(1)),
+    MODIFY COLUMN cgroup_cpu_system_usec CODEC (ZSTD(1));
+-- +goose StatementEnd

--- a/packages/clickhouse/migrations/20260709120000_webhook_bodies_zstd3.sql
+++ b/packages/clickhouse/migrations/20260709120000_webhook_bodies_zstd3.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- Webhook bodies/headers are large, highly compressible JSON payloads.
+-- ZSTD(3) trades a little more CPU for a meaningfully smaller on-disk
+-- footprint than ZSTD(1). Codec-only MODIFY COLUMN (no type/default repeated)
+-- avoids drift with the original column definitions.
+ALTER TABLE webhook_deliveries_local
+    MODIFY COLUMN request_body CODEC (ZSTD(3)),
+    MODIFY COLUMN request_headers CODEC (ZSTD(3)),
+    MODIFY COLUMN response_body CODEC (ZSTD(3)),
+    MODIFY COLUMN response_headers CODEC (ZSTD(3));
+
+-- +goose Down
+ALTER TABLE webhook_deliveries_local
+    MODIFY COLUMN request_body CODEC (ZSTD(1)),
+    MODIFY COLUMN request_headers CODEC (ZSTD(1)),
+    MODIFY COLUMN response_body CODEC (ZSTD(1)),
+    MODIFY COLUMN response_headers CODEC (ZSTD(1));

--- a/packages/clickhouse/pkg/clickhouse.go
+++ b/packages/clickhouse/pkg/clickhouse.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 )
 
 type SandboxQueriesProvider interface {
@@ -32,13 +34,28 @@ type Client struct {
 }
 
 func NewDriver(connectionString string) (driver.Conn, error) {
+	return NewDriverWithFeatureFlags(context.Background(), connectionString, nil)
+}
+
+// NewDriverWithFeatureFlags opens a driver connection with pool sizing read
+// from LaunchDarkly at creation time. ff may be nil, in which case flag
+// fallbacks apply.
+func NewDriverWithFeatureFlags(ctx context.Context, connectionString string, ff *featureflags.Client) (driver.Conn, error) {
 	options, err := clickhouse.ParseDSN(connectionString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse ClickHouse DSN: %w", err)
 	}
 
 	options.MaxOpenConns = 10
-	options.MaxIdleConns = 3
+	// Keep idle conns warm so bursty batcher flushes reuse connections instead
+	// of paying the ClickHouse handshake on each flush. Read once at driver
+	// creation; restart to pick up flag changes.
+	options.MaxIdleConns = featureflags.ClickhouseMaxIdleConns.Fallback()
+	if ff != nil {
+		if n := ff.IntFlag(ctx, featureflags.ClickhouseMaxIdleConns); n > 0 {
+			options.MaxIdleConns = n
+		}
+	}
 
 	conn, err := clickhouse.Open(options)
 	if err != nil {

--- a/packages/clickhouse/pkg/events/delivery.go
+++ b/packages/clickhouse/pkg/events/delivery.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	clickhouse "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -51,6 +52,7 @@ VALUES (
 type ClickhouseDelivery struct {
 	batcher *batcher.Batcher[SandboxEvent]
 	conn    driver.Conn
+	ff      *featureflags.Client
 }
 
 type GatedClickhouseDelivery struct {
@@ -71,7 +73,7 @@ func NewDefaultClickhouseSandboxEventsDelivery(ctx context.Context, conn driver.
 	batcherQueueSize := featureFlags.IntFlag(ctx, featureflags.ClickhouseBatcherQueueSize)
 
 	return NewClickhouseSandboxEventsDelivery(
-		ctx, conn, batcher.BatcherOptions{
+		ctx, conn, featureFlags, batcher.BatcherOptions{
 			Name:         batcherName,
 			MaxBatchSize: maxBatchSize,
 			MaxDelay:     maxDelay,
@@ -87,10 +89,10 @@ func NewGatedDelivery(inner *ClickhouseDelivery, featureFlags *featureflags.Clie
 	return &GatedClickhouseDelivery{ClickhouseDelivery: inner, ff: featureFlags}
 }
 
-func NewClickhouseSandboxEventsDelivery(ctx context.Context, conn driver.Conn, opts batcher.BatcherOptions) (*ClickhouseDelivery, error) {
+func NewClickhouseSandboxEventsDelivery(ctx context.Context, conn driver.Conn, featureFlags *featureflags.Client, opts batcher.BatcherOptions) (*ClickhouseDelivery, error) {
 	var err error
 
-	delivery := &ClickhouseDelivery{conn: conn}
+	delivery := &ClickhouseDelivery{conn: conn, ff: featureFlags}
 	delivery.batcher, err = batcher.NewBatcher(delivery.batchInserter, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create batcher: %w", err)
@@ -152,6 +154,12 @@ func (c *ClickhouseDelivery) batchInserter(ctx context.Context, events []Sandbox
 	attr := trace.WithAttributes(attribute.Int("batch.size", len(events)))
 	ctx, span := tracer.Start(ctx, "Flush sandbox events batch to Clickhouse", attr)
 	defer span.End()
+
+	// Client batches are already large Native blocks, so the server-side async
+	// buffer only adds flush latency. Kill-switch skips it (default keeps it).
+	if c.ff != nil && !c.ff.BoolFlag(ctx, featureflags.ClickhouseBatcherAsyncInsertFlag) {
+		ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{"async_insert": 0}))
+	}
 
 	batch, err := c.conn.PrepareBatch(ctx, InsertSandboxEventQuery, driver.WithReleaseConnection())
 	if err != nil {

--- a/packages/clickhouse/pkg/hoststats/delivery.go
+++ b/packages/clickhouse/pkg/hoststats/delivery.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	clickhouse "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -43,6 +44,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 type ClickhouseDelivery struct {
 	batcher *batcher.Batcher[SandboxHostStat]
 	conn    driver.Conn
+	ff      *featureflags.Client
 }
 
 type GatedClickhouseDelivery struct {
@@ -66,7 +68,7 @@ func NewDefaultClickhouseHostStatsDelivery(
 	batcherQueueSize := featureFlags.IntFlag(ctx, featureflags.ClickhouseBatcherQueueSize)
 
 	return NewClickhouseHostStatsDelivery(
-		ctx, conn, batcher.BatcherOptions{
+		ctx, conn, featureFlags, batcher.BatcherOptions{
 			Name:         batcherName,
 			MaxBatchSize: maxBatchSize,
 			MaxDelay:     maxDelay,
@@ -85,9 +87,10 @@ func NewGatedDelivery(inner *ClickhouseDelivery, featureFlags *featureflags.Clie
 func NewClickhouseHostStatsDelivery(
 	ctx context.Context,
 	conn driver.Conn,
+	featureFlags *featureflags.Client,
 	opts batcher.BatcherOptions,
 ) (*ClickhouseDelivery, error) {
-	delivery := &ClickhouseDelivery{conn: conn}
+	delivery := &ClickhouseDelivery{conn: conn, ff: featureFlags}
 
 	var err error
 	delivery.batcher, err = batcher.NewBatcher(delivery.batchInserter, opts)
@@ -123,6 +126,12 @@ func (c *ClickhouseDelivery) batchInserter(ctx context.Context, stats []SandboxH
 	attrs := trace.WithAttributes(attribute.Int("batch.size", len(stats)))
 	ctx, span := tracer.Start(ctx, "Flush host stats batch to Clickhouse", attrs)
 	defer span.End()
+
+	// Client batches are already large Native blocks, so the server-side async
+	// buffer only adds flush latency. Kill-switch skips it (default keeps it).
+	if c.ff != nil && !c.ff.BoolFlag(ctx, featureflags.ClickhouseBatcherAsyncInsertFlag) {
+		ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{"async_insert": 0}))
+	}
 
 	batch, err := c.conn.PrepareBatch(ctx, InsertSandboxHostStatQuery, driver.WithReleaseConnection())
 	if err != nil {

--- a/packages/clickhouse/pkg/sandbox.go
+++ b/packages/clickhouse/pkg/sandbox.go
@@ -24,6 +24,12 @@ type Metrics struct {
 	DiskUsed       float64   `ch:"disk_used"`
 }
 
+// maxSandboxTTL is an upper bound on how long a sandbox can run. It must stay
+// >= the largest tiers.max_length_hours so a running sandbox's metrics always
+// fall inside the scan window. Used to bound latest-metric lookups instead of
+// sweeping the table's full retention history.
+const maxSandboxTTL = 24 * time.Hour
+
 var latestMetricsSelectQuery = fmt.Sprintf(`
 SELECT sandbox_id,
        team_id,
@@ -39,9 +45,13 @@ SELECT sandbox_id,
 FROM   sandbox_metrics_gauge
 WHERE  sandbox_id IN ?
        AND team_id = ?
+       -- No sandbox runs longer than maxSandboxTTL, so its latest values are
+       -- always inside this window; bound the scan instead of sweeping the
+       -- table's full retention history for argMaxIf.
+       AND timestamp >= now() - INTERVAL %d HOUR
 GROUP  BY sandbox_id,
           team_id; 
-`, telemetry.SandboxCpuTotalGaugeName, telemetry.SandboxCpuUsedGaugeName, telemetry.SandboxRamTotalGaugeName, telemetry.SandboxRamUsedGaugeName, telemetry.SandboxRamCacheGaugeName, telemetry.SandboxDiskTotalGaugeName, telemetry.SandboxDiskUsedGaugeName)
+`, telemetry.SandboxCpuTotalGaugeName, telemetry.SandboxCpuUsedGaugeName, telemetry.SandboxRamTotalGaugeName, telemetry.SandboxRamUsedGaugeName, telemetry.SandboxRamCacheGaugeName, telemetry.SandboxDiskTotalGaugeName, telemetry.SandboxDiskUsedGaugeName, int(maxSandboxTTL.Hours()))
 
 // QueryLatestMetrics returns rows ordered by timestamp, paged by limit.
 func (c *Client) QueryLatestMetrics(ctx context.Context, sandboxIDs []string, teamID string) ([]Metrics, error) {

--- a/packages/orchestrator/pkg/factories/run.go
+++ b/packages/orchestrator/pkg/factories/run.go
@@ -474,7 +474,7 @@ func run(config cfg.Config, opts Options) (success bool) {
 	// the unsuffixed default batcher names to preserve pre-multi-endpoint
 	// behavior and existing dashboards/alerts.
 	if config.ClickhouseConnectionString != "" {
-		clickhouseConn, err := clickhouse.NewDriver(config.ClickhouseConnectionString)
+		clickhouseConn, err := clickhouse.NewDriverWithFeatureFlags(ctx, config.ClickhouseConnectionString, featureFlags)
 		if err != nil {
 			logger.L().Fatal(ctx, "failed to create clickhouse driver", zap.Error(err))
 		}
@@ -538,7 +538,7 @@ func run(config cfg.Config, opts Options) (success bool) {
 				continue
 			}
 
-			clickhouseConn, err := clickhouse.NewDriver(dsn)
+			clickhouseConn, err := clickhouse.NewDriverWithFeatureFlags(ctx, dsn, featureFlags)
 			if err != nil {
 				logger.L().Error(ctx, "failed to create clickhouse driver, skipping endpoint",
 					zap.String("endpoint", label),

--- a/packages/orchestrator/pkg/sandbox/hoststats_collector.go
+++ b/packages/orchestrator/pkg/sandbox/hoststats_collector.go
@@ -21,6 +21,12 @@ type CgroupStatsFunc func(ctx context.Context) (*cgroup.Stats, error)
 
 const hostStatsSamplingInterval = 1 * time.Second
 
+// HostStatsCollector periodically samples a sandbox's cgroup counters and
+// delivers one row per sample with deltas relative to the previous sample.
+// Deltas are computed against the in-memory prev sample only; no baseline row
+// is persisted. prev is seeded at construction with zero counters and
+// Timestamp=now, so the first sample's deltas cover everything accumulated
+// since the sandbox started and its interval_us spans start-to-first-tick.
 type HostStatsCollector struct {
 	metadata    HostStatsMetadata
 	delivery    hoststats.Delivery
@@ -121,26 +127,10 @@ func (h *HostStatsCollector) CollectSample(ctx context.Context) error {
 func (h *HostStatsCollector) Start(ctx context.Context) {
 	defer close(h.stoppedCh)
 
-	// Push the zero baseline as the first row. The first real CollectSample
-	// on the ticker tick will diff against prev (zero counters at prev.Timestamp),
-	// capturing all values accumulated since then without missing anything.
-	initial := hoststats.SandboxHostStat{
-		Timestamp:          h.prev.Timestamp,
-		SandboxID:          h.metadata.SandboxID,
-		SandboxExecutionID: h.metadata.ExecutionID,
-		SandboxTemplateID:  h.metadata.TemplateID,
-		SandboxBuildID:     h.metadata.BuildID,
-		SandboxTeamID:      h.metadata.TeamID,
-		SandboxVCPUCount:   h.metadata.VCPUCount,
-		SandboxMemoryMB:    h.metadata.MemoryMB,
-		SandboxType:        h.metadata.SandboxType.String(),
-	}
-	if err := h.delivery.Push(initial); err != nil {
-		logger.L().Error(ctx, "failed to push initial host stats baseline",
-			logger.WithSandboxID(h.metadata.SandboxID),
-			zap.Error(err))
-	}
-
+	// No baseline row is persisted: the constructor seeds prev with zero
+	// counters at Timestamp=now, so the first CollectSample diffs against it
+	// and captures everything accumulated since start. Persisting the baseline
+	// would only add an all-zeros row (interval_us=0) per sandbox start.
 	ticker := time.NewTicker(hostStatsSamplingInterval)
 	defer ticker.Stop()
 

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -503,6 +503,19 @@ var (
 	// ClickHouse endpoints (CLICKHOUSE_CONNECTION_STRINGS). Default DSN
 	// is unaffected.
 	ClickhouseWriteFanoutFlag = NewBoolFlag("clickhouse-write-fanout", false)
+
+	// ClickhouseMaxIdleConns sets the driver pool's idle connection cap.
+	// Read once at driver creation. Higher values keep connections warm for
+	// bursty batcher flushes instead of paying the handshake on each flush.
+	ClickhouseMaxIdleConns = NewIntFlag("clickhouse-max-idle-conns", 8)
+
+	// ClickhouseBatcherAsyncInsert is a kill-switch for server-side async
+	// inserts on batched app writes. When false, the batchers set
+	// async_insert=0 to skip the server-side async buffer — the client
+	// batches are already large Native blocks, so the extra buffering layer
+	// only adds flush latency. Default true preserves current behavior
+	// (server default async_insert=1).
+	ClickhouseBatcherAsyncInsertFlag = NewBoolFlag("clickhouse-batcher-async-insert", true)
 )
 
 // ResolveFirecrackerVersion resolves the firecracker version using the FirecrackerVersions feature flag.


### PR DESCRIPTION
Low-risk ClickHouse utilization and insert-path optimizations. Single squashed commit, 10 files.

## Why

ClickHouse query log showed the top write load coming from `sandbox_host_stats` (~482k inserts), `sandbox_events` (~364k), and the OTel `metrics_gauge`/`metrics_sum` path (~156k), plus avoidable read scans on hot paths. These are the low-hanging fixes; structural work (`sandbox_events` ORDER BY swap, projection removal) is deferred to follow-up PRs.

## OTel collector (`iac/modules/job-otel-collector/configs/otel-collector.yaml`)
- `batch/clickhouse`: flush every 15s (was 5s) with `send_batch_max_size: 100000` — fewer, larger inserts into `metrics_gauge`/`metrics_sum`.
- `filter/external_metrics`: narrowed `e2b.*` → `^e2b\.(sandbox|team)\..*$`. All 9 currently emitted `e2b.*` metrics match, so this is a no-op today; new `e2b.*` sub-namespaces must be added intentionally. This filter is shared by the ClickHouse, GCP-telemetry, and otel-router pipelines.

## Schema migrations (codec-only `MODIFY COLUMN`, metadata-only, no part rewrites)
- `20260708220300`: `Delta+ZSTD` for timestamps and monotonic cgroup counters, `Gorilla+ZSTD` for float metric values on `team_metrics_gauge_local`, `team_metrics_sum_local`, `sandbox_metrics_gauge_local`, `sandbox_host_stats_local`.
- `20260709120000`: `ZSTD(3)` for `webhook_deliveries_local` bodies/headers (highly compressible JSON, capped at 64KB by the writer).
- Neither migration repeats column types or `DEFAULT` expressions (per review), so they cannot drift from the original definitions.

## Write path
- New kill-switch `clickhouse-batcher-async-insert` (bool, default `true` = current behavior): when flipped to `false`, batched host-stats/events inserts set `async_insert=0`. The Go batchers already send large Native blocks, so the server-side async buffer only adds a 400ms–4s blocking wait per flush on top of client-side batching.
- Removed the persisted all-zeros baseline row per sandbox start (`hoststats_collector.go`): deltas are computed against the in-memory `prev` seed, so the row was write-only noise — one extra insert per sandbox start, and its `interval_us=0` was a divide-by-zero hazard for rate queries.
- New `NewDriverWithFeatureFlags`; idle conn pool cap now comes from LD flag `clickhouse-max-idle-conns` (int, default 8; was hardcoded 3) to avoid native-protocol handshake churn on bursty batcher flushes. `NewDriver` keeps its signature (belt imports it) and uses the fallback.

## Read path
- `QueryLatestMetrics` (hot dashboard path) now bounded by `maxSandboxTTL` (24h) instead of sweeping the table's full retention history for `argMaxIf`. No sandbox outlives this window, so latest values always fall inside it. Invariant: `maxSandboxTTL` must stay ≥ the largest `tiers.max_length_hours`.

## Rollout notes (after merge, LD only — no deploys)
1. Flip `clickhouse-batcher-async-insert=false`.
2. Raise `clickhouse-batcher-max-batch-size` / `clickhouse-batcher-max-delay` (existing flags) together with queue size.
3. Watch `batcher.items.dropped`, `ProfileEvents_InsertQuery`, `InsertedRows`, and async-insert metrics before/after.
