### PR TITLE
fix(auth): debounce team_api_keys.last_used to one write per key per minute

### DIFF
--- a/packages/auth/pkg/auth/internal/service/store.go
+++ b/packages/auth/pkg/auth/internal/service/store.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
@@ -16,6 +18,23 @@ import (
 )
 
 var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/auth/pkg/auth/internal/service")
+
+// last_used is minute-grade observability metadata, but updating it on every
+// authenticated request makes team_api_keys one of the highest dead-tuple
+// producers in the registry. One write per key per window keeps it fresh
+// enough at a fraction of the churn.
+const lastUsedWriteWindow = time.Minute
+
+var lastUsedWrites sync.Map // api key hash -> time.Time of last write
+
+func shouldWriteLastUsed(hashedKey string, now time.Time) bool {
+	if v, ok := lastUsedWrites.Load(hashedKey); ok && now.Sub(v.(time.Time)) < lastUsedWriteWindow {
+		return false
+	}
+	lastUsedWrites.Store(hashedKey, now)
+
+	return true
+}
 
 type authStoreImpl struct {
 	authDB *authdb.Client
@@ -44,14 +63,16 @@ func (s *authStoreImpl) GetTeamByHashedAPIKey(ctx context.Context, hashedKey str
 		return nil, err
 	}
 
-	go func() {
-		// Run the update in a separate context to avoid an extra latency
-		ctx := context.WithoutCancel(ctx)
-		updateErr := s.authDB.UpdateLastTimeUsed(ctx, hashedKey)
-		if updateErr != nil {
-			logger.L().Error(ctx, "failed to update last time used", zap.Error(updateErr))
-		}
-	}()
+	if shouldWriteLastUsed(hashedKey, time.Now()) {
+		go func() {
+			// Run the update in a separate context to avoid an extra latency
+			ctx := context.WithoutCancel(ctx)
+			updateErr := s.authDB.UpdateLastTimeUsed(ctx, hashedKey)
+			if updateErr != nil {
+				logger.L().Error(ctx, "failed to update last time used", zap.Error(updateErr))
+			}
+		}()
+	}
 
 	team := types.NewTeam(&result.Team, &result.TeamLimit)
 

--- a/packages/auth/pkg/auth/internal/service/store.go
+++ b/packages/auth/pkg/auth/internal/service/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -25,15 +26,34 @@ var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/auth/pkg/auth/intern
 // enough at a fraction of the churn.
 const lastUsedWriteWindow = time.Minute
 
-var lastUsedWrites sync.Map // api key hash -> time.Time of last write
+var (
+	lastUsedWrites     sync.Map // api key hash -> time.Time of last write
+	lastUsedCallsSweep atomic.Int64
+)
 
 func shouldWriteLastUsed(hashedKey string, now time.Time) bool {
-	if v, ok := lastUsedWrites.Load(hashedKey); ok && now.Sub(v.(time.Time)) < lastUsedWriteWindow {
+	// Occasionally drop entries idle for many windows so the map tracks the
+	// working set of keys, not every key ever seen by the process.
+	if lastUsedCallsSweep.Add(1)%4096 == 0 {
+		lastUsedWrites.Range(func(k, v any) bool {
+			if now.Sub(v.(time.Time)) > 10*lastUsedWriteWindow {
+				lastUsedWrites.Delete(k)
+			}
+
+			return true
+		})
+	}
+
+	prev, loaded := lastUsedWrites.LoadOrStore(hashedKey, now)
+	if !loaded {
+		return true
+	}
+	if now.Sub(prev.(time.Time)) < lastUsedWriteWindow {
 		return false
 	}
-	lastUsedWrites.Store(hashedKey, now)
 
-	return true
+	// CAS so exactly one concurrent caller wins the expired window.
+	return lastUsedWrites.CompareAndSwap(hashedKey, prev, now)
 }
 
 type authStoreImpl struct {

--- a/packages/auth/pkg/auth/internal/service/store_test.go
+++ b/packages/auth/pkg/auth/internal/service/store_test.go
@@ -42,11 +42,9 @@ func TestShouldWriteLastUsedConcurrent(t *testing.T) {
 	wins := make(chan bool, n)
 	var wg sync.WaitGroup
 	for range n {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			wins <- shouldWriteLastUsed(key, later)
-		}()
+		})
 	}
 	wg.Wait()
 	close(wins)

--- a/packages/auth/pkg/auth/internal/service/store_test.go
+++ b/packages/auth/pkg/auth/internal/service/store_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestShouldWriteLastUsed(t *testing.T) {
+	t.Parallel()
+
 	base := time.Now()
 
 	if !shouldWriteLastUsed("key-a", base) {

--- a/packages/auth/pkg/auth/internal/service/store_test.go
+++ b/packages/auth/pkg/auth/internal/service/store_test.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestShouldWriteLastUsed(t *testing.T) {
+	base := time.Now()
+
+	if !shouldWriteLastUsed("key-a", base) {
+		t.Fatal("first write for a key must pass")
+	}
+	if shouldWriteLastUsed("key-a", base.Add(lastUsedWriteWindow/2)) {
+		t.Fatal("write inside the window must be suppressed")
+	}
+	if !shouldWriteLastUsed("key-b", base) {
+		t.Fatal("independent key must not be suppressed")
+	}
+	if !shouldWriteLastUsed("key-a", base.Add(lastUsedWriteWindow+time.Second)) {
+		t.Fatal("write after the window must pass")
+	}
+}

--- a/packages/auth/pkg/auth/internal/service/store_test.go
+++ b/packages/auth/pkg/auth/internal/service/store_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -8,18 +9,54 @@ import (
 func TestShouldWriteLastUsed(t *testing.T) {
 	t.Parallel()
 
+	// Unique keys per invocation: the debounce map is package state shared
+	// across repeated in-process runs (-count=2).
+	keyA := "key-a-" + t.Name() + time.Now().String()
+	keyB := "key-b-" + t.Name() + time.Now().String()
 	base := time.Now()
 
-	if !shouldWriteLastUsed("key-a", base) {
+	if !shouldWriteLastUsed(keyA, base) {
 		t.Fatal("first write for a key must pass")
 	}
-	if shouldWriteLastUsed("key-a", base.Add(lastUsedWriteWindow/2)) {
+	if shouldWriteLastUsed(keyA, base.Add(lastUsedWriteWindow/2)) {
 		t.Fatal("write inside the window must be suppressed")
 	}
-	if !shouldWriteLastUsed("key-b", base) {
+	if !shouldWriteLastUsed(keyB, base) {
 		t.Fatal("independent key must not be suppressed")
 	}
-	if !shouldWriteLastUsed("key-a", base.Add(lastUsedWriteWindow+time.Second)) {
+	if !shouldWriteLastUsed(keyA, base.Add(lastUsedWriteWindow+time.Second)) {
 		t.Fatal("write after the window must pass")
+	}
+}
+
+func TestShouldWriteLastUsedConcurrent(t *testing.T) {
+	t.Parallel()
+
+	key := "key-conc-" + time.Now().String()
+	base := time.Now()
+	shouldWriteLastUsed(key, base)
+
+	// After the window expires, exactly one concurrent caller wins.
+	later := base.Add(lastUsedWriteWindow + time.Second)
+	const n = 16
+	wins := make(chan bool, n)
+	var wg sync.WaitGroup
+	for range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			wins <- shouldWriteLastUsed(key, later)
+		}()
+	}
+	wg.Wait()
+	close(wins)
+	won := 0
+	for w := range wins {
+		if w {
+			won++
+		}
+	}
+	if won != 1 {
+		t.Fatalf("expected exactly one winner, got %d", won)
 	}
 }


### PR DESCRIPTION
## Summary

`UpdateLastTimeUsed` fires on every authenticated request and is one of the largest sources of dead-tuple churn on `team_api_keys`, for a column that is minute-grade observability metadata. An in-process per-key debounce (60s window) keeps `last_used` fresh to the minute while removing almost all of that write load; with multiple auth replicas the worst case is one write per key per replica per minute.
