### PR TITLE
docs: align fork IAM documentation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -112,8 +112,9 @@ The control-plane entry point (Gin, OpenAPI-generated from `spec/openapi.yml`, p
   already-authoritative team/sandbox/execution/template IDs; the definitions are passed to the
   orchestrator in `SandboxConfig.iam`. The API mints no credential and delivers nothing into the
   sandbox; file-based delivery is rejected at admission. Definitions are persisted in the
-  running-sandbox (Redis) and paused-snapshot (Postgres) state so they survive pause/resume and
-  orchestrator re-sync; a fork starts a new workload and does not inherit them.
+  running-sandbox (Redis) and paused-snapshot (Postgres) state so they survive pause/resume,
+  orchestrator re-sync, and fork. A fork inherits the definitions from its source snapshot but
+  gets fresh sandbox and execution IDs, so its workload identity is rederived rather than copied.
 - **Placement**: keeps a live map of orchestrator nodes (discovered via Nomad, Kubernetes, or a
   static list). Chooses a node per sandbox with a **best-of-K** algorithm
   (`internal/orchestrator/placement/`): sample K ready nodes, score by CPU

--- a/packages/api/internal/orchestrator/pause_instance_test.go
+++ b/packages/api/internal/orchestrator/pause_instance_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 // TestBuildUpsertSnapshotParams_PreservesIam verifies the sandbox workload
-// identity configuration is written into the paused-sandbox config so it
-// survives a pause/resume cycle through Postgres.
+// identity configuration is written into the paused-sandbox config so the
+// Postgres snapshot supplies it to a later resume or fork.
 func TestBuildUpsertSnapshotParams_PreservesIam(t *testing.T) {
 	t.Parallel()
 

--- a/packages/api/internal/sandbox/sandboxtypes/sandbox.go
+++ b/packages/api/internal/sandbox/sandboxtypes/sandbox.go
@@ -113,7 +113,8 @@ type Sandbox struct {
 	Network                 *types.SandboxNetworkConfig       `json:"network"`
 	VolumeMounts            []*types.SandboxVolumeMountConfig `json:"volumeMounts"`
 	// Iam records the sandbox workload identity configuration. Persisted so it
-	// survives re-sync and is carried into the paused snapshot.
+	// survives re-sync and is carried into the paused snapshot used by resume or
+	// fork.
 	Iam *types.SandboxIam `json:"iam,omitempty"`
 
 	State State `json:"state"`

--- a/packages/db/pkg/types/types.go
+++ b/packages/db/pkg/types/types.go
@@ -149,9 +149,10 @@ type PausedSandboxConfig struct {
 	AutoPauseFilesystemOnly bool `json:"autoPauseFilesystemOnly,omitempty"`
 
 	// Iam preserves the sandbox workload identity configuration across
-	// pause/resume. A resumed sandbox gets a freshly generated execution ID, so
-	// any workload identity is rederived from the current execution rather than a
-	// stored subject. Pre-existing rows omit the key and decode to nil.
+	// pause/resume and fork. A resume gets a fresh execution ID, and a fork gets
+	// fresh sandbox and execution IDs, so identity is rederived from the current
+	// execution rather than a stored subject. Pre-existing rows omit the key and
+	// decode to nil.
 	Iam *SandboxIam `json:"iam,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

- document that sandbox forks inherit IAM token definitions from the source snapshot
- clarify that fresh sandbox and execution IDs cause workload identity to be rederived
- align persistence comments and the snapshot test description with that behavior

## Why

The architecture documentation said forks do not inherit IAM definitions, while the implementation preserves those definitions in the paused snapshot used by both resume and fork. This change aligns the documentation with the reachable behavior; it does not change runtime behavior.

## Validation

- `git diff --check`
- focused IAM tests: 11 passed across handlers, orchestrator, and nodemanager packages

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/e2b-dev/codesmith/infra/pr/3336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787318289&installation_model_id=14389&pr_number=3336&repository=e2b-dev%2Finfra&return_to=https%3A%2F%2Fgithub.com%2Fe2b-dev%2Finfra%2Fpull%2F3336&signature=47527fe251abb2731e95ab263c5127d55b7cba883924df2f2712d9736902dc39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->