### PR TITLE
fix(envd): log net.Connections error in port scanner and add unit tests

### DIFF
--- a/packages/envd/internal/port/forward_test.go
+++ b/packages/envd/internal/port/forward_test.go
@@ -17,7 +17,7 @@ func TestStartForwarding_StopsOnClosedMessages(t *testing.T) {
 	t.Parallel()
 
 	l := zerolog.Nop()
-	scanner := NewScanner(time.Hour)
+	scanner := NewScanner(&l, time.Hour)
 	f := &Forwarder{
 		logger:            &l,
 		ports:             make(map[string]*PortToForward),

--- a/packages/envd/internal/port/scan.go
+++ b/packages/envd/internal/port/scan.go
@@ -3,12 +3,14 @@ package port
 import (
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/shirou/gopsutil/v4/net"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
 )
 
 type Scanner struct {
+	logger   *zerolog.Logger
 	scanExit chan struct{}
 	subs     *smap.Map[*ScannerSubscriber]
 	period   time.Duration
@@ -18,8 +20,9 @@ func (s *Scanner) Destroy() {
 	close(s.scanExit)
 }
 
-func NewScanner(period time.Duration) *Scanner {
+func NewScanner(logger *zerolog.Logger, period time.Duration) *Scanner {
 	return &Scanner{
+		logger:   logger,
 		period:   period,
 		subs:     smap.New[*ScannerSubscriber](),
 		scanExit: make(chan struct{}),
@@ -40,11 +43,17 @@ func (s *Scanner) ScanAndBroadcast() {
 
 	for {
 		// tcp monitors both ipv4 and ipv6 connections.
-		processes, _ := net.Connections("tcp")
-		for _, sub := range s.subs.Items() {
-			// Pass scanExit so a subscriber that stopped consuming can't park this
-			// loop on a send and keep it from reaching the select below.
-			sub.Signal(processes, s.scanExit)
+		processes, err := net.Connections("tcp")
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Error().Err(err).Msg("Failed to scan open TCP connections")
+			}
+		} else {
+			for _, sub := range s.subs.Items() {
+				// Pass scanExit so a subscriber that stopped consuming can't park this
+				// loop on a send and keep it from reaching the select below.
+				sub.Signal(processes, s.scanExit)
+			}
 		}
 		select {
 		case <-s.scanExit:

--- a/packages/envd/internal/port/scan.go
+++ b/packages/envd/internal/port/scan.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Scanner struct {
+	logger    *zerolog.Logger
 	Processes chan net.ConnectionStat
 	scanExit  chan struct{}
 	subs      *smap.Map[*ScannerSubscriber]
@@ -20,8 +21,9 @@ func (s *Scanner) Destroy() {
 	close(s.scanExit)
 }
 
-func NewScanner(period time.Duration) *Scanner {
+func NewScanner(logger *zerolog.Logger, period time.Duration) *Scanner {
 	return &Scanner{
+		logger:    logger,
 		period:    period,
 		subs:      smap.New[*ScannerSubscriber](),
 		scanExit:  make(chan struct{}),
@@ -48,9 +50,15 @@ func (s *Scanner) ScanAndBroadcast() {
 
 	for {
 		// tcp monitors both ipv4 and ipv6 connections.
-		processes, _ := net.Connections("tcp")
-		for _, sub := range s.subs.Items() {
-			sub.Signal(processes)
+		processes, err := net.Connections("tcp")
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Error().Err(err).Msg("Failed to scan open TCP connections")
+			}
+		} else {
+			for _, sub := range s.subs.Items() {
+				sub.Signal(processes)
+			}
 		}
 		select {
 		case <-s.scanExit:

--- a/packages/envd/internal/port/scan_test.go
+++ b/packages/envd/internal/port/scan_test.go
@@ -1,0 +1,114 @@
+package port
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/shirou/gopsutil/v4/net"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewScanner(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := zerolog.New(buf)
+
+	s := NewScanner(&logger, 50*time.Millisecond)
+	require.NotNil(t, s)
+	assert.NotNil(t, s.subs)
+	assert.Equal(t, 50*time.Millisecond, s.period)
+
+	sub := s.AddSubscriber("test-sub", &ScannerFilter{
+		IPs:   []string{"127.0.0.1"},
+		State: "LISTEN",
+	})
+	require.NotNil(t, sub)
+	assert.Equal(t, "test-sub", sub.id)
+}
+
+func TestScanAndBroadcastLifecycle(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := zerolog.New(buf)
+
+	s := NewScanner(&logger, 10*time.Millisecond)
+	sub := s.AddSubscriber("sub-1", nil)
+
+	received := make(chan struct{}, 1)
+	stopDrain := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stopDrain:
+				return
+			case <-sub.Messages:
+				select {
+				case received <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		s.ScanAndBroadcast()
+		close(done)
+	}()
+
+	select {
+	case <-received:
+		// Received at least one scan message
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for scan message")
+	}
+
+	s.Destroy()
+
+	select {
+	case <-done:
+		// Scanner goroutine exited promptly
+	case <-time.After(1 * time.Second):
+		t.Fatal("ScanAndBroadcast did not exit after Destroy()")
+	}
+
+	close(stopDrain)
+}
+
+func TestSubscriberFilter(t *testing.T) {
+	sub := NewScannerSubscriber("sub-filter", &ScannerFilter{
+		IPs:   []string{"127.0.0.1", "localhost"},
+		State: "LISTEN",
+	})
+
+	conns := []net.ConnectionStat{
+		{
+			Status: "LISTEN",
+			Laddr:  net.Addr{IP: "127.0.0.1", Port: 8080},
+		},
+		{
+			Status: "ESTABLISHED",
+			Laddr:  net.Addr{IP: "127.0.0.1", Port: 8080},
+		},
+		{
+			Status: "LISTEN",
+			Laddr:  net.Addr{IP: "192.168.1.1", Port: 8080},
+		},
+	}
+
+	exit := make(chan struct{})
+	defer close(exit)
+
+	go sub.Signal(conns, exit)
+
+	select {
+	case filtered := <-sub.Messages:
+		require.Len(t, filtered, 1)
+		assert.Equal(t, uint32(8080), filtered[0].Laddr.Port)
+		assert.Equal(t, "127.0.0.1", filtered[0].Laddr.IP)
+		assert.Equal(t, "LISTEN", filtered[0].Status)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for filtered messages")
+	}
+}

--- a/packages/envd/internal/port/scan_test.go
+++ b/packages/envd/internal/port/scan_test.go
@@ -1,0 +1,117 @@
+package port
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/shirou/gopsutil/v4/net"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewScanner(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := zerolog.New(buf)
+
+	s := NewScanner(&logger, 50*time.Millisecond)
+	require.NotNil(t, s)
+	assert.NotNil(t, s.Processes)
+	assert.NotNil(t, s.subs)
+	assert.Equal(t, 50*time.Millisecond, s.period)
+
+	sub := s.AddSubscriber(&logger, "test-sub", &ScannerFilter{
+		IPs:   []string{"127.0.0.1"},
+		State: "LISTEN",
+	})
+	require.NotNil(t, sub)
+	assert.Equal(t, "test-sub", sub.ID())
+
+	s.Unsubscribe(sub)
+	_, ok := <-sub.Messages
+	assert.False(t, ok, "subscriber channel should be closed upon unsubscribe")
+}
+
+func TestScanAndBroadcastLifecycle(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := zerolog.New(buf)
+
+	s := NewScanner(&logger, 10*time.Millisecond)
+	sub := s.AddSubscriber(&logger, "sub-1", nil)
+
+	received := make(chan struct{}, 1)
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		for range sub.Messages {
+			select {
+			case received <- struct{}{}:
+			default:
+			}
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		s.ScanAndBroadcast()
+		close(done)
+	}()
+
+	select {
+	case <-received:
+		// Received at least one scan message
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for scan message")
+	}
+
+	s.Unsubscribe(sub)
+	s.Destroy()
+
+	select {
+	case <-done:
+		// Scanner goroutine exited promptly
+	case <-time.After(1 * time.Second):
+		t.Fatal("ScanAndBroadcast did not exit after Destroy()")
+	}
+
+	<-drainDone
+}
+
+func TestSubscriberFilter(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := zerolog.New(buf)
+
+	sub := NewScannerSubscriber(&logger, "sub-filter", &ScannerFilter{
+		IPs:   []string{"127.0.0.1", "localhost"},
+		State: "LISTEN",
+	})
+	defer sub.Destroy()
+
+	conns := []net.ConnectionStat{
+		{
+			Status: "LISTEN",
+			Laddr:  net.Addr{IP: "127.0.0.1", Port: 8080},
+		},
+		{
+			Status: "ESTABLISHED",
+			Laddr:  net.Addr{IP: "127.0.0.1", Port: 8080},
+		},
+		{
+			Status: "LISTEN",
+			Laddr:  net.Addr{IP: "192.168.1.1", Port: 8080},
+		},
+	}
+
+	go sub.Signal(conns)
+
+	select {
+	case filtered := <-sub.Messages:
+		require.Len(t, filtered, 1)
+		assert.Equal(t, uint32(8080), filtered[0].Laddr.Port)
+		assert.Equal(t, "127.0.0.1", filtered[0].Laddr.IP)
+		assert.Equal(t, "LISTEN", filtered[0].Status)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for filtered messages")
+	}
+}

--- a/packages/envd/internal/port/scanner_test.go
+++ b/packages/envd/internal/port/scanner_test.go
@@ -73,7 +73,7 @@ func TestScannerSubscriber_Signal_DeliversToSlowReceiver(t *testing.T) {
 func TestScanner_Destroy_ExitsWithStalledSubscriber(t *testing.T) {
 	t.Parallel()
 
-	scanner := NewScanner(10 * time.Millisecond)
+	scanner := NewScanner(nil, 10*time.Millisecond)
 	scanner.AddSubscriber("stalled-sub", nil)
 
 	scanDone := make(chan struct{})

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -303,11 +303,12 @@ func run() error {
 		IdleTimeout:  idleTimeout,
 	}
 
+	portLogger := l.With().Str("logger", "port-forwarder").Logger()
+
 	// Bind all open ports on 127.0.0.1 and localhost to the eth0 interface
-	portScanner := publicport.NewScanner(portScannerInterval)
+	portScanner := publicport.NewScanner(&portLogger, portScannerInterval)
 	defer portScanner.Destroy()
 
-	portLogger := l.With().Str("logger", "port-forwarder").Logger()
 	portForwarder := publicport.NewForwarder(&portLogger, portScanner, cgroupManager)
 	if resumeHandover {
 		// Re-adopt the socats carried across the upgrade before the forwarder's

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.6.13" // x-release-please-version
+const Version = "0.6.14" // x-release-please-version


### PR DESCRIPTION
Closes #3421

## Summary

- Add `logger *zerolog.Logger` field to `Scanner` and log `net.Connections("tcp")` errors in `packages/envd/internal/port/scan.go`
- Prevent `ScanAndBroadcast` from signaling subscribers with `nil` connection lists on scan failure
- Update `NewScanner` in `packages/envd/main.go` to receive logger
- Bump `envd` version to `0.6.14` in `packages/envd/pkg/version.go`
- Add unit test coverage in `packages/envd/internal/port/scan_test.go` for scanner initialization, filtering, and prompt shutdown

## Why

Currently, `ScanAndBroadcast` discards errors returned by `net.Connections("tcp")` with `_`. When reading `/proc/net/tcp` fails (e.g. transient procfs read failures or system resource exhaustion), `processes` is `nil`. `ScanAndBroadcast` passes `nil` to subscribers, causing `Forwarder` to assume zero TCP ports are open. As a result, `Forwarder` marks all active forwarded ports as `DELETE` and forcibly kills all active background `socat` forwarding processes, silently dropping user process reachability inside sandboxes. Logging the error and skipping subscriber signaling on failure preserves active `socat` port forwarding until the next successful scan.

## Test Plan

- [x] Unit tests pass: `go test -count=1 -v ./packages/envd/internal/port/...`
- [x] Code inspection & validation: `go vet ./packages/envd/internal/port/... ./packages/envd/...`
- [x] Verified scanner lifecycle, subscriber filtering, and prompt shutdown via `Destroy()` in `scan_test.go`
- [x] Bumped `envd` version to `0.6.14` per `docs/ARCHITECTURE.md` requirement

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi