### PR TITLE
fix(shared): enforce valid port boundaries and fix error assertion in proxy target parser

### DIFF
--- a/packages/shared/pkg/proxy/handler.go
+++ b/packages/shared/pkg/proxy/handler.go
@@ -40,7 +40,7 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 			return
 		}
 
-		var invalidPortErr *InvalidSandboxPortError
+		var invalidPortErr InvalidSandboxPortError
 		if errors.As(err, &invalidPortErr) {
 			logger.L().Warn(ctx, "invalid sandbox port", zap.String("host", r.Host), zap.String("port", invalidPortErr.Port))
 			http.Error(w, "Invalid sandbox port", http.StatusBadRequest)

--- a/packages/shared/pkg/proxy/host.go
+++ b/packages/shared/pkg/proxy/host.go
@@ -95,6 +95,10 @@ func parseHost(host string) (sandboxID string, port uint64, err error) {
 		return "", 0, InvalidSandboxPortError{sandboxPortString, err}
 	}
 
+	if sandboxPort == 0 || sandboxPort > 65535 {
+		return "", 0, InvalidSandboxPortError{sandboxPortString, fmt.Errorf("port out of range: %d", sandboxPort)}
+	}
+
 	return sandboxID, sandboxPort, nil
 }
 
@@ -130,6 +134,10 @@ func parseHeaders(h http.Header) (sandboxID string, port uint64, ok bool, err er
 	port, err = strconv.ParseUint(portString, 10, 64)
 	if err != nil {
 		return "", 0, false, InvalidSandboxPortError{portString, err}
+	}
+
+	if port == 0 || port > 65535 {
+		return "", 0, false, InvalidSandboxPortError{portString, fmt.Errorf("port out of range: %d", port)}
 	}
 
 	return sandboxID, port, true, nil

--- a/packages/shared/pkg/proxy/host_test.go
+++ b/packages/shared/pkg/proxy/host_test.go
@@ -78,6 +78,16 @@ func TestGetTargetFromRequest(t *testing.T) {
 			wantErrAs: InvalidSandboxPortError{},
 		},
 		{
+			name:      "sandbox-host-with-zero-port",
+			host:      "0-isv6ril5xadwn1k9t2jye.e2b.app",
+			wantErrAs: InvalidSandboxPortError{},
+		},
+		{
+			name:      "sandbox-host-with-port-exceeding-max",
+			host:      "65536-isv6ril5xadwn1k9t2jye.e2b.app",
+			wantErrAs: InvalidSandboxPortError{},
+		},
+		{
 			name:      "sandbox-host-without-domain",
 			host:      "49983-isv6ril5xadwn1k9t2jye",
 			wantID:    "isv6ril5xadwn1k9t2jye",
@@ -107,6 +117,24 @@ func TestGetTargetFromRequest(t *testing.T) {
 			},
 			wantID:   "isv6ril5xadwn1k9t2jye",
 			wantPort: 8080,
+		},
+		{
+			name: "headers: zero port",
+			host: "localhost:1234",
+			headers: http.Header{
+				headerSandboxID:   []string{"isv6ril5xadwn1k9t2jye"},
+				headerSandboxPort: []string{"0"},
+			},
+			wantErrAs: InvalidSandboxPortError{},
+		},
+		{
+			name: "headers: port exceeding max",
+			host: "localhost:1234",
+			headers: http.Header{
+				headerSandboxID:   []string{"isv6ril5xadwn1k9t2jye"},
+				headerSandboxPort: []string{"70000"},
+			},
+			wantErrAs: InvalidSandboxPortError{},
 		},
 		{
 			name: "headers: loopback IPv4",
@@ -235,7 +263,8 @@ func TestGetTargetFromRequest(t *testing.T) {
 			}
 
 			if tt.wantErrAs != nil {
-				require.ErrorAs(t, err, &tt.wantErrIs) //nolint:testifylint // doesn't need to
+				var targetErr InvalidSandboxPortError
+				require.ErrorAs(t, err, &targetErr)
 
 				return // no further checks when an error was expected
 			}

--- a/packages/shared/pkg/proxy/proxy_test.go
+++ b/packages/shared/pkg/proxy/proxy_test.go
@@ -1170,3 +1170,26 @@ func TestConnectionLimitBlocksExcessConnections(t *testing.T) {
 	defer resp.Body.Close()
 	assertBackendOutput(t, backend, resp)
 }
+
+func TestProxyInvalidSandboxPortError(t *testing.T) {
+	t.Parallel()
+
+	getDestination := func(_ *http.Request) (*pool.Destination, error) {
+		return nil, InvalidSandboxPortError{Port: "invalid", wrapped: errors.New("invalid port")}
+	}
+
+	proxy, port, err := newTestProxy(t, getDestination)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		proxy.Close()
+	})
+
+	resp, err := httpGet(t, fmt.Sprintf("http://127.0.0.1:%d/", port))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "Invalid sandbox port")
+}


### PR DESCRIPTION
Closes #3430

## Summary

- Add valid TCP port boundary validation (`1 <= port <= 65535`) to `parseHost` and `parseHeaders` in `packages/shared/pkg/proxy/host.go`
- Fix `errors.As` target type in `packages/shared/pkg/proxy/handler.go` from `*InvalidSandboxPortError` (pointer target) to `InvalidSandboxPortError` (value struct target)
- Fix test assertion in `TestGetTargetFromRequest` in `packages/shared/pkg/proxy/host_test.go` to properly verify `InvalidSandboxPortError` concrete type
- Add test cases for port `0` and out-of-range ports (`65536`, `70000`) for both URL subdomains and `E2b-Sandbox-Port` headers in `host_test.go`
- Add `TestProxyInvalidSandboxPortError` integration test in `packages/shared/pkg/proxy/proxy_test.go` asserting HTTP `400 Bad Request` ("Invalid sandbox port")

## Why

1. `parseHost` and `parseHeaders` parsed ports using `strconv.ParseUint` into `uint64` without enforcing valid TCP port boundaries. Passing port `0` (e.g. `0-sandboxid.e2b.app` or `E2b-Sandbox-Port: 0`) or out-of-range ports returned `port = 0`, causing downstream proxy dialers to attempt invalid dials to port 0.
2. In `handler.go`, `var invalidPortErr *InvalidSandboxPortError` was passed as a target to `errors.As`. Because `host.go` returns `InvalidSandboxPortError` as a value struct (`InvalidSandboxPortError{...}`), double-pointer indirection (`**InvalidSandboxPortError`) caused `errors.As` to return `false` for all invalid port errors. This allowed invalid port errors to fall through to uncaught error handling rather than returning `400 Bad Request`.
3. In `host_test.go`, `require.ErrorAs(t, err, &tt.wantErrIs)` executed `errors.As(err, (*error))` against a `nil` `error` interface, which matched any non-nil error and allowed error-type mismatches to pass silently.

## Test Plan

- [x] Unit tests pass: `go test -v ./packages/shared/pkg/proxy/...`
- [x] Tested port `0` and `> 65535` handling returns `InvalidSandboxPortError`
- [x] Tested proxy handler returns HTTP `400 Bad Request` ("Invalid sandbox port") when `InvalidSandboxPortError` occurs
- [x] Confirmed `require.ErrorAs` correctly asserts error types in `TestGetTargetFromRequest`
- [x] No regressions in valid sandbox routing or proxy connection pooling

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi