### PR TITLE
fix(proxy): CORS on edge-synthesized sandbox errors

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,7 +160,10 @@ Key mechanisms (all under `pkg/sandbox/`):
   (with SNI/Host-inspecting TCP firewall for domain allow/deny lists). Slots are pooled and
   reused; slot allocation is coordinated through Consul KV.
 - **Sandbox proxy** (:5007, `pkg/proxy/`): reverse-proxies incoming traffic from client-proxy to
-  the sandbox's slot IP and requested port, enforcing per-sandbox traffic access tokens.
+  the sandbox's slot IP and requested port, enforcing per-sandbox traffic access tokens. A live
+  sandbox answers CORS itself (envd allows all origins); when the sandbox is missing or
+  unreachable the proxy synthesizes the response instead, so it carries its own CORS headers
+  and answers preflights (`pkg/proxy/cors/`) — otherwise a browser would hide the error from JS.
 - Writes sandbox lifecycle **events** and cgroup **host stats** to ClickHouse; exports metrics via
   OTel. Sandbox and template-build log writes go through a flag-resolved HTTP route: the legacy
   collector remains the fallback primary destination, and configured shadow destinations can mirror

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -163,7 +163,8 @@ Key mechanisms (all under `pkg/sandbox/`):
   the sandbox's slot IP and requested port, enforcing per-sandbox traffic access tokens. A live
   sandbox answers CORS itself (envd allows all origins); when the sandbox is missing or
   unreachable the proxy synthesizes the response instead, so it carries its own CORS headers
-  and answers preflights (`pkg/proxy/cors/`) — otherwise a browser would hide the error from JS.
+  and answers preflights (`packages/shared/pkg/proxy/cors/`) — otherwise a browser would hide the
+  error from JS.
 - Writes sandbox lifecycle **events** and cgroup **host stats** to ClickHouse; exports metrics via
   OTel. Sandbox and template-build log writes go through a flag-resolved HTTP route: the legacy
   collector remains the fallback primary destination, and configured shadow destinations can mirror

--- a/packages/shared/pkg/proxy/cors/cors.go
+++ b/packages/shared/pkg/proxy/cors/cors.go
@@ -1,0 +1,62 @@
+// Package cors adds CORS headers to responses the proxy synthesizes itself.
+//
+// Responses produced by a live sandbox get their CORS headers from envd. When
+// the sandbox is gone, or the proxy cannot reach it, the proxy answers instead —
+// and without these headers the browser hands JS an opaque network error rather
+// than the status and body we generated.
+package cors
+
+import "net/http"
+
+// preflightMaxAge is how long a browser may cache a preflight result. Browsers
+// clamp this to their own ceiling (Chrome caps it at 2 hours).
+const preflightMaxAge = "86400"
+
+// SetHeaders marks a response as readable by browser JS from any origin.
+//
+// These endpoints do not rely on cookies, so no Access-Control-Allow-Credentials
+// is sent; note that credentialed requests and the "*" origin are mutually
+// exclusive if that ever changes.
+func SetHeaders(w http.ResponseWriter) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Add("Vary", "Origin")
+}
+
+// Error replies with a plain-text error like http.Error, plus the CORS headers
+// without which a browser hides the status and body from JS.
+func Error(w http.ResponseWriter, message string, code int) {
+	SetHeaders(w)
+	http.Error(w, message, code)
+}
+
+// isPreflight reports whether r is a CORS preflight request. A bare OPTIONS is
+// an ordinary request and has to be answered as one.
+func isPreflight(r *http.Request) bool {
+	return r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != ""
+}
+
+// HandlePreflight answers a CORS preflight request and reports whether it did.
+//
+// A browser only honors a preflight response with an ok status, so an error
+// response can never satisfy one: the browser rejects the preflight and never
+// sends the real request, hiding the very error we were trying to report. Use
+// this on paths that would otherwise answer with an error status.
+func HandlePreflight(w http.ResponseWriter, r *http.Request) bool {
+	if !isPreflight(r) {
+		return false
+	}
+
+	SetHeaders(w)
+	w.Header().Set("Access-Control-Allow-Methods", "*")
+	// Echo whatever the browser asked for. The CORS-safelist is fixed by the
+	// Fetch standard, so a server cannot opt out of preflights for its own
+	// headers — X-Access-Token, Connect-Protocol-Version and the routing headers
+	// all force one.
+	if headers := r.Header.Get("Access-Control-Request-Headers"); headers != "" {
+		w.Header().Set("Access-Control-Allow-Headers", headers)
+	}
+	w.Header().Set("Access-Control-Max-Age", preflightMaxAge)
+	w.WriteHeader(http.StatusNoContent)
+
+	return true
+}

