### PR TITLE
fix(api): add nil guard in volume mount response conversion

### DIFF
--- a/packages/api/internal/handlers/sandboxes_list.go
+++ b/packages/api/internal/handlers/sandboxes_list.go
@@ -347,6 +347,10 @@ func convertFromDBMountsToAPIMounts(mounts []*dbtypes.SandboxVolumeMountConfig) 
 	results := make([]api.SandboxVolumeMount, 0, len(mounts))
 
 	for _, item := range mounts {
+		if item == nil {
+			continue
+		}
+
 		results = append(results, api.SandboxVolumeMount{
 			Name: item.Name,
 			Path: item.Path,

--- a/packages/api/internal/handlers/volume_util_test.go
+++ b/packages/api/internal/handlers/volume_util_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/orchestrator/nodemanager"
 	"github.com/e2b-dev/infra/packages/auth/pkg/types"
 	authqueries "github.com/e2b-dev/infra/packages/db/pkg/auth/queries"
+	dbtypes "github.com/e2b-dev/infra/packages/db/pkg/types"
 )
 
 func TestVolumeTokenAudience(t *testing.T) {
@@ -150,4 +151,49 @@ func TestFindNodesByVolumeLabel(t *testing.T) {
 			assert.Equal(t, tc.expectedUnmatched, matchedIDs(unmatched))
 		})
 	}
+}
+
+func TestConvertFromDBMountsToAPIMounts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("converts valid mounts", func(t *testing.T) {
+		t.Parallel()
+
+		mounts := []*dbtypes.SandboxVolumeMountConfig{
+			{Name: "v1", Path: "/mnt/data1"},
+			{Name: "v2", Path: "/mnt/data2"},
+		}
+
+		res := convertFromDBMountsToAPIMounts(mounts)
+		assert.NotNil(t, res)
+		assert.Len(t, *res, 2)
+		assert.Equal(t, "v1", (*res)[0].Name)
+		assert.Equal(t, "/mnt/data1", (*res)[0].Path)
+		assert.Equal(t, "v2", (*res)[1].Name)
+		assert.Equal(t, "/mnt/data2", (*res)[1].Path)
+	})
+
+	t.Run("skips nil items safely without panic", func(t *testing.T) {
+		t.Parallel()
+
+		mounts := []*dbtypes.SandboxVolumeMountConfig{
+			{Name: "v1", Path: "/mnt/data1"},
+			nil,
+			{Name: "v2", Path: "/mnt/data2"},
+		}
+
+		res := convertFromDBMountsToAPIMounts(mounts)
+		assert.NotNil(t, res)
+		assert.Len(t, *res, 2)
+		assert.Equal(t, "v1", (*res)[0].Name)
+		assert.Equal(t, "v2", (*res)[1].Name)
+	})
+
+	t.Run("empty input returns non-nil pointer to empty slice", func(t *testing.T) {
+		t.Parallel()
+
+		res := convertFromDBMountsToAPIMounts(nil)
+		assert.NotNil(t, res)
+		assert.Empty(t, *res)
+	})
 }


### PR DESCRIPTION
Closes #3450

## Summary

- Add `if item == nil { continue }` guard in `convertFromDBMountsToAPIMounts` within `packages/api/internal/handlers/sandboxes_list.go`.
- Add `TestConvertFromDBMountsToAPIMounts` unit tests in `packages/api/internal/handlers/volume_util_test.go` asserting nil items are skipped safely without panicking.

## Why

When converting database volume mount configs to API response models, `convertFromDBMountsToAPIMounts` iterated over the slice items directly. If a `nil` pointer existed in the slice (e.g. from JSONB unmarshaling edge cases), dereferencing `item.Name` or `item.Path` triggered a nil pointer panic, crashing the active request handler goroutine for `GET /sandboxes/{id}` or `GET /v2/sandboxes`. Adding an explicit nil check guarantees handler safety.

## Test Plan

- [x] Unit tests pass: `go test -race -v -run TestConvertFromDBMountsToAPIMounts ./packages/api/internal/handlers/...`
- [x] Verified nil slice element handling without panics
- [x] Formatted code cleanly: `go fmt ./...`
- [x] No regressions in volume utility handler tests

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi