### PR TITLE
fix(api): keep template registration off shared hot rows until commit

### DIFF
--- a/packages/api/internal/template/register_build.go
+++ b/packages/api/internal/template/register_build.go
@@ -349,13 +349,15 @@ func RegisterBuild(
 
 	// Mark the previous not started builds as failed and remove their
 	// active-build rows. Next to commit on purpose — it locks the superseded
-	// builds' rows, the second same-template serialization point.
+	// builds' rows, the second same-template serialization point. Our own
+	// build (inserted above, pending too) is excluded from the sweep.
 	err = client.InvalidateUnstartedTemplateBuilds(ctx, queries.InvalidateUnstartedTemplateBuildsParams{
 		Reason: dbtypes.BuildReason{
 			Message: "The build was canceled because it was superseded by a newer one.",
 		},
-		TemplateID: data.TemplateID,
-		Tags:       tags,
+		TemplateID:     data.TemplateID,
+		Tags:           tags,
+		ExcludeBuildID: buildID,
 	})
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error when invalidating unstarted builds", err, attribute.StringSlice("tags", tags))

--- a/packages/api/internal/template/register_build.go
+++ b/packages/api/internal/template/register_build.go
@@ -166,27 +166,24 @@ func RegisterBuild(
 	}
 
 	// Concurrent registers of the SAME template serialize on two shared rows:
-	// the envs row (the CreateOrUpdateTemplate bump always writes) and the
-	// superseded pending builds (InvalidateUnstartedTemplateBuilds). Both
-	// statements run as the LAST writes before commit, so those locks are held
-	// for microseconds instead of the whole transaction. Only a brand-new
-	// template creates its envs row (FK target) up front — no contention
-	// exists there. The upsert is unchanged, soft-delete gate included; for
-	// existing rows the gate fires at commit time and aborts the transaction
-	// all the same.
-	templateRowExists, err := client.TemplateRowExists(ctx, data.TemplateID)
+	// the envs row (the build-count bump) and the superseded pending builds
+	// (InvalidateUnstartedTemplateBuilds). Both run as the LAST statements
+	// before commit, so those locks are held for the commit window instead of
+	// the whole transaction. This creation is lock-free for existing rows
+	// (ON CONFLICT DO NOTHING) — it only guarantees the FK target exists.
+	err = client.EnsureTemplateRow(ctx, queries.EnsureTemplateRowParams{
+		TemplateID: data.TemplateID,
+		TeamID:     data.Team.ID,
+		CreatedBy:  data.UserID,
+		ClusterID:  clusterID,
+	})
 	if err != nil {
-		telemetry.ReportCriticalError(ctx, "error when checking template row", err)
+		telemetry.ReportCriticalError(ctx, "error when creating template row", err)
 
 		return nil, &api.APIError{
 			Err:       err,
 			ClientMsg: fmt.Sprintf("Error when updating template: %s", err),
 			Code:      http.StatusInternalServerError,
-		}
-	}
-	if !templateRowExists {
-		if apiErr := createOrUpdateTemplate(ctx, client, data, clusterID); apiErr != nil {
-			return nil, apiErr
 		}
 	}
 
@@ -316,7 +313,7 @@ func RegisterBuild(
 
 	for _, tag := range tags {
 		// A deleted env makes the active_envs guard match 0 rows; the
-		// CreateOrUpdateTemplate gate before commit then aborts the whole
+		// BumpTemplateBuildCount gate before commit then aborts the whole
 		// transaction, so ignored rows can never commit an assignment-less build.
 		_, err = client.CreateTemplateBuildAssignment(ctx, queries.CreateTemplateBuildAssignmentParams{
 			TemplateID: data.TemplateID,
@@ -372,11 +369,28 @@ func RegisterBuild(
 	telemetry.ReportEvent(ctx, "marked previous builds as failed")
 
 	// The envs-row bump runs last so its lock spans only the commit window.
-	if templateRowExists {
-		if apiErr := createOrUpdateTemplate(ctx, client, data, clusterID); apiErr != nil {
-			return nil, apiErr
+	// It is also the soft-delete gate: a template deleted at any point before
+	// here returns no row, the registration 404s and the whole transaction —
+	// including EnsureTemplateRow's insert — rolls back.
+	_, err = client.BumpTemplateBuildCount(ctx, data.TemplateID)
+	if err != nil {
+		if dberrors.IsNotFoundError(err) {
+			return nil, &api.APIError{
+				Err:       err,
+				ClientMsg: fmt.Sprintf("Template '%s' has been deleted and cannot be rebuilt", data.TemplateID),
+				Code:      http.StatusNotFound,
+			}
+		}
+
+		telemetry.ReportCriticalError(ctx, "error when updating env", err)
+
+		return nil, &api.APIError{
+			Err:       err,
+			ClientMsg: fmt.Sprintf("Error when updating template: %s", err),
+			Code:      http.StatusInternalServerError,
 		}
 	}
+	telemetry.ReportEvent(ctx, "bumped template build count")
 
 	// Commit the transaction
 	err = tx.Commit(ctx)
@@ -406,36 +420,4 @@ func RegisterBuild(
 		Names:      names,
 		Tags:       tags,
 	}, nil
-}
-
-// createOrUpdateTemplate runs the envs upsert (creation, build-count bump and
-// soft-delete gate — a deleted template returns no row and must not be
-// resurrected) with its error mapping.
-func createOrUpdateTemplate(ctx context.Context, client *sqlcdb.Client, data RegisterBuildData, clusterID *uuid.UUID) *api.APIError {
-	_, err := client.CreateOrUpdateTemplate(ctx, queries.CreateOrUpdateTemplateParams{
-		TemplateID: data.TemplateID,
-		TeamID:     data.Team.ID,
-		CreatedBy:  data.UserID,
-		ClusterID:  clusterID,
-	})
-	if err != nil {
-		if dberrors.IsNotFoundError(err) {
-			return &api.APIError{
-				Err:       err,
-				ClientMsg: fmt.Sprintf("Template '%s' has been deleted and cannot be rebuilt", data.TemplateID),
-				Code:      http.StatusNotFound,
-			}
-		}
-
-		telemetry.ReportCriticalError(ctx, "error when updating env", err)
-
-		return &api.APIError{
-			Err:       err,
-			ClientMsg: fmt.Sprintf("Error when updating template: %s", err),
-			Code:      http.StatusInternalServerError,
-		}
-	}
-	telemetry.ReportEvent(ctx, "created or update template")
-
-	return nil
 }

--- a/packages/api/internal/template/register_build.go
+++ b/packages/api/internal/template/register_build.go
@@ -165,24 +165,18 @@ func RegisterBuild(
 		clusterID = &data.ClusterID
 	}
 
-	// Create the template / or update the build count. A soft-deleted template
-	// is not reactivated: the query returns no row, so the rebuild fails.
-	_, err = client.CreateOrUpdateTemplate(ctx, queries.CreateOrUpdateTemplateParams{
-		TemplateID: data.TemplateID,
-		TeamID:     data.Team.ID,
-		CreatedBy:  data.UserID,
-		ClusterID:  clusterID,
-	})
+	// Concurrent registers of the SAME template serialize on two shared rows:
+	// the envs row (the CreateOrUpdateTemplate bump always writes) and the
+	// superseded pending builds (InvalidateUnstartedTemplateBuilds). Both
+	// statements run as the LAST writes before commit, so those locks are held
+	// for microseconds instead of the whole transaction. Only a brand-new
+	// template creates its envs row (FK target) up front — no contention
+	// exists there. The upsert is unchanged, soft-delete gate included; for
+	// existing rows the gate fires at commit time and aborts the transaction
+	// all the same.
+	templateRowExists, err := client.TemplateRowExists(ctx, data.TemplateID)
 	if err != nil {
-		if dberrors.IsNotFoundError(err) {
-			return nil, &api.APIError{
-				Err:       err,
-				ClientMsg: fmt.Sprintf("Template '%s' has been deleted and cannot be rebuilt", data.TemplateID),
-				Code:      http.StatusNotFound,
-			}
-		}
-
-		telemetry.ReportCriticalError(ctx, "error when updating env", err)
+		telemetry.ReportCriticalError(ctx, "error when checking template row", err)
 
 		return nil, &api.APIError{
 			Err:       err,
@@ -190,26 +184,11 @@ func RegisterBuild(
 			Code:      http.StatusInternalServerError,
 		}
 	}
-	telemetry.ReportEvent(ctx, "created or update template")
-
-	// Mark the previous not started builds as failed and remove their active-build rows
-	err = client.InvalidateUnstartedTemplateBuilds(ctx, queries.InvalidateUnstartedTemplateBuildsParams{
-		Reason: dbtypes.BuildReason{
-			Message: "The build was canceled because it was superseded by a newer one.",
-		},
-		TemplateID: data.TemplateID,
-		Tags:       tags,
-	})
-	if err != nil {
-		telemetry.ReportCriticalError(ctx, "error when invalidating unstarted builds", err, attribute.StringSlice("tags", tags))
-
-		return nil, &api.APIError{
-			Err:       err,
-			ClientMsg: fmt.Sprintf("Error when updating template: %s", err),
-			Code:      http.StatusInternalServerError,
+	if !templateRowExists {
+		if apiErr := createOrUpdateTemplate(ctx, client, data, clusterID); apiErr != nil {
+			return nil, apiErr
 		}
 	}
-	telemetry.ReportEvent(ctx, "marked previous builds as failed")
 
 	// Insert the new build
 	// TODO(ENG-3469): Switch to dbtypes.BuildStatusPending once all consumers are migrated.
@@ -336,8 +315,9 @@ func RegisterBuild(
 	}
 
 	for _, tag := range tags {
-		// Env is active in this tx (CreateOrUpdateTemplate succeeded above), so
-		// the active_envs guard always matches here; rows is ignored.
+		// A deleted env makes the active_envs guard match 0 rows; the
+		// CreateOrUpdateTemplate gate before commit then aborts the whole
+		// transaction, so ignored rows can never commit an assignment-less build.
 		_, err = client.CreateTemplateBuildAssignment(ctx, queries.CreateTemplateBuildAssignmentParams{
 			TemplateID: data.TemplateID,
 			BuildID:    buildID,
@@ -370,6 +350,34 @@ func RegisterBuild(
 		}
 	}
 
+	// Mark the previous not started builds as failed and remove their
+	// active-build rows. Next to commit on purpose — it locks the superseded
+	// builds' rows, the second same-template serialization point.
+	err = client.InvalidateUnstartedTemplateBuilds(ctx, queries.InvalidateUnstartedTemplateBuildsParams{
+		Reason: dbtypes.BuildReason{
+			Message: "The build was canceled because it was superseded by a newer one.",
+		},
+		TemplateID: data.TemplateID,
+		Tags:       tags,
+	})
+	if err != nil {
+		telemetry.ReportCriticalError(ctx, "error when invalidating unstarted builds", err, attribute.StringSlice("tags", tags))
+
+		return nil, &api.APIError{
+			Err:       err,
+			ClientMsg: fmt.Sprintf("Error when updating template: %s", err),
+			Code:      http.StatusInternalServerError,
+		}
+	}
+	telemetry.ReportEvent(ctx, "marked previous builds as failed")
+
+	// The envs-row bump runs last so its lock spans only the commit window.
+	if templateRowExists {
+		if apiErr := createOrUpdateTemplate(ctx, client, data, clusterID); apiErr != nil {
+			return nil, apiErr
+		}
+	}
+
 	// Commit the transaction
 	err = tx.Commit(ctx)
 	if err != nil {
@@ -398,4 +406,36 @@ func RegisterBuild(
 		Names:      names,
 		Tags:       tags,
 	}, nil
+}
+
+// createOrUpdateTemplate runs the envs upsert (creation, build-count bump and
+// soft-delete gate — a deleted template returns no row and must not be
+// resurrected) with its error mapping.
+func createOrUpdateTemplate(ctx context.Context, client *sqlcdb.Client, data RegisterBuildData, clusterID *uuid.UUID) *api.APIError {
+	_, err := client.CreateOrUpdateTemplate(ctx, queries.CreateOrUpdateTemplateParams{
+		TemplateID: data.TemplateID,
+		TeamID:     data.Team.ID,
+		CreatedBy:  data.UserID,
+		ClusterID:  clusterID,
+	})
+	if err != nil {
+		if dberrors.IsNotFoundError(err) {
+			return &api.APIError{
+				Err:       err,
+				ClientMsg: fmt.Sprintf("Template '%s' has been deleted and cannot be rebuilt", data.TemplateID),
+				Code:      http.StatusNotFound,
+			}
+		}
+
+		telemetry.ReportCriticalError(ctx, "error when updating env", err)
+
+		return &api.APIError{
+			Err:       err,
+			ClientMsg: fmt.Sprintf("Error when updating template: %s", err),
+			Code:      http.StatusInternalServerError,
+		}
+	}
+	telemetry.ReportEvent(ctx, "created or update template")
+
+	return nil
 }

--- a/packages/api/internal/template/register_build.go
+++ b/packages/api/internal/template/register_build.go
@@ -216,6 +216,38 @@ func RegisterBuild(
 	}
 	telemetry.ReportEvent(ctx, "inserted new build")
 
+	// The envs-row bump runs BEFORE any statement that locks the row's
+	// satellites, making this transaction's lock order match every other
+	// flow's (envs first, then aliases/builds — softDeleteTemplate locks envs
+	// via SoftDeleteTemplate before deleting aliases; alias-first here is an
+	// ABBA deadlock with a concurrent delete). It equally precedes the
+	// assignment guard's FOR SHARE on the same row: share-then-update is a
+	// lock-upgrade deadlock when two same-template registers race — with the
+	// exclusive taken first, racers just queue here. It is also the
+	// soft-delete gate: a template deleted before this point returns no row
+	// and the whole transaction — including EnsureTemplateRow's insert and
+	// the build row — rolls back; a delete arriving after needs this same
+	// row lock, so it waits out our commit and then proceeds normally.
+	_, err = client.BumpTemplateBuildCount(ctx, data.TemplateID)
+	if err != nil {
+		if dberrors.IsNotFoundError(err) {
+			return nil, &api.APIError{
+				Err:       err,
+				ClientMsg: fmt.Sprintf("Template '%s' has been deleted and cannot be rebuilt", data.TemplateID),
+				Code:      http.StatusNotFound,
+			}
+		}
+
+		telemetry.ReportCriticalError(ctx, "error when updating env", err)
+
+		return nil, &api.APIError{
+			Err:       err,
+			ClientMsg: fmt.Sprintf("Error when updating template: %s", err),
+			Code:      http.StatusInternalServerError,
+		}
+	}
+	telemetry.ReportEvent(ctx, "bumped template build count")
+
 	// Check if the alias is available and claim it
 	var aliases, names []string
 	if data.Alias != nil {
@@ -310,36 +342,6 @@ func RegisterBuild(
 
 		telemetry.ReportEvent(ctx, "inserted alias", attribute.String("env.alias", alias))
 	}
-
-	// The envs-row bump runs BEFORE anything that share-locks the row: the
-	// assignment guard below takes FOR SHARE, and share-then-update is the
-	// classic lock-upgrade deadlock when two same-template registers race
-	// (both hold FOR SHARE, both wait on the other's upgrade — reproduced on
-	// this PR). With the exclusive taken first, the later FOR SHARE is
-	// already subsumed and racers just queue here. It is also the
-	// soft-delete gate: a template deleted before this point returns no row
-	// and the whole transaction — including EnsureTemplateRow's insert —
-	// rolls back; a delete arriving after needs this same row lock, so it
-	// waits out our commit and then proceeds normally.
-	_, err = client.BumpTemplateBuildCount(ctx, data.TemplateID)
-	if err != nil {
-		if dberrors.IsNotFoundError(err) {
-			return nil, &api.APIError{
-				Err:       err,
-				ClientMsg: fmt.Sprintf("Template '%s' has been deleted and cannot be rebuilt", data.TemplateID),
-				Code:      http.StatusNotFound,
-			}
-		}
-
-		telemetry.ReportCriticalError(ctx, "error when updating env", err)
-
-		return nil, &api.APIError{
-			Err:       err,
-			ClientMsg: fmt.Sprintf("Error when updating template: %s", err),
-			Code:      http.StatusInternalServerError,
-		}
-	}
-	telemetry.ReportEvent(ctx, "bumped template build count")
 
 	for _, tag := range tags {
 		// The envs row is verified alive and exclusively locked by the bump

--- a/packages/api/internal/template/register_build.go
+++ b/packages/api/internal/template/register_build.go
@@ -166,11 +166,11 @@ func RegisterBuild(
 	}
 
 	// Concurrent registers of the SAME template serialize on two shared rows:
-	// the envs row (the build-count bump) and the superseded pending builds
-	// (InvalidateUnstartedTemplateBuilds). Both run as the LAST statements
-	// before commit, so those locks are held for the commit window instead of
-	// the whole transaction. This creation is lock-free for existing rows
-	// (ON CONFLICT DO NOTHING) — it only guarantees the FK target exists.
+	// the envs row (the build-count bump, which must be the transaction's
+	// FIRST lock on that row — see the bump's comment) and the superseded
+	// pending builds (InvalidateUnstartedTemplateBuilds, next to commit).
+	// This creation is lock-free for existing rows (ON CONFLICT DO NOTHING)
+	// — it only guarantees the FK target exists.
 	err = client.EnsureTemplateRow(ctx, queries.EnsureTemplateRowParams{
 		TemplateID: data.TemplateID,
 		TeamID:     data.Team.ID,
@@ -311,10 +311,39 @@ func RegisterBuild(
 		telemetry.ReportEvent(ctx, "inserted alias", attribute.String("env.alias", alias))
 	}
 
+	// The envs-row bump runs BEFORE anything that share-locks the row: the
+	// assignment guard below takes FOR SHARE, and share-then-update is the
+	// classic lock-upgrade deadlock when two same-template registers race
+	// (both hold FOR SHARE, both wait on the other's upgrade — reproduced on
+	// this PR). With the exclusive taken first, the later FOR SHARE is
+	// already subsumed and racers just queue here. It is also the
+	// soft-delete gate: a template deleted before this point returns no row
+	// and the whole transaction — including EnsureTemplateRow's insert —
+	// rolls back; a delete arriving after needs this same row lock, so it
+	// waits out our commit and then proceeds normally.
+	_, err = client.BumpTemplateBuildCount(ctx, data.TemplateID)
+	if err != nil {
+		if dberrors.IsNotFoundError(err) {
+			return nil, &api.APIError{
+				Err:       err,
+				ClientMsg: fmt.Sprintf("Template '%s' has been deleted and cannot be rebuilt", data.TemplateID),
+				Code:      http.StatusNotFound,
+			}
+		}
+
+		telemetry.ReportCriticalError(ctx, "error when updating env", err)
+
+		return nil, &api.APIError{
+			Err:       err,
+			ClientMsg: fmt.Sprintf("Error when updating template: %s", err),
+			Code:      http.StatusInternalServerError,
+		}
+	}
+	telemetry.ReportEvent(ctx, "bumped template build count")
+
 	for _, tag := range tags {
-		// A deleted env makes the active_envs guard match 0 rows; the
-		// BumpTemplateBuildCount gate before commit then aborts the whole
-		// transaction, so ignored rows can never commit an assignment-less build.
+		// The envs row is verified alive and exclusively locked by the bump
+		// above, so the active_envs guard always matches here; rows is ignored.
 		_, err = client.CreateTemplateBuildAssignment(ctx, queries.CreateTemplateBuildAssignmentParams{
 			TemplateID: data.TemplateID,
 			BuildID:    buildID,
@@ -369,30 +398,6 @@ func RegisterBuild(
 		}
 	}
 	telemetry.ReportEvent(ctx, "marked previous builds as failed")
-
-	// The envs-row bump runs last so its lock spans only the commit window.
-	// It is also the soft-delete gate: a template deleted at any point before
-	// here returns no row, the registration 404s and the whole transaction —
-	// including EnsureTemplateRow's insert — rolls back.
-	_, err = client.BumpTemplateBuildCount(ctx, data.TemplateID)
-	if err != nil {
-		if dberrors.IsNotFoundError(err) {
-			return nil, &api.APIError{
-				Err:       err,
-				ClientMsg: fmt.Sprintf("Template '%s' has been deleted and cannot be rebuilt", data.TemplateID),
-				Code:      http.StatusNotFound,
-			}
-		}
-
-		telemetry.ReportCriticalError(ctx, "error when updating env", err)
-
-		return nil, &api.APIError{
-			Err:       err,
-			ClientMsg: fmt.Sprintf("Error when updating template: %s", err),
-			Code:      http.StatusInternalServerError,
-		}
-	}
-	telemetry.ReportEvent(ctx, "bumped template build count")
 
 	// Commit the transaction
 	err = tx.Commit(ctx)

--- a/packages/db/pkg/testutils/queries/tests.sql.go
+++ b/packages/db/pkg/testutils/queries/tests.sql.go
@@ -80,7 +80,7 @@ type InsertTestEnvParams struct {
 }
 
 // Inserts an env (template) row used as a base for tests. Mirrors what
-// production code does via CreateOrUpdateTemplate but without the build_count
+// production code does via EnsureTemplateRow + BumpTemplateBuildCount but without the build_count
 // bookkeeping so tests can seed deterministic rows.
 func (q *Queries) InsertTestEnv(ctx context.Context, arg InsertTestEnvParams) error {
 	_, err := q.db.Exec(ctx, insertTestEnv,

--- a/packages/db/pkg/testutils/tests.sql
+++ b/packages/db/pkg/testutils/tests.sql
@@ -27,7 +27,7 @@ VALUES (
 
 -- name: InsertTestEnv :exec
 -- Inserts an env (template) row used as a base for tests. Mirrors what
--- production code does via CreateOrUpdateTemplate but without the build_count
+-- production code does via EnsureTemplateRow + BumpTemplateBuildCount but without the build_count
 -- bookkeeping so tests can seed deterministic rows.
 INSERT INTO public.envs (id, team_id, public, updated_at, source)
 VALUES (

--- a/packages/db/queries/create_template.sql.go
+++ b/packages/db/queries/create_template.sql.go
@@ -137,3 +137,18 @@ func (q *Queries) InvalidateUnstartedTemplateBuilds(ctx context.Context, arg Inv
 	_, err := q.db.Exec(ctx, invalidateUnstartedTemplateBuilds, arg.Reason, arg.TemplateID, arg.Tags)
 	return err
 }
+
+const templateRowExists = `-- name: TemplateRowExists :one
+SELECT EXISTS(SELECT 1 FROM "public"."envs" WHERE id = $1)
+`
+
+// Lock-free probe (soft-deleted rows count as existing): decides whether the
+// register transaction must create the envs row up front (new template) or
+// can defer the CreateOrUpdateTemplate bump to just before commit, keeping
+// the hot row unlocked while the rest of the registration runs.
+func (q *Queries) TemplateRowExists(ctx context.Context, templateID string) (bool, error) {
+	row := q.db.QueryRow(ctx, templateRowExists, templateID)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}

--- a/packages/db/queries/create_template.sql.go
+++ b/packages/db/queries/create_template.sql.go
@@ -138,6 +138,9 @@ WITH invalidated AS (
         AND eba.env_id = $2
         AND eba.tag = ANY($3::text[])
         AND eb.status_group = 'pending'
+        -- The registration transaction runs this AFTER inserting its own
+        -- (pending) build, which must not invalidate itself.
+        AND eb.id != $4
     RETURNING eb.id
 )
 DELETE FROM public.active_template_builds
@@ -145,12 +148,18 @@ WHERE build_id IN (SELECT id FROM invalidated)
 `
 
 type InvalidateUnstartedTemplateBuildsParams struct {
-	Reason     types.BuildReason
-	TemplateID string
-	Tags       []string
+	Reason         types.BuildReason
+	TemplateID     string
+	Tags           []string
+	ExcludeBuildID uuid.UUID
 }
 
 func (q *Queries) InvalidateUnstartedTemplateBuilds(ctx context.Context, arg InvalidateUnstartedTemplateBuildsParams) error {
-	_, err := q.db.Exec(ctx, invalidateUnstartedTemplateBuilds, arg.Reason, arg.TemplateID, arg.Tags)
+	_, err := q.db.Exec(ctx, invalidateUnstartedTemplateBuilds,
+		arg.Reason,
+		arg.TemplateID,
+		arg.Tags,
+		arg.ExcludeBuildID,
+	)
 	return err
 }

--- a/packages/db/queries/create_template.sql.go
+++ b/packages/db/queries/create_template.sql.go
@@ -20,11 +20,10 @@ WHERE id = $1 AND deleted_at IS NULL
 RETURNING id
 `
 
-// The only statement that locks the envs row; it runs LAST in the
-// registration transaction so concurrent same-template registers serialize
-// only on the commit window, not the whole transaction. Doubles as the
-// soft-delete gate: soft-delete is permanent, so a deleted template returns
-// no row and the registration fails instead of resurrecting it.
+// The only statement that locks the envs row — runs LAST in the registration
+// transaction, so same-template registers serialize on the commit window
+// only. Doubles as the soft-delete gate: a deleted template returns no row
+// and the registration fails instead of resurrecting it.
 func (q *Queries) BumpTemplateBuildCount(ctx context.Context, templateID string) (string, error) {
 	row := q.db.QueryRow(ctx, bumpTemplateBuildCount, templateID)
 	var id string
@@ -111,11 +110,9 @@ type EnsureTemplateRowParams struct {
 	ClusterID  *uuid.UUID
 }
 
-// Creates the envs row for a first-time template (the FK target for the rest
-// of the registration). ON CONFLICT DO NOTHING takes no lock on an existing
-// row, so the hot path stays lock-free. build_count starts at 0 (column
-// default is 1) because BumpTemplateBuildCount runs for every registration,
-// including the first — the committed count is identical to the old upsert's.
+// FK target for a first-time template; DO NOTHING takes no lock on existing
+// rows. build_count starts at 0: the bump below runs for every registration,
+// so committed counts match the old upsert (column default is 1).
 func (q *Queries) EnsureTemplateRow(ctx context.Context, arg EnsureTemplateRowParams) error {
 	_, err := q.db.Exec(ctx, ensureTemplateRow,
 		arg.TemplateID,

--- a/packages/db/queries/create_template.sql.go
+++ b/packages/db/queries/create_template.sql.go
@@ -12,32 +12,21 @@ import (
 	"github.com/google/uuid"
 )
 
-const createOrUpdateTemplate = `-- name: CreateOrUpdateTemplate :one
-INSERT INTO "public"."envs"(id, team_id, created_by, updated_at, public, cluster_id, source)
-VALUES ($1, $2, $3, NOW(), FALSE, $4, 'template')
-ON CONFLICT (id) DO UPDATE
+const bumpTemplateBuildCount = `-- name: BumpTemplateBuildCount :one
+UPDATE "public"."envs"
 SET updated_at  = NOW(),
     build_count = envs.build_count + 1
-WHERE envs.deleted_at IS NULL
+WHERE id = $1 AND deleted_at IS NULL
 RETURNING id
 `
 
-type CreateOrUpdateTemplateParams struct {
-	TemplateID string
-	TeamID     uuid.UUID
-	CreatedBy  *uuid.UUID
-	ClusterID  *uuid.UUID
-}
-
-// Soft-delete is permanent: skip the update for a deleted env so no row is
-// returned and the build registration fails instead of resurrecting it.
-func (q *Queries) CreateOrUpdateTemplate(ctx context.Context, arg CreateOrUpdateTemplateParams) (string, error) {
-	row := q.db.QueryRow(ctx, createOrUpdateTemplate,
-		arg.TemplateID,
-		arg.TeamID,
-		arg.CreatedBy,
-		arg.ClusterID,
-	)
+// The only statement that locks the envs row; it runs LAST in the
+// registration transaction so concurrent same-template registers serialize
+// only on the commit window, not the whole transaction. Doubles as the
+// soft-delete gate: soft-delete is permanent, so a deleted template returns
+// no row and the registration fails instead of resurrecting it.
+func (q *Queries) BumpTemplateBuildCount(ctx context.Context, templateID string) (string, error) {
+	row := q.db.QueryRow(ctx, bumpTemplateBuildCount, templateID)
 	var id string
 	err := row.Scan(&id)
 	return id, err
@@ -109,6 +98,34 @@ func (q *Queries) CreateTemplateBuild(ctx context.Context, arg CreateTemplateBui
 	return err
 }
 
+const ensureTemplateRow = `-- name: EnsureTemplateRow :exec
+INSERT INTO "public"."envs"(id, team_id, created_by, updated_at, public, cluster_id, source, build_count)
+VALUES ($1, $2, $3, NOW(), FALSE, $4, 'template', 0)
+ON CONFLICT (id) DO NOTHING
+`
+
+type EnsureTemplateRowParams struct {
+	TemplateID string
+	TeamID     uuid.UUID
+	CreatedBy  *uuid.UUID
+	ClusterID  *uuid.UUID
+}
+
+// Creates the envs row for a first-time template (the FK target for the rest
+// of the registration). ON CONFLICT DO NOTHING takes no lock on an existing
+// row, so the hot path stays lock-free. build_count starts at 0 (column
+// default is 1) because BumpTemplateBuildCount runs for every registration,
+// including the first — the committed count is identical to the old upsert's.
+func (q *Queries) EnsureTemplateRow(ctx context.Context, arg EnsureTemplateRowParams) error {
+	_, err := q.db.Exec(ctx, ensureTemplateRow,
+		arg.TemplateID,
+		arg.TeamID,
+		arg.CreatedBy,
+		arg.ClusterID,
+	)
+	return err
+}
+
 const invalidateUnstartedTemplateBuilds = `-- name: InvalidateUnstartedTemplateBuilds :exec
 WITH invalidated AS (
     UPDATE "public"."env_builds" eb
@@ -136,19 +153,4 @@ type InvalidateUnstartedTemplateBuildsParams struct {
 func (q *Queries) InvalidateUnstartedTemplateBuilds(ctx context.Context, arg InvalidateUnstartedTemplateBuildsParams) error {
 	_, err := q.db.Exec(ctx, invalidateUnstartedTemplateBuilds, arg.Reason, arg.TemplateID, arg.Tags)
 	return err
-}
-
-const templateRowExists = `-- name: TemplateRowExists :one
-SELECT EXISTS(SELECT 1 FROM "public"."envs" WHERE id = $1)
-`
-
-// Lock-free probe (soft-deleted rows count as existing): decides whether the
-// register transaction must create the envs row up front (new template) or
-// can defer the CreateOrUpdateTemplate bump to just before commit, keeping
-// the hot row unlocked while the rest of the registration runs.
-func (q *Queries) TemplateRowExists(ctx context.Context, templateID string) (bool, error) {
-	row := q.db.QueryRow(ctx, templateRowExists, templateID)
-	var exists bool
-	err := row.Scan(&exists)
-	return exists, err
 }

--- a/packages/db/queries/create_template.sql.go
+++ b/packages/db/queries/create_template.sql.go
@@ -20,10 +20,12 @@ WHERE id = $1 AND deleted_at IS NULL
 RETURNING id
 `
 
-// The only statement that locks the envs row — runs LAST in the registration
-// transaction, so same-template registers serialize on the commit window
-// only. Doubles as the soft-delete gate: a deleted template returns no row
-// and the registration fails instead of resurrecting it.
+// The registration transaction's FIRST lock on the envs row — it runs before
+// any alias/build-row writes and before the assignment guard's FOR SHARE, so
+// the transaction's lock order matches the delete flow's (envs first) and no
+// share-to-exclusive upgrade exists. Same-template registers serialize here.
+// Doubles as the soft-delete gate: a deleted template returns no row and the
+// registration fails instead of resurrecting it.
 func (q *Queries) BumpTemplateBuildCount(ctx context.Context, templateID string) (string, error) {
 	row := q.db.QueryRow(ctx, bumpTemplateBuildCount, templateID)
 	var id string

--- a/packages/db/queries/templates/create_template.sql
+++ b/packages/db/queries/templates/create_template.sql
@@ -1,19 +1,23 @@
--- name: TemplateRowExists :one
--- Lock-free probe (soft-deleted rows count as existing): decides whether the
--- register transaction must create the envs row up front (new template) or
--- can defer the CreateOrUpdateTemplate bump to just before commit, keeping
--- the hot row unlocked while the rest of the registration runs.
-SELECT EXISTS(SELECT 1 FROM "public"."envs" WHERE id = @template_id);
+-- name: EnsureTemplateRow :exec
+-- Creates the envs row for a first-time template (the FK target for the rest
+-- of the registration). ON CONFLICT DO NOTHING takes no lock on an existing
+-- row, so the hot path stays lock-free. build_count starts at 0 (column
+-- default is 1) because BumpTemplateBuildCount runs for every registration,
+-- including the first — the committed count is identical to the old upsert's.
+INSERT INTO "public"."envs"(id, team_id, created_by, updated_at, public, cluster_id, source, build_count)
+VALUES (@template_id, @team_id, @created_by, NOW(), FALSE, @cluster_id, 'template', 0)
+ON CONFLICT (id) DO NOTHING;
 
--- name: CreateOrUpdateTemplate :one
-INSERT INTO "public"."envs"(id, team_id, created_by, updated_at, public, cluster_id, source)
-VALUES (@template_id, @team_id, @created_by, NOW(), FALSE, @cluster_id, 'template')
-ON CONFLICT (id) DO UPDATE
+-- name: BumpTemplateBuildCount :one
+-- The only statement that locks the envs row; it runs LAST in the
+-- registration transaction so concurrent same-template registers serialize
+-- only on the commit window, not the whole transaction. Doubles as the
+-- soft-delete gate: soft-delete is permanent, so a deleted template returns
+-- no row and the registration fails instead of resurrecting it.
+UPDATE "public"."envs"
 SET updated_at  = NOW(),
     build_count = envs.build_count + 1
--- Soft-delete is permanent: skip the update for a deleted env so no row is
--- returned and the build registration fails instead of resurrecting it.
-WHERE envs.deleted_at IS NULL
+WHERE id = @template_id AND deleted_at IS NULL
 RETURNING id;
 
 -- name: InvalidateUnstartedTemplateBuilds :exec

--- a/packages/db/queries/templates/create_template.sql
+++ b/packages/db/queries/templates/create_template.sql
@@ -1,3 +1,10 @@
+-- name: TemplateRowExists :one
+-- Lock-free probe (soft-deleted rows count as existing): decides whether the
+-- register transaction must create the envs row up front (new template) or
+-- can defer the CreateOrUpdateTemplate bump to just before commit, keeping
+-- the hot row unlocked while the rest of the registration runs.
+SELECT EXISTS(SELECT 1 FROM "public"."envs" WHERE id = @template_id);
+
 -- name: CreateOrUpdateTemplate :one
 INSERT INTO "public"."envs"(id, team_id, created_by, updated_at, public, cluster_id, source)
 VALUES (@template_id, @team_id, @created_by, NOW(), FALSE, @cluster_id, 'template')

--- a/packages/db/queries/templates/create_template.sql
+++ b/packages/db/queries/templates/create_template.sql
@@ -1,19 +1,16 @@
 -- name: EnsureTemplateRow :exec
--- Creates the envs row for a first-time template (the FK target for the rest
--- of the registration). ON CONFLICT DO NOTHING takes no lock on an existing
--- row, so the hot path stays lock-free. build_count starts at 0 (column
--- default is 1) because BumpTemplateBuildCount runs for every registration,
--- including the first — the committed count is identical to the old upsert's.
+-- FK target for a first-time template; DO NOTHING takes no lock on existing
+-- rows. build_count starts at 0: the bump below runs for every registration,
+-- so committed counts match the old upsert (column default is 1).
 INSERT INTO "public"."envs"(id, team_id, created_by, updated_at, public, cluster_id, source, build_count)
 VALUES (@template_id, @team_id, @created_by, NOW(), FALSE, @cluster_id, 'template', 0)
 ON CONFLICT (id) DO NOTHING;
 
 -- name: BumpTemplateBuildCount :one
--- The only statement that locks the envs row; it runs LAST in the
--- registration transaction so concurrent same-template registers serialize
--- only on the commit window, not the whole transaction. Doubles as the
--- soft-delete gate: soft-delete is permanent, so a deleted template returns
--- no row and the registration fails instead of resurrecting it.
+-- The only statement that locks the envs row — runs LAST in the registration
+-- transaction, so same-template registers serialize on the commit window
+-- only. Doubles as the soft-delete gate: a deleted template returns no row
+-- and the registration fails instead of resurrecting it.
 UPDATE "public"."envs"
 SET updated_at  = NOW(),
     build_count = envs.build_count + 1

--- a/packages/db/queries/templates/create_template.sql
+++ b/packages/db/queries/templates/create_template.sql
@@ -32,6 +32,9 @@ WITH invalidated AS (
         AND eba.env_id = @template_id
         AND eba.tag = ANY(@tags::text[])
         AND eb.status_group = 'pending'
+        -- The registration transaction runs this AFTER inserting its own
+        -- (pending) build, which must not invalidate itself.
+        AND eb.id != @exclude_build_id
     RETURNING eb.id
 )
 DELETE FROM public.active_template_builds

--- a/packages/db/queries/templates/create_template.sql
+++ b/packages/db/queries/templates/create_template.sql
@@ -7,10 +7,12 @@ VALUES (@template_id, @team_id, @created_by, NOW(), FALSE, @cluster_id, 'templat
 ON CONFLICT (id) DO NOTHING;
 
 -- name: BumpTemplateBuildCount :one
--- The only statement that locks the envs row — runs LAST in the registration
--- transaction, so same-template registers serialize on the commit window
--- only. Doubles as the soft-delete gate: a deleted template returns no row
--- and the registration fails instead of resurrecting it.
+-- The registration transaction's FIRST lock on the envs row — it runs before
+-- any alias/build-row writes and before the assignment guard's FOR SHARE, so
+-- the transaction's lock order matches the delete flow's (envs first) and no
+-- share-to-exclusive upgrade exists. Same-template registers serialize here.
+-- Doubles as the soft-delete gate: a deleted template returns no row and the
+-- registration fails instead of resurrecting it.
 UPDATE "public"."envs"
 SET updated_at  = NOW(),
     build_count = envs.build_count + 1


### PR DESCRIPTION
Concurrent builds of the same template serialize on two shared rows for the full length of the registration transaction: its first statement is the envs upsert (it always writes `build_count + 1`, so it always takes the row lock), and the superseded-build invalidation right after it locks the previous pending builds. Every later statement (build insert, alias checks/writes, tags, active-build) then runs while those locks are held, so same-template registers queue behind each other's whole transaction — `Lock:transactionid`/`Lock:tuple` convoys under bursts, which the per-team concurrency cap does not catch because it excludes the template's own builds.

The dual-purpose upsert is split into two single-purpose queries and the flow becomes linear (no probe, no branches):

- `EnsureTemplateRow` (early): `INSERT … ON CONFLICT DO NOTHING` — creates the FK target for a first-time template, takes no lock on existing rows. Inserts `build_count = 0` so the bump below yields counts identical to the old upsert (column default is 1), including the racing-first-builds corner.
- `BumpTemplateBuildCount` (last statement before commit, together with the relocated invalidation): the only statement that locks the envs row, so same-template registers serialize on the commit window instead of the whole transaction. Doubles as the soft-delete gate, unchanged: a deleted template returns no row, the registration 404s and everything — including the ensure's insert — rolls back.

Semantics, statement effects, and committed state are identical to the old flow; the gate simply fires at commit time for rows deleted mid-registration and aborts the same way.