--- a/packages/shared/pkg/proxy/cors/cors_test.go
+++ b/packages/shared/pkg/proxy/cors/cors_test.go
@@ -1,0 +1,84 @@
+package cors
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlePreflight(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodOptions, "/health", nil)
+	r.Header.Set("Origin", "https://app.example.com")
+	r.Header.Set("Access-Control-Request-Method", "GET")
+	r.Header.Set("Access-Control-Request-Headers", "e2b-sandbox-id,e2b-sandbox-port")
+	w := httptest.NewRecorder()
+
+	require.True(t, HandlePreflight(w, r))
+
+	// A preflight is only honored by the browser with an ok status.
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "e2b-sandbox-id,e2b-sandbox-port", w.Header().Get("Access-Control-Allow-Headers"))
+	assert.Equal(t, preflightMaxAge, w.Header().Get("Access-Control-Max-Age"))
+	assert.Equal(t, "Origin", w.Header().Get("Vary"))
+}
+
+func TestHandlePreflightWithoutRequestedHeaders(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodOptions, "/health", nil)
+	r.Header.Set("Access-Control-Request-Method", "GET")
+	w := httptest.NewRecorder()
+
+	require.True(t, HandlePreflight(w, r))
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Empty(t, w.Header().Values("Access-Control-Allow-Headers"))
+}
+
+func TestHandlePreflightIgnoresNonPreflights(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name   string
+		method string
+		// A bare OPTIONS without Access-Control-Request-Method is not a preflight,
+		// so it has to fall through to the caller's own error handling.
+		requestMethodHeader string
+	}{
+		{name: "GET", method: http.MethodGet},
+		{name: "GET with request method header", method: http.MethodGet, requestMethodHeader: "GET"},
+		{name: "bare OPTIONS", method: http.MethodOptions},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := httptest.NewRequestWithContext(t.Context(), tt.method, "/health", nil)
+			if tt.requestMethodHeader != "" {
+				r.Header.Set("Access-Control-Request-Method", tt.requestMethodHeader)
+			}
+			w := httptest.NewRecorder()
+
+			assert.False(t, HandlePreflight(w, r))
+			assert.Empty(t, w.Header(), "the response must be left untouched")
+			assert.Empty(t, w.Body.String())
+		})
+	}
+}
+
+func TestError(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	Error(w, "Invalid sandbox port", http.StatusBadRequest)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "Invalid sandbox port\n", w.Body.String())
+}

--- a/packages/shared/pkg/proxy/cors_test.go
+++ b/packages/shared/pkg/proxy/cors_test.go
@@ -1,18 +1,21 @@
 package proxy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg/connlimit"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/pool"
 )
@@ -59,6 +62,53 @@ func TestHandlerDoesNotShortCircuitBareOptions(t *testing.T) {
 	assert.JSONEq(t,
 		`{"sandboxId":"im9r2ycjiy2534qsdy1oo","message":"The sandbox was not found","code":502}`,
 		w.Body.String())
+}
+
+// The connection limit is reached only when the sandbox resolved, so it sits
+// past the handler's err != nil preflight check and needs its own. The 429 it
+// would otherwise answer with is not an ok status, so the browser would reject
+// the preflight and JS would never get to read the limit it hit.
+func TestHandlerAnswersPreflightForConnectionLimitedSandbox(t *testing.T) {
+	t.Parallel()
+
+	var blocked atomic.Int64
+	connLimitConfig := &ConnectionLimitConfig{
+		Limiter:             connlimit.NewConnectionLimiter(),
+		GetMaxLimit:         func(context.Context) int { return 0 },
+		OnConnectionBlocked: func(context.Context) { blocked.Add(1) },
+	}
+	h := handler(nil, func(*http.Request) (*pool.Destination, error) {
+		return &pool.Destination{
+			SandboxId:     "im9r2ycjiy2534qsdy1oo",
+			RequestLogger: logger.NewNopLogger(),
+			ConnectionKey: "limited",
+		}, nil
+	}, connLimitConfig)
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodOptions, "/health", nil)
+	r.Header.Set("Origin", "https://app.example.com")
+	r.Header.Set("Access-Control-Request-Method", "GET")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	// Answering the preflight never reaches the sandbox, so no connection was
+	// blocked and the metric must not claim otherwise.
+	assert.Zero(t, blocked.Load())
+
+	// The real request that follows still gets the limit error, with the headers
+	// that let JS read it.
+	r = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
+	r.Header.Set("Origin", "https://app.example.com")
+	w = httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, int64(1), blocked.Load())
 }
 
 // The raw http.Error paths are equally unreadable from a browser, so they carry

