### PR TITLE
fix(envd): serve procfs/sysfs files on identity download path

### DIFF
--- a/packages/envd/internal/api/download.go
+++ b/packages/envd/internal/api/download.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"compress/gzip"
 	"errors"
 	"fmt"
@@ -15,6 +16,11 @@ import (
 	"github.com/e2b-dev/infra/packages/envd/internal/logs"
 	"github.com/e2b-dev/infra/packages/envd/internal/permissions"
 )
+
+// Virtual files (procfs, sysfs) report stat size 0 even though reading them
+// yields content. Files reporting size 0 are buffered up to this cap so they
+// can be served with a correct Content-Length.
+const zeroSizeFileBufferLimit = 16 << 20 // 16 MiB
 
 func (a *API) GetFiles(w http.ResponseWriter, r *http.Request, params GetFilesParams) {
 	defer r.Body.Close()
@@ -164,6 +170,46 @@ func (a *API) GetFiles(w http.ResponseWriter, r *http.Request, params GetFilesPa
 		_, err = io.Copy(gw, file)
 		if err != nil {
 			a.logger.Error().Err(err).Str(string(logs.OperationIDKey), operationID).Msg("error writing gzip response")
+		}
+
+		return
+	}
+
+	// http.ServeContent sizes the response by seeking to the end of the file,
+	// so virtual files (procfs, sysfs) that report stat size 0 would get an
+	// empty body. Buffer them to serve the real content with a correct length.
+	if stat.Size() == 0 {
+		buffered, readErr := io.ReadAll(io.LimitReader(file, zeroSizeFileBufferLimit+1))
+		if readErr != nil {
+			errMsg = fmt.Errorf("error reading file '%s': %w", resolvedPath, readErr)
+			errorCode = http.StatusInternalServerError
+			jsonError(w, errorCode, errMsg)
+
+			return
+		}
+
+		if len(buffered) <= zeroSizeFileBufferLimit {
+			http.ServeContent(w, r, path, stat.ModTime(), bytes.NewReader(buffered))
+
+			return
+		}
+
+		// The file outgrew the buffer cap; stream the rest without a known
+		// length, like the gzip path does.
+		contentType := mime.TypeByExtension(filepath.Ext(path))
+		if contentType == "" {
+			contentType = http.DetectContentType(buffered)
+		}
+		w.Header().Set("Content-Type", contentType)
+
+		if _, err := w.Write(buffered); err != nil {
+			a.logger.Error().Err(err).Str(string(logs.OperationIDKey), operationID).Msg("error writing response")
+
+			return
+		}
+
+		if _, err := io.Copy(w, file); err != nil {
+			a.logger.Error().Err(err).Str(string(logs.OperationIDKey), operationID).Msg("error writing response")
 		}
 
 		return

--- a/packages/envd/internal/api/download_test.go
+++ b/packages/envd/internal/api/download_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -257,6 +259,138 @@ func TestGetFiles_GzipDownload(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, originalContent, decompressed)
+}
+
+func TestGetFiles_IdentityDownload_EmptyFile(t *testing.T) {
+	t.Parallel()
+
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+	tempFile := filepath.Join(tempDir, "empty.txt")
+	err = os.WriteFile(tempFile, nil, 0o644)
+	require.NoError(t, err)
+
+	logger := zerolog.Nop()
+	defaults := &execcontext.Defaults{
+		EnvVars: utils.NewEnvVars(),
+		User:    currentUser.Username,
+	}
+	api := New(&logger, defaults, nil, false, cgroups.NewNoopManager())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/files?path="+url.QueryEscape(tempFile), nil)
+	w := httptest.NewRecorder()
+
+	params := GetFilesParams{
+		Path:     &tempFile,
+		Username: &currentUser.Username,
+	}
+	api.GetFiles(w, req, params)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "0", resp.Header.Get("Content-Length"))
+	assert.Empty(t, body)
+}
+
+// Virtual files (procfs, sysfs) report stat size 0 but yield content when
+// read. The identity path must serve their real content, not an empty body.
+func TestGetFiles_IdentityDownload_VirtualFile(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("procfs is only available on Linux")
+	}
+
+	virtualFile := "/proc/version"
+
+	stat, err := os.Stat(virtualFile)
+	require.NoError(t, err)
+	if stat.Size() != 0 {
+		t.Skipf("expected %s to report stat size 0, got %d", virtualFile, stat.Size())
+	}
+
+	expectedContent, err := os.ReadFile(virtualFile)
+	require.NoError(t, err)
+	require.NotEmpty(t, expectedContent)
+
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	logger := zerolog.Nop()
+	defaults := &execcontext.Defaults{
+		EnvVars: utils.NewEnvVars(),
+		User:    currentUser.Username,
+	}
+	api := New(&logger, defaults, nil, false, cgroups.NewNoopManager())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/files?path="+url.QueryEscape(virtualFile), nil)
+	w := httptest.NewRecorder()
+
+	params := GetFilesParams{
+		Path:     &virtualFile,
+		Username: &currentUser.Username,
+	}
+	api.GetFiles(w, req, params)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, expectedContent, body)
+	assert.Equal(t, strconv.Itoa(len(expectedContent)), resp.Header.Get("Content-Length"))
+}
+
+func TestGetFiles_IdentityRangeDownload_VirtualFile(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("procfs is only available on Linux")
+	}
+
+	virtualFile := "/proc/version"
+
+	expectedContent, err := os.ReadFile(virtualFile)
+	require.NoError(t, err)
+	require.Greater(t, len(expectedContent), 5)
+
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	logger := zerolog.Nop()
+	defaults := &execcontext.Defaults{
+		EnvVars: utils.NewEnvVars(),
+		User:    currentUser.Username,
+	}
+	api := New(&logger, defaults, nil, false, cgroups.NewNoopManager())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/files?path="+url.QueryEscape(virtualFile), nil)
+	req.Header.Set("Range", "bytes=0-4")
+	w := httptest.NewRecorder()
+
+	params := GetFilesParams{
+		Path:     &virtualFile,
+		Username: &currentUser.Username,
+	}
+	api.GetFiles(w, req, params)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusPartialContent, resp.StatusCode)
+	assert.Equal(t, expectedContent[:5], body)
 }
 
 func TestPostFiles_GzipUpload(t *testing.T) {

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.6.10"
+const Version = "0.6.11"


### PR DESCRIPTION
Fixes #3363

## Problem

`GET /files` returned an empty 200 for procfs/sysfs files (e.g. `/proc/sys/kernel/random/boot_id`) unless the client negotiated gzip. Virtual files report stat size 0 even though reading them yields content, and the identity path delegates to `http.ServeContent`, which sizes the response by seeking to the end of the file — so it set `Content-Length: 0` and copied zero bytes. The gzip path streams with `io.Copy` and was unaffected, which is why undici/httpx-based SDKs worked by accident while Cloudflare Workers `fetch` and plain `curl`/`wget` silently read virtual files as empty.

## Fix

On the identity path, when `stat.Size() == 0`, buffer the file (capped at 16 MiB) and serve it via `http.ServeContent` with a `bytes.Reader`:

- genuinely empty files still get a correct `Content-Length: 0`
- virtual files get their real content and a correct length
- Range/conditional semantics are preserved (verified by a 206 test against `/proc/version`)
- files that outgrow the cap (e.g. unbounded virtual files) are streamed without a known length, matching the existing gzip-path behavior

Also bumps the envd version to 0.6.11 per the behavioral-change policy.

## Testing

- New unit tests: identity download of an empty regular file (regression guard), identity download of `/proc/version` (Linux-only), and a Range request against `/proc/version` (Linux-only).
- Verified the virtual-file test fails against the old code with exactly the reported symptom (empty body) and passes with the fix, in a Linux container.
- Full `packages/envd` test suite passes on Linux (docker, `golang:1.26`) and macOS; `make lint` and `make fmt` are clean for the touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)