### PR TITLE
fix(db): drop the unused plain env_builds status index

### DIFF
--- a/packages/db/migrations/20260725040800_drop_env_builds_status_index.sql
+++ b/packages/db/migrations/20260725040800_drop_env_builds_status_index.sql
@@ -5,8 +5,8 @@
 -- hangs unbounded nor dies to a short session default.
 SET statement_timeout = '1h';
 
--- Plain btree on the raw status column: 10 lifetime scans in
--- pg_stat_user_indexes against ~3.6 GiB of size, while every build
+-- Plain btree on the raw status column: a negligible number of lifetime scans in
+-- pg_stat_user_indexes, while every build
 -- insert/supersede pays its maintenance write. Status-filtered access runs
 -- on the status_group partial indexes instead. env_builds is the single
 -- most write-amplified table (0% HOT updates, 8 indexes), so each dropped

--- a/packages/db/migrations/20260725040800_drop_env_builds_status_index.sql
+++ b/packages/db/migrations/20260725040800_drop_env_builds_status_index.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- DROP only waits on in-flight lock holders; bound the wait so it neither
+-- hangs unbounded nor dies to a short session default.
+SET statement_timeout = '1h';
+
+-- Plain btree on the raw status column: 10 lifetime scans in
+-- pg_stat_user_indexes against ~3.6 GiB of size, while every build
+-- insert/supersede pays its maintenance write. Status-filtered access runs
+-- on the status_group partial indexes instead. env_builds is the single
+-- most write-amplified table (0% HOT updates, 8 indexes), so each dropped
+-- index cuts real WAL and dead-tuple volume.
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_env_builds_status;
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+-- A concurrent rebuild on a ~330M row table runs for hours, and a mid-build
+-- timeout would strand an INVALID index. Rolling back is a deliberate manual
+-- operation with an operator present — unbounded on purpose.
+SET statement_timeout = 0;
+
+-- An interrupted CONCURRENTLY build leaves an INVALID index that IF NOT
+-- EXISTS would then skip forever — clear any leftover before rebuilding.
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_env_builds_status;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_env_builds_status
+    ON public.env_builds (status);

--- a/packages/db/migrations/20260725040800_drop_env_builds_status_index.sql
+++ b/packages/db/migrations/20260725040800_drop_env_builds_status_index.sql
@@ -13,9 +13,10 @@ SET statement_timeout = '1h';
 -- index cuts real WAL and dead-tuple volume.
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_env_builds_status;
 
--- The migrator session is reused for subsequent migrations — don't leak the
--- widened bound into them.
-RESET statement_timeout;
+-- The migrator session is reused for subsequent migrations: restore its
+-- baseline (scripts/migrator.go sets 3h per connection; RESET would clear
+-- to the unbounded server default instead).
+SET statement_timeout = '3h';
 
 -- +goose Down
 -- +goose NO TRANSACTION
@@ -32,4 +33,5 @@ DROP INDEX CONCURRENTLY IF EXISTS public.idx_env_builds_status;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_env_builds_status
     ON public.env_builds (status);
 
-RESET statement_timeout;
+-- Restore the migrator session baseline (see Up).
+SET statement_timeout = '3h';

--- a/packages/db/migrations/20260725040800_drop_env_builds_status_index.sql
+++ b/packages/db/migrations/20260725040800_drop_env_builds_status_index.sql
@@ -13,6 +13,10 @@ SET statement_timeout = '1h';
 -- index cuts real WAL and dead-tuple volume.
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_env_builds_status;
 
+-- The migrator session is reused for subsequent migrations — don't leak the
+-- widened bound into them.
+RESET statement_timeout;
+
 -- +goose Down
 -- +goose NO TRANSACTION
 
@@ -27,3 +31,5 @@ DROP INDEX CONCURRENTLY IF EXISTS public.idx_env_builds_status;
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_env_builds_status
     ON public.env_builds (status);
+
+RESET statement_timeout;


### PR DESCRIPTION
## Summary

`idx_env_builds_status` (plain btree on raw `status`) has **a negligible number of lifetime scans** in `pg_stat_user_indexes`. Status-filtered access runs on the purpose-built indexes instead (`idx_env_builds_env_status_created`, `idx_env_builds_team_status_group`, `idx_env_builds_team_status_pagination`, and the covering index including `status_group`).

env_builds is the most write-amplified table in the registry (0% HOT updates, 8 indexes), so every dropped index removes real WAL and dead-tuple volume from each build insert/supersede.

Draft on purpose: requesting an owner's confirmation that nothing planned depends on a full-table raw-status scan path before this lands.