--- a/packages/shared/pkg/proxy/cors_test.go
+++ b/packages/shared/pkg/proxy/cors_test.go
@@ -1,0 +1,234 @@
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/pool"
+)
+
+// unroutableHandler is the handler as it behaves when the sandbox cannot be
+// resolved, which is the only path where the proxy answers on its own behalf.
+func unroutableHandler(err error) http.HandlerFunc {
+	return handler(nil, func(*http.Request) (*pool.Destination, error) { return nil, err }, nil)
+}
+
+// Without this, the browser rejects the preflight and never sends the request
+// the error was meant for, so JS sees an opaque network error instead of the
+// status telling it the sandbox is gone.
+func TestHandlerAnswersPreflightForMissingSandbox(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodOptions, "/health", nil)
+	r.Header.Set("Origin", "https://app.example.com")
+	r.Header.Set("Access-Control-Request-Method", "GET")
+	r.Header.Set("Access-Control-Request-Headers", "e2b-sandbox-id,e2b-sandbox-port")
+	w := httptest.NewRecorder()
+
+	unroutableHandler(NewErrSandboxNotFound("im9r2ycjiy2534qsdy1oo")).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "e2b-sandbox-id,e2b-sandbox-port", w.Header().Get("Access-Control-Allow-Headers"))
+	assert.Empty(t, w.Body.String())
+}
+
+// A bare OPTIONS is a normal request, not a preflight, so it must still get the
+// error the sandbox lookup produced.
+func TestHandlerDoesNotShortCircuitBareOptions(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodOptions, "/health", nil)
+	w := httptest.NewRecorder()
+
+	unroutableHandler(NewErrSandboxNotFound("im9r2ycjiy2534qsdy1oo")).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.JSONEq(t,
+		`{"sandboxId":"im9r2ycjiy2534qsdy1oo","message":"The sandbox was not found","code":502}`,
+		w.Body.String())
+}
+
+// The raw http.Error paths are equally unreadable from a browser, so they carry
+// the headers too.
+func TestHandlerSetsCORSHeadersOnRawErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name       string
+		err        error
+		statusCode int
+	}{
+		{name: "invalid host", err: ErrInvalidHost, statusCode: http.StatusBadRequest},
+		{name: "invalid sandbox ID", err: ErrInvalidSandboxID, statusCode: http.StatusBadRequest},
+		{name: "missing header", err: MissingHeaderError{}, statusCode: http.StatusBadRequest},
+		{name: "invalid sandbox port", err: &InvalidSandboxPortError{Port: "abc"}, statusCode: http.StatusBadRequest},
+		{name: "unexpected", err: assert.AnError, statusCode: http.StatusInternalServerError},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
+			r.Header.Set("Origin", "https://app.example.com")
+			w := httptest.NewRecorder()
+
+			unroutableHandler(tt.err).ServeHTTP(w, r)
+
+			require.Equal(t, tt.statusCode, w.Code)
+			assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+		})
+	}
+}
+
+// response is what a browser gets to see about a proxy-synthesized reply: the
+// status and the headers, which is all these tests assert on.
+type response struct {
+	statusCode int
+	header     http.Header
+}
+
+func do(t *testing.T, r *http.Request) response {
+	t.Helper()
+
+	resp, err := http.DefaultClient.Do(r)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	return response{statusCode: resp.StatusCode, header: resp.Header}
+}
+
+func preflight(t *testing.T, port uint) response {
+	t.Helper()
+
+	r, err := http.NewRequestWithContext(t.Context(), http.MethodOptions, fmt.Sprintf("http://127.0.0.1:%d/health", port), nil)
+	require.NoError(t, err)
+	r.Header.Set("Origin", "https://app.example.com")
+	r.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	r.Header.Set("Access-Control-Request-Headers", "e2b-sandbox-id,e2b-sandbox-port")
+
+	return do(t, r)
+}
+
+func crossOriginGet(t *testing.T, port uint) response {
+	t.Helper()
+
+	r, err := http.NewRequestWithContext(t.Context(), http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/health", port), nil)
+	require.NoError(t, err)
+	r.Header.Set("Origin", "https://app.example.com")
+	r.Header.Set("Sec-Fetch-Mode", "cors")
+
+	return do(t, r)
+}
+
+// Reproduces the browser's two-step exchange against a missing sandbox: the
+// preflight must be ok or the browser never sends the GET whose 502 is the whole
+// answer the SDK is after.
+func TestProxyCORSForMissingSandbox(t *testing.T) {
+	t.Parallel()
+
+	proxy, port, err := newTestProxy(t, func(*http.Request) (*pool.Destination, error) {
+		return nil, NewErrSandboxNotFound("test-sandbox")
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { proxy.Close() })
+
+	resp := preflight(t, port)
+	assert.Equal(t, http.StatusNoContent, resp.statusCode)
+	assert.Equal(t, "*", resp.header.Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "e2b-sandbox-id,e2b-sandbox-port", resp.header.Get("Access-Control-Allow-Headers"))
+
+	resp = crossOriginGet(t, port)
+	assert.Equal(t, http.StatusBadGateway, resp.statusCode)
+	assert.Equal(t, "*", resp.header.Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "application/json; charset=utf-8", resp.header.Get("Content-Type"))
+}
+
+// Same for a sandbox that resolves but cannot be reached, which is answered by
+// the pool's error handler instead.
+func TestProxyCORSForUnreachableSandbox(t *testing.T) {
+	t.Parallel()
+
+	var lisCfg net.ListenConfig
+	listener, err := lisCfg.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	backend, err := newTestBackend(listener, "backend-1")
+	require.NoError(t, err)
+	// Nothing is listening on the backend address any more.
+	backend.Close()
+
+	proxy, port, err := newTestProxy(t, func(*http.Request) (*pool.Destination, error) {
+		return &pool.Destination{
+			Url:                backend.url,
+			SandboxId:          "test-sandbox",
+			SandboxPort:        3000,
+			RequestLogger:      logger.NewNopLogger(),
+			ConnectionKey:      backend.id,
+			DefaultToPortError: true,
+		}, nil
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { proxy.Close() })
+
+	resp := preflight(t, port)
+	assert.Equal(t, http.StatusNoContent, resp.statusCode)
+	assert.Equal(t, "*", resp.header.Get("Access-Control-Allow-Origin"))
+
+	resp = crossOriginGet(t, port)
+	assert.Equal(t, http.StatusBadGateway, resp.statusCode)
+	assert.Equal(t, "*", resp.header.Get("Access-Control-Allow-Origin"))
+}
+
+// A live sandbox sends its own CORS headers, so the proxy must not add a second
+// value — a browser rejects a response carrying two Access-Control-Allow-Origin
+// headers just as it rejects one carrying none.
+func TestProxyDoesNotDuplicateSandboxCORSHeaders(t *testing.T) {
+	t.Parallel()
+
+	var lisCfg net.ListenConfig
+	listener, err := lisCfg.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET")
+			w.WriteHeader(http.StatusNoContent)
+		}),
+		ReadHeaderTimeout: time.Second,
+	}
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Logf("backend server: %v", err)
+		}
+	}()
+	t.Cleanup(func() { server.Close() })
+
+	backendURL := &url.URL{Scheme: "http", Host: listener.Addr().String()}
+	proxy, port, err := newTestProxy(t, func(*http.Request) (*pool.Destination, error) {
+		return &pool.Destination{
+			Url:           backendURL,
+			SandboxId:     "test-sandbox",
+			RequestLogger: logger.NewNopLogger(),
+			ConnectionKey: "live",
+		}, nil
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { proxy.Close() })
+
+	for _, resp := range []response{preflight(t, port), crossOriginGet(t, port)} {
+		assert.Equal(t, []string{"*"}, resp.header.Values("Access-Control-Allow-Origin"))
+		assert.Equal(t, []string{"GET"}, resp.header.Values("Access-Control-Allow-Methods"))
+	}
+}

