### PR TITLE
fix(db): drop duplicate snapshots sandbox_id index

### DIFF
--- a/packages/db/migrations/20260725040700_drop_duplicate_snapshots_sandbox_id_index.sql
+++ b/packages/db/migrations/20260725040700_drop_duplicate_snapshots_sandbox_id_index.sql
@@ -11,6 +11,10 @@ SET statement_timeout = '1h';
 -- write paid its ~6 GiB maintenance tax.
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_snapshots_sandbox_id;
 
+-- The migrator session is reused for subsequent migrations — don't leak the
+-- widened bound into them.
+RESET statement_timeout;
+
 -- +goose Down
 -- +goose NO TRANSACTION
 
@@ -26,3 +30,5 @@ DROP INDEX CONCURRENTLY IF EXISTS public.idx_snapshots_sandbox_id;
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_snapshots_sandbox_id
     ON public.snapshots (sandbox_id);
+
+RESET statement_timeout;

--- a/packages/db/migrations/20260725040700_drop_duplicate_snapshots_sandbox_id_index.sql
+++ b/packages/db/migrations/20260725040700_drop_duplicate_snapshots_sandbox_id_index.sql
@@ -8,7 +8,7 @@ SET statement_timeout = '1h';
 -- Exact duplicate of snapshots_sandbox_id_unique (same single column, same
 -- order): the planner always has the unique index available, and this copy
 -- recorded 0 lifetime scans in pg_stat_user_indexes while every snapshot
--- write paid its ~6 GiB maintenance tax.
+-- write paid its maintenance tax.
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_snapshots_sandbox_id;
 
 -- The migrator session is reused for subsequent migrations: restore its

--- a/packages/db/migrations/20260725040700_drop_duplicate_snapshots_sandbox_id_index.sql
+++ b/packages/db/migrations/20260725040700_drop_duplicate_snapshots_sandbox_id_index.sql
@@ -11,9 +11,10 @@ SET statement_timeout = '1h';
 -- write paid its ~6 GiB maintenance tax.
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_snapshots_sandbox_id;
 
--- The migrator session is reused for subsequent migrations — don't leak the
--- widened bound into them.
-RESET statement_timeout;
+-- The migrator session is reused for subsequent migrations: restore its
+-- baseline (scripts/migrator.go sets 3h per connection; RESET would clear
+-- to the unbounded server default instead).
+SET statement_timeout = '3h';
 
 -- +goose Down
 -- +goose NO TRANSACTION
@@ -31,4 +32,5 @@ DROP INDEX CONCURRENTLY IF EXISTS public.idx_snapshots_sandbox_id;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_snapshots_sandbox_id
     ON public.snapshots (sandbox_id);
 
-RESET statement_timeout;
+-- Restore the migrator session baseline (see Up).
+SET statement_timeout = '3h';

--- a/packages/db/migrations/20260725040700_drop_duplicate_snapshots_sandbox_id_index.sql
+++ b/packages/db/migrations/20260725040700_drop_duplicate_snapshots_sandbox_id_index.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- DROP only waits on in-flight lock holders; bound the wait so it neither
+-- hangs unbounded nor dies to a short session default.
+SET statement_timeout = '1h';
+
+-- Exact duplicate of snapshots_sandbox_id_unique (same single column, same
+-- order): the planner always has the unique index available, and this copy
+-- recorded 0 lifetime scans in pg_stat_user_indexes while every snapshot
+-- write paid its ~6 GiB maintenance tax.
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_snapshots_sandbox_id;
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+-- A concurrent rebuild on a table this size can run for hours, and a
+-- mid-build timeout would strand an INVALID index. Rolling back is a
+-- deliberate manual operation with an operator present — unbounded on
+-- purpose.
+SET statement_timeout = 0;
+
+-- An interrupted CONCURRENTLY build leaves an INVALID index that IF NOT
+-- EXISTS would then skip forever — clear any leftover before rebuilding.
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_snapshots_sandbox_id;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_snapshots_sandbox_id
+    ON public.snapshots (sandbox_id);


### PR DESCRIPTION
## Summary

`idx_snapshots_sandbox_id` is an exact duplicate of `snapshots_sandbox_id_unique` (same single column, same order). The unique index serves all lookups; the copy has **0 lifetime scans** in `pg_stat_user_indexes`, while every snapshot write maintains it for nothing.

`DROP INDEX CONCURRENTLY` with the same timeout/INVALID-leftover handling as the recent drop-index precedent. Down rebuilds it concurrently (unbounded timeout, manual operation by design).
