### PR TITLE
fix(envd): kick stalled process-output subscribers instead of wedging the fan-out

### DIFF
--- a/packages/envd/internal/services/process/connect.go
+++ b/packages/envd/internal/services/process/connect.go
@@ -27,10 +27,10 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 
 	exitChan := make(chan struct{})
 
-	data, dataCancel := proc.DataEvent.Fork()
+	data, dataKicked, dataCancel := proc.DataEvent.Fork()
 	defer dataCancel()
 
-	end, endCancel := proc.EndEvent.Fork()
+	end, endKicked, endCancel := proc.EndEvent.Fork()
 	defer endCancel()
 
 	streamErr := stream.Send(&rpc.ConnectResponse{
@@ -72,6 +72,10 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 				cancel(ctx.Err())
 
 				return
+			case <-dataKicked:
+				cancel(errSubscriberKicked())
+
+				return
 			case event, ok := <-data:
 				if !ok {
 					break dataLoop
@@ -95,6 +99,10 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 		select {
 		case <-ctx.Done():
 			cancel(ctx.Err())
+
+			return
+		case <-endKicked:
+			cancel(errSubscriberKicked())
 
 			return
 		case event, ok := <-end:

--- a/packages/envd/internal/services/process/handler/multiplex.go
+++ b/packages/envd/internal/services/process/handler/multiplex.go
@@ -4,13 +4,37 @@ import (
 	"slices"
 	"sync"
 	"sync/atomic"
+	"time"
+)
+
+const (
+	// subscriberBuffer smooths bursts so a live subscriber that is briefly
+	// behind is not treated as stalled.
+	subscriberBuffer = 64
+
+	// subscriberSendGrace bounds how long the fan-out loop waits for a
+	// subscriber whose buffer is already full before disconnecting it.
+	//
+	// A subscriber that consumed nothing while a full buffer piled up and
+	// then made no progress for this long is either gone without erroring
+	// (e.g. its TCP connection was restored from a pause snapshot and now
+	// leads nowhere, so writes to it block forever without failing) or is
+	// pathologically slow. Without the bound, one such subscriber blocks
+	// the fan-out loop and no other consumer of the process — including
+	// freshly connected ones — receives output ever again.
+	subscriberSendGrace = 5 * time.Second
 )
 
 // MultiplexedChannel fans out values written to Source to every subscriber
-// obtained via Fork. Each subscriber send is guarded by a done channel so
-// a cancelled consumer can never wedge the fan-out loop.
+// obtained via Fork. Each subscriber send is guarded by a done channel so a
+// cancelled consumer can never wedge the fan-out loop, and bounded by a
+// grace timeout so a stalled consumer that never cancels (e.g. one whose
+// connection died without erroring across a sandbox pause/resume) is
+// disconnected instead of wedging the fan-out loop forever.
 type MultiplexedChannel[T any] struct {
 	Source chan T
+
+	sendGrace time.Duration
 
 	mu       sync.RWMutex
 	channels []*subscriber[T]
@@ -18,9 +42,12 @@ type MultiplexedChannel[T any] struct {
 }
 
 type subscriber[T any] struct {
-	ch   chan T
-	done chan struct{}
-	once sync.Once
+	ch     chan T
+	done   chan struct{}
+	kicked chan struct{}
+
+	once     sync.Once
+	kickOnce sync.Once
 }
 
 // cancel marks the subscriber as gone. Idempotent and non-blocking.
@@ -28,6 +55,16 @@ func (s *subscriber[T]) cancel() {
 	s.once.Do(func() {
 		close(s.done)
 	})
+}
+
+// kick disconnects a subscriber that stopped draining its channel and
+// signals the disconnection on the kicked channel. Idempotent and
+// non-blocking.
+func (s *subscriber[T]) kick() {
+	s.kickOnce.Do(func() {
+		close(s.kicked)
+	})
+	s.cancel()
 }
 
 // isCancelled reports whether cancel has been called.
@@ -41,8 +78,14 @@ func (s *subscriber[T]) isCancelled() bool {
 }
 
 func NewMultiplexedChannel[T any](buffer int) *MultiplexedChannel[T] {
+	return newMultiplexedChannelWithGrace[T](buffer, subscriberSendGrace)
+}
+
+// newMultiplexedChannelWithGrace exists so tests can shorten the kick grace.
+func newMultiplexedChannelWithGrace[T any](buffer int, sendGrace time.Duration) *MultiplexedChannel[T] {
 	c := &MultiplexedChannel[T]{
-		Source: make(chan T, buffer),
+		Source:    make(chan T, buffer),
+		sendGrace: sendGrace,
 	}
 
 	go c.run()
@@ -67,6 +110,11 @@ func (m *MultiplexedChannel[T]) run() {
 			select {
 			case s.ch <- v:
 			case <-s.done:
+			default:
+				// The subscriber's buffer is full. Give it a bounded grace
+				// to make progress, then disconnect it so it cannot block
+				// the fan-out for every other consumer of this process.
+				m.sendWithGrace(s, v)
 			}
 		}
 	}
@@ -84,6 +132,22 @@ func (m *MultiplexedChannel[T]) run() {
 	m.channels = nil
 }
 
+// sendWithGrace waits up to sendGrace for the subscriber to accept v and
+// kicks (disconnects) it when it does not. A slow-but-draining subscriber
+// keeps its backpressure semantics: as long as it frees buffer space at
+// least once per grace period it is never kicked.
+func (m *MultiplexedChannel[T]) sendWithGrace(s *subscriber[T], v T) {
+	timer := time.NewTimer(m.sendGrace)
+	defer timer.Stop()
+
+	select {
+	case s.ch <- v:
+	case <-s.done:
+	case <-timer.C:
+		s.kick()
+	}
+}
+
 // HasSubscribers reports whether any non-cancelled subscriber exists.
 func (m *MultiplexedChannel[T]) HasSubscribers() bool {
 	m.mu.RLock()
@@ -98,14 +162,14 @@ func (m *MultiplexedChannel[T]) HasSubscribers() bool {
 	return false
 }
 
-// Fork registers a new subscriber and returns its channel plus a cancel func.
-// If Source is already closed it returns a pre-closed channel and a no-op cancel.
-func (m *MultiplexedChannel[T]) Fork() (<-chan T, func()) {
+// Fork registers a new subscriber and returns its channel, a channel closed
+// if the subscriber is forcibly disconnected for not consuming events (see
+// subscriberSendGrace), and a cancel func.
+// If Source is already closed it returns a pre-closed channel, a
+// never-closed kicked channel, and a no-op cancel.
+func (m *MultiplexedChannel[T]) Fork() (<-chan T, <-chan struct{}, func()) {
 	if m.exited.Load() {
-		ch := make(chan T)
-		close(ch)
-
-		return ch, func() {}
+		return closedFork[T]()
 	}
 
 	m.mu.Lock()
@@ -113,22 +177,27 @@ func (m *MultiplexedChannel[T]) Fork() (<-chan T, func()) {
 
 	// Re-check under lock in case run() finished between the fast path and here.
 	if m.exited.Load() {
-		ch := make(chan T)
-		close(ch)
-
-		return ch, func() {}
+		return closedFork[T]()
 	}
 
 	s := &subscriber[T]{
-		ch:   make(chan T),
-		done: make(chan struct{}),
+		ch:     make(chan T, subscriberBuffer),
+		done:   make(chan struct{}),
+		kicked: make(chan struct{}),
 	}
 
 	m.channels = append(m.channels, s)
 
-	return s.ch, func() {
+	return s.ch, s.kicked, func() {
 		m.remove(s)
 	}
+}
+
+func closedFork[T any]() (<-chan T, <-chan struct{}, func()) {
+	ch := make(chan T)
+	close(ch)
+
+	return ch, make(chan struct{}), func() {}
 }
 
 // remove unsubscribes s. Safe to call multiple times.

--- a/packages/envd/internal/services/process/handler/multiplex_test.go
+++ b/packages/envd/internal/services/process/handler/multiplex_test.go
@@ -46,8 +46,8 @@ func TestMultiplexedChannel_BasicFanOut(t *testing.T) {
 
 	m := NewMultiplexedChannel[int](1)
 
-	consA, cancelA := m.Fork()
-	consB, cancelB := m.Fork()
+	consA, _, cancelA := m.Fork()
+	consB, _, cancelB := m.Fork()
 	t.Cleanup(cancelA)
 	t.Cleanup(cancelB)
 
@@ -92,7 +92,7 @@ func TestMultiplexedChannel_AbandonedConsumerDoesNotWedgeFanOut(t *testing.T) {
 	m := NewMultiplexedChannel[int](1)
 	t.Cleanup(func() { close(m.Source) })
 
-	abandoned, cancelAbandoned := m.Fork()
+	abandoned, _, cancelAbandoned := m.Fork()
 
 	// Consumer reads one value then exits, modeling a disconnected client.
 	abandonReader := make(chan struct{})
@@ -140,7 +140,7 @@ func TestMultiplexedChannel_AbandonedConsumerDoesNotStarveOthers(t *testing.T) {
 	m := NewMultiplexedChannel[int](1)
 	t.Cleanup(func() { close(m.Source) })
 
-	healthy, cancelHealthy := m.Fork()
+	healthy, _, cancelHealthy := m.Fork()
 	t.Cleanup(cancelHealthy)
 
 	healthyReceived := make(chan int, 16)
@@ -150,7 +150,7 @@ func TestMultiplexedChannel_AbandonedConsumerDoesNotStarveOthers(t *testing.T) {
 		}
 	}()
 
-	abandoned, cancelAbandoned := m.Fork()
+	abandoned, _, cancelAbandoned := m.Fork()
 	go func() {
 		<-abandoned
 	}()
@@ -184,7 +184,7 @@ func TestMultiplexedChannel_CancelIsIdempotentAndPrompt(t *testing.T) {
 
 	m := NewMultiplexedChannel[int](0)
 
-	_, cancel := m.Fork()
+	_, _, cancel := m.Fork()
 
 	// Concurrently push values without anyone draining the consumer chan.
 	stop := make(chan struct{})
@@ -228,7 +228,7 @@ func TestMultiplexedChannel_SourceCloseClosesLiveSubscribers(t *testing.T) {
 
 	m := NewMultiplexedChannel[int](1)
 
-	cons, cancel := m.Fork()
+	cons, _, cancel := m.Fork()
 	t.Cleanup(cancel)
 
 	done := make(chan struct{})
@@ -269,11 +269,113 @@ func TestMultiplexedChannel_ForkAfterSourceCloseReturnsClosedChan(t *testing.T) 
 		time.Sleep(time.Millisecond)
 	}
 
-	cons, cancel := m.Fork()
+	cons, _, cancel := m.Fork()
 	cancel() // must not panic
 
 	_, ok := recvOrTimeout(t, cons, multiplexTestTimeout)
 	assert.False(t, ok, "Fork after shutdown must return a pre-closed channel")
+}
+
+// Regression (#1587): a subscriber that stops draining without cancelling —
+// e.g. its handler goroutine is blocked writing to a connection restored
+// from a pause snapshot that never errors — must be kicked after the send
+// grace instead of wedging the fan-out for every other subscriber.
+func TestMultiplexedChannel_StalledSubscriberIsKickedAndOthersKeepFlowing(t *testing.T) {
+	t.Parallel()
+
+	m := newMultiplexedChannelWithGrace[int](1, 50*time.Millisecond)
+	t.Cleanup(func() { close(m.Source) })
+
+	healthy, _, cancelHealthy := m.Fork()
+	t.Cleanup(cancelHealthy)
+
+	healthyReceived := make(chan int, subscriberBuffer+16)
+	go func() {
+		for v := range healthy {
+			healthyReceived <- v
+		}
+	}()
+
+	// Stalled subscriber: forked but never read.
+	_, stalledKicked, cancelStalled := m.Fork()
+	t.Cleanup(cancelStalled)
+
+	// Fill the stalled subscriber's buffer and push past it. The value that
+	// finds the buffer full waits out the grace once, kicks the subscriber,
+	// and everything after must flow freely.
+	total := subscriberBuffer + 8
+	for i := 1; i <= total; i++ {
+		require.Truef(t,
+			sendOrTimeout(t, m.Source, i, 2*time.Second),
+			"send %d should not be wedged by the stalled subscriber", i,
+		)
+	}
+
+	for i := 1; i <= total; i++ {
+		got, ok := recvOrTimeout(t, healthyReceived, multiplexTestTimeout)
+		require.Truef(t, ok, "healthy subscriber should receive value %d", i)
+		assert.Equal(t, i, got)
+	}
+
+	select {
+	case <-stalledKicked:
+	case <-time.After(multiplexTestTimeout):
+		t.Fatal("stalled subscriber was not kicked")
+	}
+
+	assert.True(t, m.HasSubscribers(),
+		"healthy subscriber should remain after the stalled one is kicked")
+}
+
+// A slow-but-draining subscriber keeps backpressure semantics and is never
+// kicked as long as it makes progress within the send grace.
+func TestMultiplexedChannel_SlowButDrainingSubscriberIsNotKicked(t *testing.T) {
+	t.Parallel()
+
+	m := newMultiplexedChannelWithGrace[int](1, 250*time.Millisecond)
+	t.Cleanup(func() { close(m.Source) })
+
+	slow, slowKicked, cancelSlow := m.Fork()
+	t.Cleanup(cancelSlow)
+
+	total := subscriberBuffer + 8
+	received := make([]int, 0, total)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range total {
+			v, ok := recvOrTimeout(t, slow, 2*time.Second)
+			if !ok {
+				return
+			}
+			received = append(received, v)
+			time.Sleep(2 * time.Millisecond) // slow, but well within the grace
+		}
+	}()
+
+	for i := 1; i <= total; i++ {
+		require.Truef(t,
+			sendOrTimeout(t, m.Source, i, 2*time.Second),
+			"send %d should tolerate a slow subscriber", i,
+		)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("slow subscriber did not receive all values")
+	}
+
+	select {
+	case <-slowKicked:
+		t.Fatal("slow-but-draining subscriber must not be kicked")
+	default:
+	}
+
+	assert.Len(t, received, total)
+	for i, v := range received {
+		assert.Equal(t, i+1, v, "values must arrive in order")
+	}
 }
 
 // Goroutine count must return to baseline after cancelled subscribers settle.
@@ -286,7 +388,7 @@ func TestMultiplexedChannel_NoGoroutineLeakOnAbandon(t *testing.T) { //nolint:pa
 
 	for range wedges {
 		m := NewMultiplexedChannel[int](1)
-		_, cancel := m.Fork()
+		_, _, cancel := m.Fork()
 		// Park one value so fan-out has work, then cancel mid-iteration.
 		m.Source <- 0
 		cancel()

--- a/packages/envd/internal/services/process/service.go
+++ b/packages/envd/internal/services/process/service.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -42,6 +43,16 @@ func Handle(server *chi.Mux, l *zerolog.Logger, defaults *execcontext.Defaults, 
 	server.Mount(path, h)
 
 	return service
+}
+
+// errSubscriberKicked is returned on a process event stream whose consumer
+// stopped draining events and was disconnected by the fan-out loop so it
+// could not block output delivery to the other consumers of the process.
+func errSubscriberKicked() error {
+	return connect.NewError(
+		connect.CodeResourceExhausted,
+		errors.New("process event stream fell too far behind and was disconnected; reconnect to the process to resume streaming"),
+	)
 }
 
 func (s *Service) getProcess(selector *rpc.ProcessSelector) (*handler.Handler, error) {

--- a/packages/envd/internal/services/process/start.go
+++ b/packages/envd/internal/services/process/start.go
@@ -65,10 +65,10 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 	// goroutine has already exited on a cancelled context.
 	start := make(chan rpc.ProcessEvent_Start, 1)
 
-	data, dataCancel := proc.DataEvent.Fork()
+	data, dataKicked, dataCancel := proc.DataEvent.Fork()
 	defer dataCancel()
 
-	end, endCancel := proc.EndEvent.Fork()
+	end, endKicked, endCancel := proc.EndEvent.Fork()
 	defer endCancel()
 
 	go func() {
@@ -115,6 +115,10 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 				cancel(ctx.Err())
 
 				return
+			case <-dataKicked:
+				cancel(errSubscriberKicked())
+
+				return
 			case event, ok := <-data:
 				if !ok {
 					break dataLoop
@@ -138,6 +142,10 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 		select {
 		case <-ctx.Done():
 			cancel(ctx.Err())
+
+			return
+		case <-endKicked:
+			cancel(errSubscriberKicked())
 
 			return
 		case event, ok := <-end:

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.6.10"
+const Version = "0.6.11"


### PR DESCRIPTION
## Problem

`MultiplexedChannel.run()` delivers each event to every subscriber with a send that can block forever when a subscriber is stuck-but-not-cancelled: `select { case s.ch <- v: case <-s.done: }`. A subscriber gets stuck exactly like this when its RPC handler goroutine is blocked inside `stream.Send` on a connection that will never make progress **and never errors** — most commonly a TCP connection restored from a **pause snapshot**: after resume it leads nowhere, writes just hang in retransmission, so the handler never returns, its deferred `dataCancel()` never runs, and the fan-out loop blocks on that subscriber forever.

From that moment, **no consumer of that process receives any output ever again** — including brand-new `commands.connect(pid)` streams. This is the root cause of:

- e2b-dev/E2B#1587 — reattached stdout stream goes silent after sandbox auto-pause/resume (reproduced: every pause → resume → `connect(pid)` cycle stalls, from a fresh process/connection too, so the wedge is server-side)
- e2b-dev/E2B#1352 — `commands.connect` to a resumed sandbox stops delivering stdout after a large response

The same wedge also propagates backwards: once the fan-out blocks, the `Source` buffer fills, the pipe-reader goroutines block, the stdout pipe fills, and the sandboxed process itself blocks on `write(2)`.

## Fix

- Subscriber channels are now **buffered** (64 events) to absorb bursts.
- When a subscriber's buffer is full, the fan-out waits a bounded **5s grace**, then **disconnects that subscriber** (`kick`) instead of blocking everyone. Its stream handler terminates the RPC with `RESOURCE_EXHAUSTED` ("process event stream fell too far behind and was disconnected; reconnect to the process to resume streaming") so a live-but-too-slow client gets an actionable error rather than silence.
- Slow-but-draining subscribers keep backpressure semantics: a subscriber is only kicked after making **zero** progress for the full grace period with a full buffer.
- Ghost subscribers (dead connections) can't receive the error — they're simply detached so everyone else flows; their handler goroutine unblocks whenever the kernel finally errors the connection, same as before.

## Testing

- New unit tests: a stalled subscriber is kicked and other subscribers receive every event; a slow-but-draining subscriber is never kicked and loses nothing. Existing multiplex tests updated for the new `Fork` signature. All `packages/envd` tests pass with `-race`.
- **E2E against a real envd** (debug build in Docker, driven by the Python SDK): a consumer whose `on_stdout` never returns (so it stops reading its connection — the same shape as a snapshot-ghost socket) plus a healthy consumer, then 64MB of process output:
  - **before:** healthy consumer stalls at ~9MB, never recovers (`RESULT: WEDGED`)
  - **after:** healthy consumer receives all 65,536,008 bytes (`RESULT: OK`), stuck consumer is kicked after the 5s grace

## Notes

- envd version bumped 0.6.10 → 0.6.11.
- Client-side complement (Python SDK abandoning HTTP/2 streams without `RST_STREAM`, which manufactures such dead subscribers even without pause/resume) is fixed separately in e2b-dev/E2B (RST_STREAM on early stream close).
- Not addressed here (possible follow-ups): proactively detaching all pre-snapshot stream consumers on resume, and TCP_USER_TIMEOUT on envd connections so blackholed sockets error out in seconds instead of minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)