--- a/packages/shared/pkg/proxy/handler.go
+++ b/packages/shared/pkg/proxy/handler.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/cors"
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/pool"
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/template"
 )
@@ -18,24 +19,36 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 		ctx := r.Context()
 		d, err := getDestination(r)
 
+		// Every error below answers with an error status, which a browser refuses
+		// to accept as a preflight result — it would then never send the request
+		// the error was meant for. Answer the preflight and let the real request
+		// carry the error.
+		if err != nil && cors.HandlePreflight(w, r) {
+			logger.L().Debug(ctx, "answered CORS preflight for unroutable request",
+				zap.Error(err),
+				zap.String("host", r.Host))
+
+			return
+		}
+
 		var mhe MissingHeaderError
 		if errors.As(err, &mhe) {
 			logger.L().Warn(ctx, "missing header", zap.Error(mhe))
-			http.Error(w, "missing header", http.StatusBadRequest)
+			cors.Error(w, "missing header", http.StatusBadRequest)
 
 			return
 		}
 
 		if errors.Is(err, ErrInvalidHost) {
 			logger.L().Warn(ctx, "invalid host", zap.String("host", r.Host))
-			http.Error(w, "Invalid host", http.StatusBadRequest)
+			cors.Error(w, "Invalid host", http.StatusBadRequest)
 
 			return
 		}
 
 		if errors.Is(err, ErrInvalidSandboxID) {
 			logger.L().Warn(ctx, "invalid sandbox ID", zap.String("host", r.Host))
-			http.Error(w, "Invalid sandbox ID", http.StatusBadRequest)
+			cors.Error(w, "Invalid sandbox ID", http.StatusBadRequest)
 
 			return
 		}
@@ -43,7 +56,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 		var invalidPortErr *InvalidSandboxPortError
 		if errors.As(err, &invalidPortErr) {
 			logger.L().Warn(ctx, "invalid sandbox port", zap.String("host", r.Host), zap.String("port", invalidPortErr.Port))
-			http.Error(w, "Invalid sandbox port", http.StatusBadRequest)
+			cors.Error(w, "Invalid sandbox port", http.StatusBadRequest)
 
 			return
 		}
@@ -59,7 +72,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 				HandleError(w, r)
 			if err != nil {
 				logger.L().Error(ctx, "failed to handle sandbox not found error", zap.Error(err), logger.WithSandboxID(notFoundErr.SandboxId))
-				http.Error(w, "Failed to handle sandbox not found error", http.StatusInternalServerError)
+				cors.Error(w, "Failed to handle sandbox not found error", http.StatusInternalServerError)
 
 				return
 			}
@@ -78,7 +91,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 				HandleError(w, r)
 			if err != nil {
 				logger.L().Error(ctx, "failed to handle sandbox resume permission denied error", zap.Error(err), logger.WithSandboxID(resumeDeniedErr.SandboxId))
-				http.Error(w, "Failed to handle sandbox resume permission denied error", http.StatusInternalServerError)
+				cors.Error(w, "Failed to handle sandbox resume permission denied error", http.StatusInternalServerError)
 
 				return
 			}
@@ -97,7 +110,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 				HandleError(w, r)
 			if err != nil {
 				logger.L().Error(ctx, "failed to handle sandbox still transitioning error", zap.Error(err), logger.WithSandboxID(stillTransitioningErr.SandboxId))
-				http.Error(w, "Failed to handle sandbox still transitioning error", http.StatusInternalServerError)
+				cors.Error(w, "Failed to handle sandbox still transitioning error", http.StatusInternalServerError)
 
 				return
 			}
@@ -116,7 +129,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 				HandleError(w, r)
 			if err != nil {
 				logger.L().Error(ctx, "failed to handle team sandbox limit error", zap.Error(err), logger.WithSandboxID(resourceExhaustedErr.SandboxId))
-				http.Error(w, "Failed to handle team sandbox limit error", http.StatusInternalServerError)
+				cors.Error(w, "Failed to handle team sandbox limit error", http.StatusInternalServerError)
 
 				return
 			}
@@ -133,7 +146,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 				HandleError(w, r)
 			if err != nil {
 				logger.L().Error(ctx, "failed to handle traffic missing traffic access token header error", zap.Error(err), logger.WithSandboxID(trafficMissingTokenErr.SandboxId))
-				http.Error(w, "Failed to handle invalid missing access token header error", http.StatusInternalServerError)
+				cors.Error(w, "Failed to handle invalid missing access token header error", http.StatusInternalServerError)
 
 				return
 			}
@@ -150,7 +163,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 				HandleError(w, r)
 			if err != nil {
 				logger.L().Error(ctx, "failed to handle traffic invalid traffic access token header error", zap.Error(err), logger.WithSandboxID(trafficInvalidTokenErr.SandboxId))
-				http.Error(w, "Failed to handle invalid traffic access token header error", http.StatusInternalServerError)
+				cors.Error(w, "Failed to handle invalid traffic access token header error", http.StatusInternalServerError)
 
 				return
 			}
@@ -160,7 +173,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 
 		if err != nil {
 			logger.L().Error(ctx, "failed to route request", zap.Error(err), zap.String("host", r.Host))
-			http.Error(w, fmt.Sprintf("Unexpected error when routing request: %s", err), http.StatusInternalServerError)
+			cors.Error(w, fmt.Sprintf("Unexpected error when routing request: %s", err), http.StatusInternalServerError)
 
 			return
 		}
@@ -184,7 +197,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 					HandleError(w, r)
 				if err != nil {
 					logger.L().Error(ctx, "failed to handle too many connections error", zap.Error(err), logger.WithSandboxID(d.SandboxId))
-					http.Error(w, "Failed to handle too many connections error", http.StatusInternalServerError)
+					cors.Error(w, "Failed to handle too many connections error", http.StatusInternalServerError)
 
 					return
 				}

--- a/packages/shared/pkg/proxy/handler.go
+++ b/packages/shared/pkg/proxy/handler.go
@@ -183,6 +183,19 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 			maxLimit := connLimitConfig.GetMaxLimit(ctx)
 			count, acquired := connLimitConfig.Limiter.TryAcquire(d.ConnectionKey, maxLimit)
 			if !acquired {
+				// The limit protects the sandbox, and a preflight answered here never
+				// reaches it, so answering costs nothing and lets the real request
+				// come back for the 429 the browser would otherwise turn into an
+				// opaque error. Not counted as blocked: nothing was.
+				if cors.HandlePreflight(w, r) {
+					logger.L().Debug(ctx, "answered CORS preflight for connection-limited sandbox",
+						zap.String("host", r.Host),
+						logger.WithSandboxID(d.SandboxId),
+						zap.Int("connection_limit", maxLimit))
+
+					return
+				}
+
 				logger.L().Warn(ctx, "sandbox too many incoming connections",
 					zap.String("host", r.Host),
 					logger.WithSandboxID(d.SandboxId),

--- a/packages/shared/pkg/proxy/pool/client.go
+++ b/packages/shared/pkg/proxy/pool/client.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/cors"
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/template"
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/tracking"
 	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
@@ -120,17 +121,28 @@ func newProxyClient(
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			ctx := r.Context()
+
+			// The sandbox never answered, so it never answered the preflight
+			// either. Every response below carries an error status, which a
+			// browser refuses to accept as a preflight result, so answer the
+			// preflight here and let the real request carry the error.
+			if cors.HandlePreflight(w, r) {
+				logger.L().Debug(ctx, "answered CORS preflight for unreachable sandbox", zap.Error(err))
+
+				return
+			}
+
 			t, ok := pc.getDestination(r)
 			if !ok {
 				logger.L().Error(ctx, "proxy request without sandbox received error", zap.Error(err))
-				http.Error(w, "Failed to route request to sandbox", http.StatusInternalServerError)
+				cors.Error(w, "Failed to route request to sandbox", http.StatusInternalServerError)
 
 				return
 			}
 
 			if r.Host == "" { // kept around for historical reasons, unsure of usefulness. todo: find out if this is useful.
 				t.RequestLogger.Error(ctx, "error handler called from rewrite because of missing DestinationContext", zap.Error(err))
-				http.Error(w, "Failed to route request to sandbox", http.StatusInternalServerError)
+				cors.Error(w, "Failed to route request to sandbox", http.StatusInternalServerError)
 
 				return
 			}
@@ -154,7 +166,7 @@ func newProxyClient(
 				if err != nil {
 					logger.L().Error(ctx, "failed to handle error", zap.Error(err))
 
-					http.Error(w, "Failed to handle closed port error", http.StatusInternalServerError)
+					cors.Error(w, "Failed to handle closed port error", http.StatusInternalServerError)
 
 					return
 				}
@@ -162,7 +174,7 @@ func newProxyClient(
 				return
 			}
 
-			http.Error(w, "Failed to route request to sandbox", http.StatusBadGateway)
+			cors.Error(w, "Failed to route request to sandbox", http.StatusBadGateway)
 		},
 		ModifyResponse: func(r *http.Response) error {
 			ctx := r.Request.Context()

--- a/packages/shared/pkg/proxy/template/template.go
+++ b/packages/shared/pkg/proxy/template/template.go
@@ -7,6 +7,9 @@ import (
 	"html/template"
 	"net/http"
 	"regexp"
+	"strings"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/cors"
 )
 
 var browserRegex = regexp.MustCompile(`(?i)mozilla|chrome|safari|firefox|edge|opera|msie`)
@@ -43,7 +46,9 @@ func (e *TemplatedError[T]) HandleError(
 		return fmt.Errorf("invalid status code: %d", e.vars.StatusCode())
 	}
 
-	if isBrowser(r) {
+	cors.SetHeaders(w)
+
+	if wantsHtml(r) {
 		body, buildErr := e.buildHtml()
 		if buildErr != nil {
 			return buildErr
@@ -73,6 +78,42 @@ func (e *TemplatedError[T]) HandleError(
 	}
 
 	return nil
+}
+
+// wantsHtml reports whether the error should be rendered as the browser error
+// page rather than as JSON.
+//
+// Intent comes first, because a fetch() from page scripts carries the browser's
+// own User-Agent and cannot override it — sniffing the User-Agent alone hands an
+// HTML page to a caller that is about to parse it as JSON. Sniffing is left as
+// the fallback, where it only catches genuine top-level navigations.
+func wantsHtml(r *http.Request) bool {
+	if prefersJson(r) || isScriptInitiated(r) {
+		return false
+	}
+
+	return isBrowser(r)
+}
+
+// prefersJson reports whether the Accept header asks for JSON over HTML.
+func prefersJson(r *http.Request) bool {
+	accept := strings.ToLower(r.Header.Get("Accept"))
+
+	return strings.Contains(accept, "application/json") && !strings.Contains(accept, "text/html")
+}
+
+// isScriptInitiated reports whether the request was made by page scripts rather
+// than by navigating to the URL. Sec-Fetch-Mode is set by the browser itself and
+// is a forbidden header name for scripts; X-Requested-With covers older clients.
+func isScriptInitiated(r *http.Request) bool {
+	// A top-level navigation, which is what the HTML pages are for, sends
+	// "navigate" instead.
+	switch strings.ToLower(r.Header.Get("Sec-Fetch-Mode")) {
+	case "cors", "no-cors", "same-origin":
+		return true
+	}
+
+	return r.Header.Get("X-Requested-With") != ""
 }
 
 func isBrowser(r *http.Request) bool {

--- a/packages/shared/pkg/proxy/template/template_test.go
+++ b/packages/shared/pkg/proxy/template/template_test.go
@@ -1,0 +1,160 @@
+package template
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const chromeUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
+
+// errorHandler erases the concrete type parameter so every constructor can go
+// into one table.
+type errorHandler func(w http.ResponseWriter, r *http.Request) error
+
+func handlers(t *testing.T) map[string]errorHandler {
+	t.Helper()
+
+	const (
+		sandboxID = "im9r2ycjiy2534qsdy1oo"
+		host      = "49983-im9r2ycjiy2534qsdy1oo.e2b.app"
+	)
+
+	return map[string]errorHandler{
+		"sandbox_not_found":                NewSandboxNotFoundError(sandboxID, host).HandleError,
+		"sandbox_still_transitioning":      NewSandboxStillTransitioningError(sandboxID, host).HandleError,
+		"sandbox_resume_permission_denied": NewSandboxResumePermissionDeniedError(sandboxID, host).HandleError,
+		"port_closed":                      NewPortClosedError(sandboxID, host, 3000).HandleError,
+		"team_sandbox_limit":               NewTeamSandboxLimitError(sandboxID, host, "limit reached").HandleError,
+		"sandbox_too_many_connections":     NewSandboxTooManyConnectionsError(sandboxID, host, 1024).HandleError,
+		"traffic_access_token_missing":     NewTrafficAccessTokenMissingHeader(sandboxID, host, "X-Access-Token").HandleError,
+		"traffic_access_token_invalid":     NewTrafficAccessTokenInvalidHeader(sandboxID, host, "X-Access-Token").HandleError,
+	}
+}
+
+// Every template is a response the proxy synthesizes in place of a sandbox that
+// would have sent its own CORS headers, so all of them need ours. Driving the
+// whole set keeps a newly added template from silently missing the header.
+func TestHandleErrorSetsCORSHeaders(t *testing.T) {
+	t.Parallel()
+
+	for name, handle := range handlers(t) {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, mode := range []struct {
+				name      string
+				userAgent string
+			}{
+				{name: "json", userAgent: ""},
+				{name: "html", userAgent: chromeUserAgent},
+			} {
+				t.Run(mode.name, func(t *testing.T) {
+					t.Parallel()
+
+					r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
+					r.Header.Set("Origin", "https://app.example.com")
+					r.Header.Set("User-Agent", mode.userAgent)
+					w := httptest.NewRecorder()
+
+					require.NoError(t, handle(w, r))
+					assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+					assert.Equal(t, "Origin", w.Header().Get("Vary"))
+					assert.NotEmpty(t, w.Body.String())
+				})
+			}
+		})
+	}
+}
+
+// Browser JS cannot override the User-Agent, so User-Agent sniffing alone sends
+// an HTML page to callers that are about to parse it as JSON.
+func TestHandleErrorContentNegotiation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		htmlContentType = "text/html; charset=utf-8"
+		jsonContentType = "application/json; charset=utf-8"
+	)
+
+	for _, tt := range []struct {
+		name        string
+		headers     map[string]string
+		contentType string
+	}{
+		{
+			name:        "no user agent",
+			contentType: jsonContentType,
+		},
+		{
+			name:        "top-level navigation",
+			headers:     map[string]string{"User-Agent": chromeUserAgent, "Sec-Fetch-Mode": "navigate", "Accept": "text/html,application/xhtml+xml,*/*"},
+			contentType: htmlContentType,
+		},
+		{
+			name:        "bare browser user agent",
+			headers:     map[string]string{"User-Agent": chromeUserAgent},
+			contentType: htmlContentType,
+		},
+		{
+			name:        "browser user agent accepting html",
+			headers:     map[string]string{"User-Agent": chromeUserAgent, "Accept": "text/html"},
+			contentType: htmlContentType,
+		},
+		{
+			name:        "browser user agent accepting json",
+			headers:     map[string]string{"User-Agent": chromeUserAgent, "Accept": "application/json"},
+			contentType: jsonContentType,
+		},
+		{
+			// What a default fetch() from page scripts looks like: browser
+			// User-Agent, no JSON preference in Accept.
+			name:        "cross-origin fetch",
+			headers:     map[string]string{"User-Agent": chromeUserAgent, "Sec-Fetch-Mode": "cors", "Accept": "*/*"},
+			contentType: jsonContentType,
+		},
+		{
+			name:        "same-origin fetch",
+			headers:     map[string]string{"User-Agent": chromeUserAgent, "Sec-Fetch-Mode": "same-origin", "Accept": "*/*"},
+			contentType: jsonContentType,
+		},
+		{
+			name:        "legacy xhr",
+			headers:     map[string]string{"User-Agent": chromeUserAgent, "X-Requested-With": "XMLHttpRequest"},
+			contentType: jsonContentType,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
+			for header, value := range tt.headers {
+				r.Header.Set(header, value)
+			}
+			w := httptest.NewRecorder()
+
+			require.NoError(t, NewSandboxNotFoundError("im9r2ycjiy2534qsdy1oo", "e2b.app").HandleError(w, r))
+
+			assert.Equal(t, http.StatusBadGateway, w.Code)
+			assert.Equal(t, tt.contentType, w.Header().Get("Content-Type"))
+		})
+	}
+}
+
+func TestHandleErrorRejectsInvalidStatusCode(t *testing.T) {
+	t.Parallel()
+
+	e := &TemplatedError[sandboxNotFoundData]{
+		template: sandboxNotFoundHtmlTemplate,
+		vars:     sandboxNotFoundData{Code: 0},
+	}
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	require.Error(t, e.HandleError(w, r))
+	assert.Empty(t, w.Body.String())
+}

--- a/tests/integration/internal/tests/proxies/sandbox_not_found_test.go
+++ b/tests/integration/internal/tests/proxies/sandbox_not_found_test.go
@@ -69,3 +69,46 @@ func TestSandboxNotFound(t *testing.T) {
 	assert.Contains(t, string(body), sbx.SandboxID)
 	assert.True(t, strings.HasSuffix(string(body), "</html>"))
 }
+
+// A missing sandbox is answered by the proxy rather than by envd, so the proxy
+// owns the CORS headers. Without them a browser turns the 502 into an opaque
+// network error and the SDK cannot tell a stopped sandbox from being offline.
+func TestSandboxNotFoundCORS(t *testing.T) {
+	t.Parallel()
+	url, err := url.Parse(setup.EnvdProxy)
+	require.NoError(t, err)
+
+	port := 3210
+	client := &http.Client{Timeout: 60 * time.Second}
+	sbx := &api.Sandbox{
+		SandboxID: "i" + id.Generate(),
+		ClientID:  "unknown",
+	}
+
+	// Envd requests carry headers that are not CORS-safelisted, so a browser
+	// always preflights before the real request.
+	preflight := utils.NewRequest(sbx, url, port, &http.Header{
+		"Origin":                         []string{"https://app.example.com"},
+		"Access-Control-Request-Method":  []string{http.MethodGet},
+		"Access-Control-Request-Headers": []string{"e2b-sandbox-id,e2b-sandbox-port"},
+	})
+	preflight.Method = http.MethodOptions
+
+	resp, err := client.Do(preflight)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	// A browser only honors a preflight with an ok status, so a 502 here would
+	// stop the real request from ever being sent.
+	assert.Less(t, resp.StatusCode, http.StatusMultipleChoices)
+	assert.GreaterOrEqual(t, resp.StatusCode, http.StatusOK)
+	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "e2b-sandbox-id,e2b-sandbox-port", resp.Header.Get("Access-Control-Allow-Headers"))
+
+	headers := &http.Header{"Origin": []string{"https://app.example.com"}}
+	resp = utils.WaitForStatus(t, client, sbx, url, port, headers, http.StatusBadGateway)
+	require.NotNil(t, resp)
+	require.NoError(t, resp.Body.Close())
+
+	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+}


### PR DESCRIPTION
Sibling of #3388 — same class of bug (a CORS gap that makes an SDK feature silently unusable in browsers), but in the sandbox proxy rather than the API. Tracked SDK-side as SDK-294; surfaced by the new browser test leg (SDK-292 / e2b#1609), which currently skips 13 tests because of it.

## Problem

When a sandbox is running, the CORS headers on its host come from **envd, inside the sandbox**. When it is paused or killed there is no envd to answer, so the **proxy synthesizes the error** — and that response carried no `Access-Control-*` headers at all. Measured against production:

| sandbox state | preflight (`OPTIONS`) | actual (`GET`) |
| --- | --- | --- |
| running | `204` · `ACAO: *` · `ACAH: authorization,user-agent` | `204` · `ACAO: *` |
| paused / killed | `502` · **no CORS headers** | `502` · **no CORS headers** |

CORS support was therefore coupled to the sandbox being alive. For anything that probes liveness this is inverted: the one answer the probe exists to deliver is the one a browser cannot receive. `Sandbox.isRunning()` maps the 502 to `false`, but in a browser `fetch` rejects before there is a status to read, so a bare `TypeError: Failed to fetch` reaches the caller, indistinguishable from being offline. Knock-on, `checkSandboxHealth` can only return `true` or `undefined` in a browser, so **24 SDK call sites** downgrade an actionable `TimeoutError("The sandbox was killed…")` to a generic `SandboxError("network error")`.

**Adding the headers to the 502 alone would not have fixed it.** Every envd request carries `E2b-Sandbox-Id` and `E2b-Sandbox-Port` (plus `X-Access-Token` for secured sandboxes) — non-safelisted, so a browser always preflights. Per the Fetch standard a preflight response must have an ok status or the browser returns a network error regardless of which headers it carries. Hence two parts.

## Changes

New `packages/shared/pkg/proxy/cors/`, used by both `client-proxy` and the edge:

- **Answer preflights with `204`** on paths that would otherwise answer with an error status — in `handler()` when `getDestination` fails, and in the pool's `ErrorHandler`, which owns `port_closed` and the unreachable-sandbox 502. A bare `OPTIONS` (no `Access-Control-Request-Method`) is not a preflight and still falls through to the error.
- **`Access-Control-Allow-Origin: *`** (matching what envd sends) on the synthesized responses. `TemplatedError.HandleError` is the single choke point for all eight error templates, so it covers `sandbox_not_found`, `port_closed`, `sandbox_still_transitioning`, `sandbox_resume_permission_denied`, `sandbox_too_many_connections`, `team_sandbox_limit` and both `traffic_access_token_error`s at once. The raw `http.Error` paths — missing header, invalid host/sandbox-ID/port, and the unreachable-sandbox ones in the pool — go through the new `cors.Error`.

The healthy path is untouched: envd keeps answering its own preflights, and the proxy must **not** add a second `Access-Control-Allow-Origin` (a browser rejects two values as readily as none) — there is a test for that.

**Also fixes content negotiation**, found while investigating. `template.go` chose HTML over JSON by User-Agent sniffing, but a `fetch()` from page scripts carries the browser's User-Agent and cannot override it (UA is a forbidden header name), so an SDK call from a browser got the HTML error page where it expects JSON, and `Accept` was ignored entirely:

```
no UA                                -> 502 application/json
chrome UA                            -> 502 text/html
chrome UA + Accept: application/json -> 502 text/html   <- Accept ignored
```

Intent now decides first: JSON when `Accept` prefers it, or when `Sec-Fetch-Mode` / `X-Requested-With` mark the request as script-initiated. UA sniffing stays as the fallback, where it only catches genuine top-level navigations — which is what the HTML pages are for.

## Tests

- `packages/shared/pkg/proxy/cors/cors_test.go` — the helpers in isolation.
- `packages/shared/pkg/proxy/cors_test.go` — handler-level, plus socket-level tests that reproduce the browser's preflight-then-request exchange against a missing and an unreachable sandbox, and assert the live-sandbox path does not get a duplicated header.
- `packages/shared/pkg/proxy/template/template_test.go` — a table over all eight constructors asserting the header in both HTML and JSON modes, so a newly added template cannot silently miss it, plus the content-negotiation matrix.
- `tests/integration/.../sandbox_not_found_test.go` — extended: a stopped sandbox's preflight is 2xx with the echoed headers and the follow-up `GET` is 502 *with* `Access-Control-Allow-Origin`.

Both new behaviors were checked to have teeth by reverting the fix and watching the tests fail. Verified with `go test -race ./packages/shared/pkg/proxy/...`, `make fmt` and `make lint` (the one remaining lint failure, `cmd/create-build/proxyport_test.go`, is pre-existing on `main` and platform-related).

## Rollout

No SDK release is coupled to this; the flag removal is test-only. Deploy order: infra fix → staging → production → drop `canObserveStoppedSandbox` from the JS SDK's `tests/setup.ts`, which should leave the 13 currently-skipped browser tests green with no SDK change. The browser CI leg only runs against production, so those stay red until the production rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)