### PR TITLE
feat(orch): upgrade envd in filesystem-only snapshots via offline rootfs swap

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -329,6 +329,17 @@ sequenceDiagram
   best-effort — a delivery failure before the `exec` leaves the old envd serving — except an
   unrecoverable post-`exec` failure (the new envd never re-initializes), which fails the resume
   rather than return a permanently unusable sandbox.
+- **Envd offline-upgrade on cold-boot resume**: reaches envd too old for the live `/upgrade`
+  handover (below `MinEnvdVersionForUpgrade`). When a *filesystem-only* snapshot cold-boots
+  (`RebootSandbox`), the orchestrator rewrites `/usr/bin/envd` in the rootfs **before** the VM
+  boots (`PreBootFn` → `pkg/sandbox/rootfs.SwapEnvdBinary`), entirely in userspace via a jailed
+  `debugfs` — never a host-kernel mount of the tenant image. The old envd never participates, so
+  the method is version-agnostic. Gated by the `envd-offline-upgrade-target` flag (a sibling of
+  `envd-upgrade-target` sharing the same version-remap resolver), and applied only when the
+  snapshot's rootfs was captured frozen (`fs_quiesced`, so it is crash-consistent); best-effort
+  (a swap failure boots the original envd). Because the swap keys on the snapshot's *built-with*
+  version, which it does not advance, it re-fires idempotently on each cold-boot resume until a
+  re-pause re-bakes the running version.
 - Auto-pause/auto-resume make sandboxes effectively serverless: idle sandboxes pause, traffic
   resumes them (see traffic flow above).
 

--- a/packages/orchestrator/pkg/sandbox/reboot.go
+++ b/packages/orchestrator/pkg/sandbox/reboot.go
@@ -9,14 +9,22 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/fc"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/rootfs"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/template"
+	buildenvd "github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/core/envd"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/constants"
 	"github.com/e2b-dev/infra/packages/shared/pkg/fc/models"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/units"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
@@ -28,6 +36,12 @@ const (
 	// rebootEnvdTimeout bounds the systemd boot + envd start; a cold boot needs a
 	// longer window than a memory resume (matches the template build's wait).
 	rebootEnvdTimeout = 60 * time.Second
+)
+
+var (
+	// Offline-upgrade rollout metrics (meter shared with sandbox.go).
+	envdOfflineUpgradeAttempts     = utils.Must(telemetry.GetCounter(meter, telemetry.OrchestratorEnvdOfflineUpgradeAttempts))
+	envdOfflineUpgradeDurationHist = utils.Must(telemetry.GetHistogram(meter, telemetry.OrchestratorEnvdOfflineUpgradeDurationName))
 )
 
 // RebootSandbox cold-boots a fresh Firecracker VM from the template's rootfs,
@@ -128,6 +142,8 @@ func (f *Factory) RebootSandbox(
 		opt(&processOptions)
 	}
 
+	preBoot := f.envdOfflineUpgradePreBoot(ctx, config, runtime, meta.IsFsQuiesced(), buildID)
+
 	sbx, err := f.CreateSandbox(
 		ctx,
 		config,
@@ -140,7 +156,7 @@ func (f *Factory) RebootSandbox(
 		"",
 		processOptions,
 		apiConfigToStore,
-		nil,
+		preBoot,
 		WithDeferredMarkRunning(),
 		withNetworkAssignReason(NetworkAssignReasonReboot),
 	)
@@ -169,4 +185,157 @@ func (f *Factory) RebootSandbox(
 	}
 
 	return sbx, nil
+}
+
+// offlineSwapDecision is the pure outcome of the offline-upgrade gate: whether to
+// rewrite the rootfs envd, and — when not — how to report the no-op.
+type offlineSwapDecision struct {
+	swap         bool   // run the rootfs swap
+	countResult  string // if set, record offline_upgrade.attempts{result=...} for this gated no-op
+	logMisconfig bool   // log the resolver's no-op reason (a misconfigured / unstaged target)
+}
+
+// decideOfflineSwap gates the cold-boot envd swap on the resolver outcome and the
+// snapshot's crash-consistency. resolverPath is "" when the resolver returns no
+// upgrade (reason says why); fsQuiesced is whether the rootfs was frozen at pause.
+//
+//   - no upgrade, benign reason (off / same_version)       -> no swap, silent
+//   - no upgrade, misconfig (not_staged / downgrade / ...)  -> no swap, log the reason
+//   - upgrade wanted but rootfs not frozen                  -> no swap, count not_quiesced
+//   - upgrade wanted and rootfs frozen                      -> swap
+func decideOfflineSwap(resolverPath, reason string, fsQuiesced bool) offlineSwapDecision {
+	if resolverPath == "" {
+		switch reason {
+		case "", "off", "same_version":
+			return offlineSwapDecision{}
+		default:
+			return offlineSwapDecision{logMisconfig: true}
+		}
+	}
+	if !fsQuiesced {
+		return offlineSwapDecision{countResult: "not_quiesced"}
+	}
+
+	return offlineSwapDecision{swap: true}
+}
+
+// envdOfflineUpgradePreBoot returns a PreBootFn that rewrites the rootfs envd
+// binary before the cold boot, or nil when no upgrade applies. It
+// resolves the target through the shared envd-upgrade decision (ResolveEnvdOfflineUpgrade,
+// sibling flag envd-offline-upgrade-target) keyed on the snapshot's built-with
+// version — there is no running envd at cold-boot swap time, so unlike the live
+// path there is no LiveEnvdVersion to key on, and the built-with never advances
+// across an upgrade, so the swap re-fires idempotently on every resume until a
+// re-pause re-bakes the version. The swap runs only when the snapshot's rootfs
+// was frozen at pause (fs_quiesced): a legacy/sync-fallback snapshot is left on
+// its current envd and becomes eligible after its next freezing pause. Fully
+// best-effort — any failure boots the ORIGINAL envd, never aborting the boot.
+func (f *Factory) envdOfflineUpgradePreBoot(
+	ctx context.Context,
+	config *Config,
+	runtime RuntimeMetadata,
+	fsQuiesced bool,
+	buildID uuid.UUID,
+) PreBootFn {
+	from := config.Envd.Version
+
+	sbCtx := featureflags.SandboxContext(runtime.SandboxID)
+	tmplCtx := featureflags.TemplateContext(runtime.TemplateID)
+	path, toVersion, reason := featureflags.ResolveEnvdOfflineUpgrade(
+		ctx, f.featureFlags, from, f.config.HostEnvdPath, buildenvd.GetEnvdVersion, sbCtx, tmplCtx,
+	)
+	dec := decideOfflineSwap(path, reason, fsQuiesced)
+	if !dec.swap {
+		// A misconfigured / unstaged target is worth a logged signal on a ramp;
+		// off / same_version are the expected per-resume no-ops and stay silent.
+		if dec.logMisconfig {
+			logger.L().Info(ctx, "offline envd upgrade: target not resolved",
+				logger.WithSandboxID(runtime.SandboxID),
+				logger.WithBuildID(buildID.String()),
+				zap.String("reason", reason),
+				zap.String("built_with", from),
+			)
+		}
+		// The resolver wanted an upgrade but the rootfs isn't known crash-consistent
+		// (not frozen at pause): don't rewrite it — record the gated skip so a ramp
+		// can see the population waiting for a future freezing pause.
+		if dec.countResult != "" {
+			logger.L().Info(ctx, "skipping offline envd upgrade: snapshot rootfs was not frozen at pause (not crash-consistent); awaiting a future freezing pause",
+				logger.WithSandboxID(runtime.SandboxID),
+				logger.WithBuildID(buildID.String()),
+				zap.String("built_with", from),
+				zap.String("target", path),
+				zap.String("to_version", toVersion),
+			)
+			envdOfflineUpgradeAttempts.Add(ctx, 1, metric.WithAttributes(
+				attribute.String("result", dec.countResult),
+				attribute.String("from_version", from),
+				attribute.String("to_version", toVersion),
+			))
+		}
+
+		return nil
+	}
+
+	return func(ctx context.Context, rootfsPath string) error {
+		start := time.Now()
+		// Cancel-free but time-bounded: a request cancellation must not kill
+		// debugfs mid-write (a half-written inode would break the boot/export that
+		// follows), yet a hung tool must not stall the boot forever.
+		swapCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rootfs.EnvdSwapTimeout)
+		err := rootfs.SwapEnvdBinary(swapCtx, rootfsPath, path)
+		cancel()
+
+		// An unrecoverable swap (failed AND the original was not restored) may leave
+		// the rootfs without a usable envd. Booting it would hand back a running but
+		// envd-less sandbox; instead fail the boot so CreateSandbox tears down and
+		// the dirty overlay is discarded. Every other failure left the original in
+		// place, so it stays best-effort and boots the original.
+		unrecoverable := errors.Is(err, rootfs.ErrOfflineSwapUnrecoverable)
+		result := "success"
+		switch {
+		case err == nil:
+			logger.L().Info(ctx, "swapped envd binary before reboot",
+				logger.WithSandboxID(runtime.SandboxID),
+				logger.WithBuildID(buildID.String()),
+				zap.String("target", path),
+				zap.String("to_version", toVersion),
+				zap.String("built_with", from),
+			)
+		case unrecoverable:
+			result = "unrecoverable"
+			logger.L().Error(ctx, "offline envd swap left the rootfs without a usable envd; failing boot to discard the overlay",
+				logger.WithSandboxID(runtime.SandboxID),
+				logger.WithBuildID(buildID.String()),
+				zap.String("target", path),
+				zap.String("built_with", from),
+				zap.Error(err),
+			)
+		default:
+			result = "swap_failed"
+			logger.L().Error(ctx, "offline envd swap before reboot failed; booting original envd",
+				logger.WithSandboxID(runtime.SandboxID),
+				logger.WithBuildID(buildID.String()),
+				zap.String("target", path),
+				zap.String("built_with", from),
+				zap.Error(err),
+			)
+		}
+
+		envdOfflineUpgradeAttempts.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("result", result),
+			attribute.String("from_version", from),
+			attribute.String("to_version", toVersion),
+		))
+		envdOfflineUpgradeDurationHist.Record(ctx, time.Since(start).Milliseconds(),
+			metric.WithAttributes(attribute.String("result", result)))
+
+		if unrecoverable {
+			return fmt.Errorf("offline envd upgrade left rootfs unbootable: %w", err)
+		}
+
+		// Best-effort: swallow a recoverable failure so the cold boot proceeds on
+		// the original envd rather than failing the whole resume.
+		return nil
+	}
 }

--- a/packages/orchestrator/pkg/sandbox/reboot_offline_upgrade_test.go
+++ b/packages/orchestrator/pkg/sandbox/reboot_offline_upgrade_test.go
@@ -1,0 +1,60 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDecideOfflineSwap pins the cold-boot envd-swap gate: it must swap only when
+// the resolver returns a target AND the snapshot's rootfs was frozen at pause, and
+// otherwise report the no-op correctly. The frozen (fs_quiesced) gate is the
+// load-bearing safety property — a torn-journal rootfs must never be rewritten.
+func TestDecideOfflineSwap(t *testing.T) {
+	t.Parallel()
+
+	const target = "/fc-envd/envd.abc123"
+
+	tests := []struct {
+		name            string
+		resolverPath    string
+		reason          string
+		fsQuiesced      bool
+		wantSwap        bool
+		wantCountResult string // offline_upgrade.attempts{result=...} for a gated no-op ("" = none)
+		wantLog         bool   // log the misconfigured/unstaged reason
+	}{
+		// No upgrade from the resolver — benign no-ops, silent, no metric.
+		{"off, quiesced", "", "off", true, false, "", false},
+		{"empty reason, quiesced", "", "", true, false, "", false},
+		{"same_version, quiesced", "", "same_version", true, false, "", false},
+		// No upgrade from the resolver — misconfigured target, logged, no metric.
+		{"not_staged", "", "not_staged", true, false, "", true},
+		{"downgrade refused", "", "downgrade", true, false, "", true},
+		{"invalid_target", "", "invalid_target", true, false, "", true},
+		{"getversion_failed", "", "getversion_failed", true, false, "", true},
+		// Upgrade wanted, but the rootfs is NOT crash-consistent → gated skip, counted.
+		{"target but not frozen", target, "", false, false, "not_quiesced", false},
+		// The one path that actually swaps: upgrade wanted AND rootfs frozen.
+		{"target and frozen", target, "", true, true, "", false},
+		// A benign resolver no-op is never overridden into a swap by fs_quiesced.
+		{"off wins over frozen", "", "off", true, false, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := decideOfflineSwap(tt.resolverPath, tt.reason, tt.fsQuiesced)
+			assert.Equal(t, tt.wantSwap, got.swap, "swap")
+			assert.Equal(t, tt.wantCountResult, got.countResult, "countResult")
+			assert.Equal(t, tt.wantLog, got.logMisconfig, "logMisconfig")
+			// A gated no-op is never also a swap, and a swap never carries a no-op count.
+			if got.swap {
+				assert.Empty(t, got.countResult, "a swap must not also count a no-op")
+				assert.False(t, got.logMisconfig, "a swap must not log a misconfig")
+			}
+		})
+	}
+}

--- a/packages/orchestrator/pkg/sandbox/rootfs/envd_swap_linux.go
+++ b/packages/orchestrator/pkg/sandbox/rootfs/envd_swap_linux.go
@@ -1,0 +1,442 @@
+//go:build linux
+
+package rootfs
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// EnvdSwapTimeout bounds a single debugfs invocation. It is paired with a
+// cancel-free context so a request cancellation can't kill debugfs mid-write and
+// leave a half-written inode on the device that the following cold boot (or a
+// later pause export) would serve.
+const EnvdSwapTimeout = 2 * time.Minute
+
+// maxSwapOutput caps captured debugfs stdio so a chatty/looping tool can't grow
+// memory without bound.
+const maxSwapOutput = 64 << 10 // 64 KiB
+
+// guestEnvdPath is the in-rootfs path the swap targets.
+const guestEnvdPath = "/usr/bin/envd"
+
+// nbdDevicePath constrains the device the jailed debugfs may touch to an NBD
+// node, so a bad caller can't point it at an arbitrary block device.
+var nbdDevicePath = regexp.MustCompile(`^/dev/nbd[0-9]+$`)
+
+// ErrOfflineSwapUnrecoverable marks a swap that failed AND could not roll the
+// original back, so the rootfs may have no usable /usr/bin/envd. The caller must
+// NOT boot such a rootfs (a running-but-envd-less sandbox is useless) — it should
+// fail the operation so the dirty overlay is discarded. Every other swap failure
+// leaves the original envd in place (untouched or restored) and is recoverable.
+var ErrOfflineSwapUnrecoverable = errors.New("offline envd swap failed and the original was not restored")
+
+// SwapEnvdBinary replaces /usr/bin/envd inside an unmounted ext4 rootfs device
+// with the binary at srcPath, entirely in userspace via debugfs (libext2fs) —
+// never a host-kernel mount of the tenant image. Intended to run in the reboot
+// PreBootFn, before Firecracker boots, so a filesystem-only snapshot cold-boots
+// onto a newer envd. The device must not be mounted or written concurrently.
+//
+// The swap is transactional against the "never brick a sandbox" guarantee:
+// debugfs runs a script of commands and exits 0 even if an individual command
+// (rm/write/sif) fails, so a naive rm-then-write could delete the old envd, fail
+// the write (e.g. ENOSPC), and still exit 0 — leaving the rootfs with no envd
+// while reporting success. To avoid that, this:
+//
+//  1. backs the original binary out to the host (so there is always something to
+//     roll back to), refusing to proceed if it can't;
+//  2. performs the rm+write+sif swap;
+//  3. verifies by reading /usr/bin/envd back out and comparing its content hash to
+//     the intended binary — the process exit is not trusted;
+//  4. on any mismatch, restores the original from the host backup and returns an
+//     error, so the guest boots its original envd rather than a broken rootfs.
+func SwapEnvdBinary(ctx context.Context, devicePath, srcPath string) (e error) {
+	ctx, span := tracer.Start(ctx, "envd-binary-swap", trace.WithAttributes(
+		attribute.String("device", devicePath),
+		attribute.String("src", srcPath),
+	))
+	defer span.End()
+
+	// Stage the new binary and the debugfs command/dump files in a private
+	// directory bound into the jail. The target's real home (/fc-envd) is a
+	// gcsfuse mount that need not propagate into the unit's private mount
+	// namespace, so copy it onto local disk first.
+	stage, err := os.MkdirTemp("", "envd-swap-*")
+	if err != nil {
+		return fmt.Errorf("create swap stage dir: %w", err)
+	}
+	defer os.RemoveAll(stage)
+
+	// The jail runs debugfs as a transient DynamicUser that must traverse this
+	// directory to read the staged binary/scripts and write its dumps; MkdirTemp
+	// creates it 0700 (owner-only), so widen it to 0755.
+	if err := os.Chmod(stage, 0o755); err != nil {
+		return fmt.Errorf("chmod swap stage dir: %w", err)
+	}
+
+	stagedNew := filepath.Join(stage, "envd.new")
+	if err := copyFile(srcPath, stagedNew, 0o755); err != nil {
+		return fmt.Errorf("stage target envd %q: %w", srcPath, err)
+	}
+	// The jailed debugfs runs as an unprivileged DynamicUser with no
+	// CAP_DAC_OVERRIDE, so it can only read the staged binary via its world bits.
+	// copyFile's mode is subject to the orchestrator umask, so set it explicitly.
+	if err := os.Chmod(stagedNew, 0o755); err != nil {
+		return fmt.Errorf("chmod staged envd: %w", err)
+	}
+	wantSHA, err := fileSHA256(stagedNew)
+	if err != nil {
+		return fmt.Errorf("hash target envd: %w", err)
+	}
+
+	// 1. Back the original out to the host BEFORE touching it, so any later
+	// failure can be rolled back. debugfs `dump` reads the inode to a host file.
+	// Pre-create the target world-writable: the DynamicUser can't create files in
+	// the root-owned stage dir, but can write an already-existing 0666 file.
+	origPath := filepath.Join(stage, "envd.orig")
+	if err := createJailWritable(origPath); err != nil {
+		return fmt.Errorf("pre-create backup target: %w", err)
+	}
+	if out, derr := runDebugfs(ctx, devicePath, stage, "backup",
+		fmt.Sprintf("dump %s %s\n", guestEnvdPath, origPath), false); derr != nil {
+		return fmt.Errorf("back up original envd: %w (output: %q)", derr, string(out))
+	}
+	if fi, serr := os.Stat(origPath); serr != nil || fi.Size() == 0 {
+		// No original to fall back to — refuse rather than risk an unrecoverable
+		// swap. (A well-formed rootfs always has /usr/bin/envd.)
+		return fmt.Errorf("refusing offline swap: could not read original %s to back up (dump produced nothing)", guestEnvdPath)
+	}
+	// createJailWritable left the backup 0666 so the jail could write the dump; the
+	// rollback later `write`s it back, so make it executable-moded now (belt-and-
+	// suspenders — the rollback also `sif`s it and verifyEnvd asserts the result).
+	if err := os.Chmod(origPath, 0o755); err != nil {
+		return fmt.Errorf("chmod original backup: %w", err)
+	}
+	origSHA, err := fileSHA256(origPath)
+	if err != nil {
+		return fmt.Errorf("hash original envd: %w", err)
+	}
+
+	// 2. Swap: remove the old inode and write the new one. Do NOT branch on the
+	// process exit — debugfs exits 0 even on per-command failures, and a non-zero
+	// exit (timeout, kill, jail/device failure) says nothing reliable about the
+	// on-disk state. The decision below reads the actual rootfs and acts on that.
+	swapScript := fmt.Sprintf("rm %s\nwrite %s %s\nsif %s mode 0100755\n",
+		guestEnvdPath, stagedNew, guestEnvdPath, guestEnvdPath)
+	swapOut, swapErr := runDebugfs(ctx, devicePath, stage, "swap", swapScript, true)
+	swapCtx := "debugfs exited cleanly"
+	if swapErr != nil {
+		swapCtx = fmt.Sprintf("debugfs errored: %v (output %q)", swapErr, string(swapOut))
+	}
+
+	// 3. Decide from the ACTUAL rootfs state, not the exit code.
+	if verifyEnvd(ctx, devicePath, stage, "verify", wantSHA) == nil {
+		return nil // /usr/bin/envd is the new binary and executable — swap landed
+	}
+
+	// Not the new binary. Read what is actually on disk to choose the safe action.
+	gotSHA, readErr := dumpSHA256(ctx, devicePath, stage, "state")
+	switch {
+	case readErr != nil:
+		// Can't even read the rootfs (e.g. a persistent jail/device failure). We
+		// cannot confirm a bootable envd and must not rm/boot blindly, so fail the
+		// boot to discard the dirty overlay rather than risk a broken sandbox.
+		return fmt.Errorf("%w: swap did not land and rootfs state is unreadable (%s): %w",
+			ErrOfflineSwapUnrecoverable, swapCtx, readErr)
+	case gotSHA == origSHA:
+		// The original is untouched (the swap never modified it — e.g. the jail
+		// failed to start). Boot it: no destructive rollback needed. Recoverable.
+		return fmt.Errorf("offline envd swap did not apply; original left in place (%s)", swapCtx)
+	default:
+		// envd is damaged or gone (partial write, or removed then not rewritten —
+		// e.g. a kill after `rm`). Restore the original from the host backup.
+		if rbErr := rollbackEnvd(ctx, devicePath, stage, origPath); rbErr != nil {
+			return fmt.Errorf("%w: swap left envd damaged and rollback failed (%s): %w",
+				ErrOfflineSwapUnrecoverable, swapCtx, rbErr)
+		}
+
+		return fmt.Errorf("offline envd swap did not land (envd was damaged, %s); original envd restored", swapCtx)
+	}
+}
+
+// rollbackEnvd restores the original binary from the host backup at origPath.
+// Best-effort within the "never brick" guarantee: it rewrites the original and
+// then reads it back to confirm the restore actually landed.
+func rollbackEnvd(ctx context.Context, devicePath, stageDir, origPath string) error {
+	// The rollback is the safety net, so it must not inherit the (possibly already
+	// expired) deadline of the swap it is recovering from: detach from cancellation
+	// and give it its own budget, or a timeout mid-swap would leave envd deleted.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), EnvdSwapTimeout)
+	defer cancel()
+
+	script := fmt.Sprintf("rm %s\nwrite %s %s\nsif %s mode 0100755\n",
+		guestEnvdPath, origPath, guestEnvdPath, guestEnvdPath)
+	if out, err := runDebugfs(ctx, devicePath, stageDir, "rollback", script, true); err != nil {
+		return fmt.Errorf("restore original envd: %w (output: %q)", err, string(out))
+	}
+
+	wantSHA, err := fileSHA256(origPath)
+	if err != nil {
+		return fmt.Errorf("hash original envd for rollback check: %w", err)
+	}
+	// Verify the restore landed as an executable regular file — same content+mode
+	// check as the forward swap, so a silent `sif` failure during rollback can't
+	// leave a non-executable envd that passes a content-only check.
+	if err := verifyEnvd(ctx, devicePath, stageDir, "rollback-verify", wantSHA); err != nil {
+		return fmt.Errorf("verify restored envd: %w", err)
+	}
+
+	return nil
+}
+
+// verifyEnvd confirms /usr/bin/envd in the rootfs matches wantSHA in content AND
+// is an executable regular file. debugfs exits 0 even when a scripted command
+// (write/sif) failed, so both are read back from the device — a content match
+// alone would miss a silent sif failure that left the binary non-executable.
+func verifyEnvd(ctx context.Context, devicePath, stageDir, phase, wantSHA string) error {
+	gotSHA, err := dumpSHA256(ctx, devicePath, stageDir, phase)
+	if err != nil {
+		return fmt.Errorf("read content: %w", err)
+	}
+	if gotSHA != wantSHA {
+		return fmt.Errorf("content mismatch: got %q want %q", gotSHA, wantSHA)
+	}
+
+	// debugfs `stat` prints the inode header (Type/Mode) to stdout — no output file.
+	out, err := runDebugfs(ctx, devicePath, stageDir, phase+"-stat",
+		fmt.Sprintf("stat %s\n", guestEnvdPath), false)
+	if err != nil {
+		return fmt.Errorf("stat for mode check: %w (output: %q)", err, string(out))
+	}
+	if !envdExecutable(string(out)) {
+		return fmt.Errorf("%s is not an executable regular file after write", guestEnvdPath)
+	}
+
+	return nil
+}
+
+// debugfsModeRe extracts the octal permission bits from a debugfs `stat` header
+// line, e.g. "Inode: 12   Type: regular    Mode:  0755   Flags: 0x0".
+var debugfsModeRe = regexp.MustCompile(`Mode:\s*0*([0-7]{3,4})`)
+
+// envdExecutable reports whether debugfs `stat` output describes a regular file
+// with the owner-execute bit set.
+func envdExecutable(statOut string) bool {
+	if !strings.Contains(statOut, "Type: regular") {
+		return false
+	}
+	m := debugfsModeRe.FindStringSubmatch(statOut)
+	if m == nil {
+		return false
+	}
+	perm, err := strconv.ParseInt(m[1], 8, 32)
+	if err != nil {
+		return false
+	}
+
+	return perm&0o100 != 0
+}
+
+// dumpSHA256 reads /usr/bin/envd out of the rootfs (read-only) and returns the
+// sha256 of its bytes.
+func dumpSHA256(ctx context.Context, devicePath, stageDir, phase string) (string, error) {
+	out := filepath.Join(stageDir, "envd."+phase)
+	// Pre-create world-writable so the jailed DynamicUser can write the dump into
+	// the root-owned stage dir (see createJailWritable).
+	if err := createJailWritable(out); err != nil {
+		return "", fmt.Errorf("pre-create dump target: %w", err)
+	}
+	if o, err := runDebugfs(ctx, devicePath, stageDir, phase,
+		fmt.Sprintf("dump %s %s\n", guestEnvdPath, out), false); err != nil {
+		return "", fmt.Errorf("dump %s: %w (output: %q)", guestEnvdPath, err, string(o))
+	}
+
+	return fileSHA256(out)
+}
+
+// createJailWritable creates (or truncates) path as an empty world-writable file
+// so the jailed debugfs DynamicUser can open it as a `dump` target: it cannot
+// create files in the root-owned 0755 stage dir, but opening an already-existing
+// 0666 file for writing needs no directory write. The explicit chmod defeats the
+// process umask.
+func createJailWritable(path string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o666)
+	if err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	return os.Chmod(path, 0o666)
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+
+		return err
+	}
+
+	return out.Close()
+}
+
+// runDebugfs runs `debugfs [-w] -f <script> <device>` under a systemd-run seccomp
+// jail: empty root, DynamicUser in group disk, no network, minimal syscall
+// surface — so a crash while parsing the tenant filesystem is contained, not a
+// host compromise. writable adds -w (the device is opened read-only otherwise, so
+// a dump/verify cannot mutate the tenant image). The staged directory (new binary,
+// command file, and dump outputs) is bind-mounted read-write at its host path so
+// `write`/`-f` sources and `dump` targets resolve unchanged. phase names the
+// transient unit and script file so sequential invocations don't collide.
+func runDebugfs(ctx context.Context, devicePath, stageDir, phase, script string, writable bool) ([]byte, error) {
+	if !nbdDevicePath.MatchString(devicePath) {
+		return nil, fmt.Errorf("refusing to run debugfs on unexpected device path %q", devicePath)
+	}
+
+	scriptPath := filepath.Join(stageDir, "cmds-"+phase)
+	if err := os.WriteFile(scriptPath, []byte(script), 0o644); err != nil {
+		return nil, fmt.Errorf("write debugfs script: %w", err)
+	}
+	// WriteFile's mode is subject to umask; the jailed DynamicUser reads the script
+	// via its world bits, so set it explicitly.
+	if err := os.Chmod(scriptPath, 0o644); err != nil {
+		return nil, fmt.Errorf("chmod debugfs script: %w", err)
+	}
+
+	unit := "envd-swap-" + phase + "-" + filepath.Base(devicePath)
+
+	args := []string{
+		"--wait", "--pipe", "--collect", "--quiet",
+		"--unit=" + unit,
+		fmt.Sprintf("--property=RuntimeMaxSec=%d", int(EnvdSwapTimeout.Seconds())),
+		"--property=KillSignal=SIGKILL",
+		"--property=TimeoutStopSec=10s",
+		"--property=DynamicUser=yes",
+		"--property=SupplementaryGroups=disk",
+		"--property=ProtectProc=invisible",
+		"--property=ProcSubset=pid",
+		"--property=PrivateNetwork=yes",
+		"--property=PrivateIPC=yes",
+		"--property=ProtectHome=yes",
+		"--property=NoNewPrivileges=yes",
+		"--property=CapabilityBoundingSet=",
+		"--property=AmbientCapabilities=",
+		"--property=RestrictNamespaces=yes",
+		"--property=SystemCallFilter=@system-service",
+		// debugfs rewrites inode fields inside the image via libext2fs, not via
+		// host chown/setuid or resource syscalls, so subtract those from the
+		// @system-service allow-list rather than leave them reachable.
+		"--property=SystemCallFilter=~@privileged @resources",
+		"--property=SystemCallArchitectures=native",
+		"--property=RestrictAddressFamilies=AF_UNIX",
+		"--property=LockPersonality=yes",
+		"--property=ProtectClock=yes",
+		"--property=ProtectKernelTunables=yes",
+		"--property=ProtectKernelModules=yes",
+		"--property=ProtectKernelLogs=yes",
+		"--property=ProtectControlGroups=yes",
+		"--property=ProtectHostname=yes",
+		"--property=RestrictRealtime=yes",
+		// debugfs does not JIT; deny writable+executable mappings.
+		"--property=MemoryDenyWriteExecute=yes",
+		// PrivateNetwork already isolates the network; make the intent explicit.
+		"--property=IPAddressDeny=any",
+		"--property=Environment=",
+		// Empty root: loader, libraries, target device, and the staged directory
+		// (read-write, for dump outputs) are all that's visible.
+		"--property=TemporaryFileSystem=/",
+		"--property=BindReadOnlyPaths=/usr",
+		"--property=BindReadOnlyPaths=/usr/lib64:/lib64",
+		"--property=BindReadOnlyPaths=/usr/lib:/lib",
+		"--property=BindReadOnlyPaths=/usr/bin:/bin",
+		"--property=BindReadOnlyPaths=/usr/sbin:/sbin",
+		"--property=BindPaths=" + stageDir,
+		"--property=MountAPIVFS=yes",
+		"--property=PrivateDevices=yes",
+		fmt.Sprintf("--property=DeviceAllow=%s rw", devicePath),
+		"--property=BindPaths=" + devicePath,
+		"--",
+		"/usr/sbin/debugfs",
+	}
+	if writable {
+		args = append(args, "-w")
+	}
+	args = append(args, "-f", scriptPath, devicePath)
+
+	out := &cappedBuffer{limit: maxSwapOutput}
+	cmd := exec.CommandContext(ctx, "systemd-run", args...)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	err := cmd.Run()
+
+	// Force the transient unit down before returning so debugfs can never outlive
+	// this call and write concurrently with the boot/export that follows.
+	stopCtx, stopCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer stopCancel()
+	_ = exec.CommandContext(stopCtx, "systemctl", "stop", "--quiet", unit+".service").Run()
+
+	return out.Bytes(), err
+}
+
+// cappedBuffer accumulates writes up to limit bytes and silently discards the
+// rest, while always reporting a full write so the child process is never blocked
+// or handed a short-write error.
+type cappedBuffer struct {
+	limit int
+	buf   bytes.Buffer
+}
+
+func (c *cappedBuffer) Write(p []byte) (int, error) {
+	if rem := c.limit - c.buf.Len(); rem > 0 {
+		if len(p) > rem {
+			c.buf.Write(p[:rem])
+		} else {
+			c.buf.Write(p)
+		}
+	}
+
+	return len(p), nil
+}
+
+func (c *cappedBuffer) Bytes() []byte { return c.buf.Bytes() }

--- a/packages/orchestrator/pkg/sandbox/rootfs/envd_swap_linux_test.go
+++ b/packages/orchestrator/pkg/sandbox/rootfs/envd_swap_linux_test.go
@@ -1,0 +1,76 @@
+//go:build linux
+
+package rootfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNBDDevicePath pins the device allowlist the jailed debugfs is constrained
+// to: only a bare NBD node, so a bad caller can't point the rewrite at an
+// arbitrary block device (a partition, a real disk, or a traversal).
+func TestNBDDevicePath(t *testing.T) {
+	t.Parallel()
+
+	for _, ok := range []string{"/dev/nbd0", "/dev/nbd1", "/dev/nbd42"} {
+		assert.Truef(t, nbdDevicePath.MatchString(ok), "%q should be accepted", ok)
+	}
+	for _, bad := range []string{
+		"/dev/sda", "/dev/nbd", "/dev/nbd0p1", "/dev/nbd0 ", "/dev/nbdx",
+		"../../dev/nbd0", "/dev/nbd0;rm", "/tmp/nbd0", "",
+	} {
+		assert.Falsef(t, nbdDevicePath.MatchString(bad), "%q should be rejected", bad)
+	}
+}
+
+// TestRunDebugfsRejectsNonNBDDevice verifies the guard is actually wired into the
+// jail launcher (not just the regex): a non-NBD device is refused before any
+// debugfs/systemd-run process is spawned, so this needs no root or debugfs.
+func TestRunDebugfsRejectsNonNBDDevice(t *testing.T) {
+	t.Parallel()
+
+	out, err := runDebugfs(t.Context(), "/dev/sda", t.TempDir(), "swap", "rm /usr/bin/envd\n", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to run debugfs on unexpected device path")
+	assert.Empty(t, out)
+}
+
+// TestEnvdExecutable pins the mode check the swap/rollback verify relies on: a
+// content match is not enough — a silent `sif` failure could leave envd
+// non-executable, which this must catch from debugfs `stat` output.
+func TestEnvdExecutable(t *testing.T) {
+	t.Parallel()
+
+	exec := "Inode: 12   Type: regular    Mode:  0755   Flags: 0x0\nUser: 0   Group: 0   Size: 100\n"
+	nonExec := "Inode: 12   Type: regular    Mode:  0644   Flags: 0x0\nUser: 0   Group: 0   Size: 100\n"
+	dir := "Inode: 2   Type: directory    Mode:  0755   Flags: 0x0\n"
+
+	assert.True(t, envdExecutable(exec), "regular file 0755 is executable")
+	assert.True(t, envdExecutable("Type: regular    Mode:  0555"), "0555 has the owner-exec bit")
+	assert.False(t, envdExecutable(nonExec), "regular file 0644 is NOT executable (silent sif failure)")
+	assert.False(t, envdExecutable(dir), "a directory is not an executable regular file")
+	assert.False(t, envdExecutable(""), "empty stat output is not executable")
+	assert.False(t, envdExecutable("Type: regular"), "missing Mode is not executable")
+}
+
+// TestCappedBuffer verifies debugfs output is bounded: writes past the limit are
+// discarded, but every Write still reports a full write so the child is never
+// blocked or handed a short-write error.
+func TestCappedBuffer(t *testing.T) {
+	t.Parallel()
+
+	b := &cappedBuffer{limit: 4}
+
+	n, err := b.Write([]byte("abcdef"))
+	require.NoError(t, err)
+	assert.Equal(t, 6, n, "Write must report the full length even when capped")
+	assert.Equal(t, "abcd", string(b.Bytes()))
+
+	n, err = b.Write([]byte("ghij"))
+	require.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, "abcd", string(b.Bytes()), "buffer stays capped across writes")
+}

--- a/packages/shared/pkg/featureflags/envd_offline_upgrade_resolver_test.go
+++ b/packages/shared/pkg/featureflags/envd_offline_upgrade_resolver_test.go
@@ -1,0 +1,98 @@
+package featureflags
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk/v7/testhelpers/ldtestdata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveEnvdOfflineUpgrade_ReadsSiblingFlag proves the offline resolver
+// is driven by envd-offline-upgrade-target and is independent of the
+// live-path flag envd-upgrade-target — so the two mechanisms ramp separately.
+// It goes through the real Client so the flag plumbing, not just the pure
+// decision, is exercised.
+func TestResolveEnvdOfflineUpgrade_ReadsSiblingFlag(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	promoted := filepath.Join(dir, "envd")
+	require.NoError(t, os.WriteFile(promoted, []byte("x"), 0o755))
+	getVersion := func(_ context.Context, _ string) (string, error) { return "0.6.12", nil }
+
+	// Live-path flag ON, offline flag OFF (its default): the offline resolver must
+	// still be a no-op — it must not read the live flag.
+	source := ldtestdata.DataSource()
+	source.Update(source.Flag(EnvdUpgradeTargetFlag.Key()).ValueForAll(ldvalue.String("promoted")))
+	ff, err := NewClientWithDatasource(source)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ff.Close(t.Context()) })
+
+	path, _, reason := ResolveEnvdOfflineUpgrade(t.Context(), ff, "0.6.5", promoted, getVersion)
+	assert.Empty(t, path, "offline resolver must ignore the live-path flag")
+	assert.Equal(t, "off", reason)
+
+	// Now turn the offline flag on: the swap resolves.
+	source.Update(source.Flag(EnvdOfflineUpgradeTargetFlag.Key()).ValueForAll(ldvalue.String("promoted")))
+	path, version, reason := ResolveEnvdOfflineUpgrade(t.Context(), ff, "0.6.5", promoted, getVersion)
+	assert.Equal(t, promoted, path)
+	assert.Equal(t, "0.6.12", version)
+	assert.Empty(t, reason)
+}
+
+// TestOfflineUpgradeConvergence covers the convergence behavior: the offline swap keys on the
+// snapshot's BUILT-WITH version (there is no running envd at cold-boot swap
+// time), and the swap never advances that recorded version. So a re-resumed,
+// already-upgraded snapshot resolves an upgrade AGAIN on every cold boot — an
+// accepted, idempotent re-fire — until a re-pause re-bakes the version. This
+// test walks the two resume cycles the PoC exercises on the cluster.
+func TestOfflineUpgradeConvergence(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	promoted := filepath.Join(dir, "envd")
+	require.NoError(t, os.WriteFile(promoted, []byte("x"), 0o755))
+
+	const (
+		builtWith = "0.6.5"  // the snapshot's recorded (built-with) version
+		target    = "0.6.12" // the staged upgrade target
+	)
+	getVersion := func(_ context.Context, path string) (string, error) {
+		if path == promoted {
+			return target, nil
+		}
+
+		return "", fmt.Errorf("unknown binary %s", path)
+	}
+
+	// Cycle 1 — first resume of the pre-upgrade snapshot: built-with < target, so
+	// the resolver returns a swap.
+	path, version, reason := resolveEnvdUpgradePath(t.Context(), "promoted", builtWith, promoted, getVersion)
+	require.Equal(t, promoted, path, "cycle 1 must resolve a swap")
+	require.Equal(t, target, version)
+	require.Empty(t, reason)
+
+	// Cycle 2 — resume AGAIN without a re-pause. The on-disk binary is now the
+	// target, but the snapshot's built-with is unchanged (the swap does not update
+	// it, and pause does not persist LiveEnvdVersion), so the resolver STILL sees
+	// built-with < target and re-fires. Harmless: the swap replaces the target
+	// binary with the same target binary (idempotent).
+	path2, version2, reason2 := resolveEnvdUpgradePath(t.Context(), "promoted", builtWith, promoted, getVersion)
+	assert.Equal(t, promoted, path2, "cycle 2 re-fires because built-with never advances")
+	assert.Equal(t, target, version2)
+	assert.Empty(t, reason2)
+
+	// Convergence only after a re-pause re-bakes the running version as built-with:
+	// then built-with == target and the resolver no-ops (same_version). This is the
+	// deferred cross-pause improvement; without it, the re-fire above is the
+	// accepted steady state.
+	pathConverged, _, reasonConverged := resolveEnvdUpgradePath(t.Context(), "promoted", target, promoted, getVersion)
+	assert.Empty(t, pathConverged, "once built-with == target the swap no-ops")
+	assert.Equal(t, "same_version", reasonConverged)
+}

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -573,10 +573,19 @@ var (
 	// and cohort canaries come for free. The fallback is env-overridable
 	// (ENVD_UPGRADE_TARGET) so it can be exercised where there is no LD (dev),
 	// mirroring build-firecracker-version's DEFAULT_FIRECRACKER_VERSION.
-	EnvdUpgradeTargetFlag       = NewStringFlag("envd-upgrade-target", env.GetEnv("ENVD_UPGRADE_TARGET", "off"))
-	DefaultPersistentVolumeType = NewStringFlag("default-persistent-volume-type", "")
-	BuildNodeInfo               = NewJSONFlag("preferred-build-node", ldvalue.Null())
-	FirecrackerVersions         = NewJSONFlag("firecracker-versions", ldvalue.FromJSONMarshal(FirecrackerVersionMap))
+	EnvdUpgradeTargetFlag = NewStringFlag("envd-upgrade-target", env.GetEnv("ENVD_UPGRADE_TARGET", "off"))
+	// EnvdOfflineUpgradeTargetFlag drives the OFFLINE envd upgrade of a
+	// filesystem-only snapshot: at cold-boot resume the rootfs binary is rewritten
+	// (jailed debugfs) before the guest boots, reaching envd too old to self-upgrade
+	// (< MinEnvdVersionForUpgrade). Same value grammar and resolver as
+	// EnvdUpgradeTargetFlag ("off" / "promoted" / "<git-sha>"); a SEPARATE flag so
+	// the newer/riskier offline mechanism ramps independently of the live path. The
+	// fallback is env-overridable (ENVD_OFFLINE_UPGRADE_TARGET) for dev, where there
+	// is no LD. Default off.
+	EnvdOfflineUpgradeTargetFlag = NewStringFlag("envd-offline-upgrade-target", env.GetEnv("ENVD_OFFLINE_UPGRADE_TARGET", "off"))
+	DefaultPersistentVolumeType  = NewStringFlag("default-persistent-volume-type", "")
+	BuildNodeInfo                = NewJSONFlag("preferred-build-node", ldvalue.Null())
+	FirecrackerVersions          = NewJSONFlag("firecracker-versions", ldvalue.FromJSONMarshal(FirecrackerVersionMap))
 
 	// ClickhouseReadEndpointFlag selects which ClickHouse DSN to use for reads.
 	// "" (empty) → singular CLICKHOUSE_CONNECTION_STRING (self-managed default).
@@ -916,6 +925,25 @@ func ResolveEnvdUpgrade(
 	getVersion func(context.Context, string) (string, error),
 ) (path, version, reason string) {
 	return resolveEnvdUpgradePath(ctx, ff.StringFlag(ctx, EnvdUpgradeTargetFlag), builtWithVersion, hostEnvdPath, getVersion)
+}
+
+// ResolveEnvdOfflineUpgrade is the offline-swap analog of ResolveEnvdUpgrade
+// same pure decision, keyed on EnvdOfflineUpgradeTargetFlag so the
+// offline path ramps independently of the live one. builtWithVersion is the
+// snapshot's recorded envd version (there is no running envd at cold-boot swap
+// time), so — unlike the live path, which keys on the reported LiveEnvdVersion —
+// the built-with never advances across an upgrade and this resolver keeps
+// returning the same target on every resume until a re-pause re-bakes the
+// version (an accepted, idempotent per-resume re-fire).
+func ResolveEnvdOfflineUpgrade(
+	ctx context.Context,
+	ff *Client,
+	builtWithVersion string,
+	hostEnvdPath string,
+	getVersion func(context.Context, string) (string, error),
+	evalContexts ...ldcontext.Context,
+) (path, version, reason string) {
+	return resolveEnvdUpgradePath(ctx, ff.StringFlag(ctx, EnvdOfflineUpgradeTargetFlag, evalContexts...), builtWithVersion, hostEnvdPath, getVersion)
 }
 
 // resolveEnvdUpgradePath is the pure decision, split out so it can be unit-tested

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -67,6 +67,15 @@ const (
 	// dropped or degraded something it re-adopted across the swap.
 	OrchestratorEnvdUpgradeHandover CounterType = "orchestrator.envd.upgrade.handover"
 
+	// OrchestratorEnvdOfflineUpgradeAttempts counts OFFLINE envd upgrades
+	// — the cold-boot rootfs binary swap of a filesystem-only snapshot — by result
+	// (success|swap_failed|not_quiesced|unrecoverable) and from_version/to_version. Because the
+	// swap keys on the snapshot's built-with version (never advanced by the swap),
+	// a re-resumed already-upgraded snapshot fires again with
+	// from_version==the old built-with and to_version==target; that expected
+	// idempotent re-fire is visible here rather than hidden.
+	OrchestratorEnvdOfflineUpgradeAttempts CounterType = "orchestrator.envd.offline_upgrade.attempts"
+
 	// PauseResumePrefetchHarvestAttempts counts pause-resume prefetch harvest
 	// attempts, by result (success|resume_failed|collect_failed|skipped). The
 	// throwaway is absent from Prometheus otherwise (registration-skip), so this
@@ -138,6 +147,12 @@ const (
 	// live-upgrade (delivery + trigger + WaitForEnvd) = overhead added to the
 	// resume. Labeled by result.
 	OrchestratorEnvdUpgradeDurationName HistogramType = "orchestrator.envd.upgrade.duration"
+
+	// OrchestratorEnvdOfflineUpgradeDurationName is the wall-time of the offline
+	// rootfs envd swap (jailed debugfs), recorded once per swap attempt. Catches
+	// pathological rewrites; the swap runs in the cold-boot PreBootFn, so it adds
+	// directly to resume latency.
+	OrchestratorEnvdOfflineUpgradeDurationName HistogramType = "orchestrator.envd.offline_upgrade.duration"
 
 	// Pre-pause envd heap collapse round-trip duration (the pause-path cost of
 	// POST /collapse: network plus envd's madvise work), recorded once per pause
@@ -269,6 +284,7 @@ var counterDesc = map[CounterType]string{
 	OrchestratorSnapshotUploadFailedCounterName: "Number of pause-snapshot uploads that never landed durably",
 	SandboxPauseFsQuiescedCounterName:           "Filesystem-only pauses by whether the rootfs was frozen (quiesced) vs sync fallback",
 	OrchestratorEnvdUpgradeAttempts:             "Resume-time envd live-upgrade attempts, by result and from/to version",
+	OrchestratorEnvdOfflineUpgradeAttempts:      "Cold-boot offline envd rootfs-swap attempts, by result and from/to version",
 	OrchestratorEnvdUpgradeGated:                "Resumes the envd-upgrade-target flag targeted but the min-version gate skipped",
 	OrchestratorEnvdUpgradeHandover:             "Live-upgrade handover items by item (proc|retained|watcher) and result (ok|failed)",
 	PauseResumePrefetchHarvestAttempts:          "Pause-resume prefetch harvest attempts, by result",
@@ -308,6 +324,7 @@ var counterUnits = map[CounterType]string{
 	OrchestratorSnapshotUploadFailedCounterName: "{snapshot}",
 	SandboxPauseFsQuiescedCounterName:           "{snapshot}",
 	OrchestratorEnvdUpgradeAttempts:             "{attempt}",
+	OrchestratorEnvdOfflineUpgradeAttempts:      "{attempt}",
 	OrchestratorEnvdUpgradeGated:                "{sandbox}",
 	OrchestratorEnvdUpgradeHandover:             "{item}",
 	PauseResumePrefetchHarvestAttempts:          "{attempt}",
@@ -484,19 +501,20 @@ func GetGaugeInt(meter metric.Meter, name GaugeIntType) (metric.Int64ObservableG
 var histogramDesc = map[HistogramType]string{
 	ApiRedisStoragePublisherPublishDuration: "Duration of a single Redis PUBLISH round-trip from the storage publisher",
 
-	BuildDurationHistogramName:            "Time taken to build a template",
-	BuildPhaseDurationHistogramName:       "Time taken to build each phase of a template",
-	BuildStepDurationHistogramName:        "Time taken to build each step of a template",
-	BuildRootfsSizeHistogramName:          "Size of the built template rootfs in bytes",
-	OrchestratorSandboxCreateDurationName: "Time taken to create a sandbox",
-	OrchestratorEnvdUpgradeDurationName:   "Wall-time of a resume-time envd upgrade (delivery + trigger + WaitForEnvd)",
-	WaitForEnvdDurationHistogramName:      "Time taken for Envd to initialize successfully",
-	EnvdCollapseDurationHistogramName:     "Time taken for the pre-pause envd heap collapse round-trip",
-	GuestSyncDurationHistogramName:        "Time taken for the mandatory pre-pause guest sync (filesystem-only pause)",
-	PauseDurationHistogramName:            "Time taken to pause a sandbox, labeled by fs_only (filesystem-only vs memory) and success",
-	SnapshotProcessMemoryDurationName:     "Time to export+diff the memory file during a pause snapshot (memory pauses only), labeled by success",
-	SnapshotProcessRootfsDurationName:     "Time to export+diff the rootfs during a pause snapshot, labeled by fs_only and success",
-	SnapshotRootfsSealDurationName:        "Time for the background deferred rootfs reflink seal (off the pause critical path), labeled by success",
+	BuildDurationHistogramName:                 "Time taken to build a template",
+	BuildPhaseDurationHistogramName:            "Time taken to build each phase of a template",
+	BuildStepDurationHistogramName:             "Time taken to build each step of a template",
+	BuildRootfsSizeHistogramName:               "Size of the built template rootfs in bytes",
+	OrchestratorSandboxCreateDurationName:      "Time taken to create a sandbox",
+	OrchestratorEnvdUpgradeDurationName:        "Wall-time of a resume-time envd upgrade (delivery + trigger + WaitForEnvd)",
+	OrchestratorEnvdOfflineUpgradeDurationName: "Wall-time of the offline cold-boot envd rootfs swap (jailed debugfs)",
+	WaitForEnvdDurationHistogramName:           "Time taken for Envd to initialize successfully",
+	EnvdCollapseDurationHistogramName:          "Time taken for the pre-pause envd heap collapse round-trip",
+	GuestSyncDurationHistogramName:             "Time taken for the mandatory pre-pause guest sync (filesystem-only pause)",
+	PauseDurationHistogramName:                 "Time taken to pause a sandbox, labeled by fs_only (filesystem-only vs memory) and success",
+	SnapshotProcessMemoryDurationName:          "Time to export+diff the memory file during a pause snapshot (memory pauses only), labeled by success",
+	SnapshotProcessRootfsDurationName:          "Time to export+diff the rootfs during a pause snapshot, labeled by fs_only and success",
+	SnapshotRootfsSealDurationName:             "Time for the background deferred rootfs reflink seal (off the pause critical path), labeled by success",
 
 	PauseResumePrefetchHarvestDurationName:  "Time taken for a pause-resume prefetch harvest run (slot-hold cost)",
 	PauseResumePrefetchHarvestPagesName:     "Harvested resume-prefetch trace size in 2 MiB blocks, per successful harvest",
@@ -546,6 +564,7 @@ var histogramUnits = map[HistogramType]string{
 	BuildRootfsSizeHistogramName:                  "{By}",
 	OrchestratorSandboxCreateDurationName:         "ms",
 	OrchestratorEnvdUpgradeDurationName:           "ms",
+	OrchestratorEnvdOfflineUpgradeDurationName:    "ms",
 	WaitForEnvdDurationHistogramName:              "ms",
 	EnvdCollapseDurationHistogramName:             "ms",
 	GuestSyncDurationHistogramName:                "ms",

--- a/packages/shared/pkg/telemetry/offline_upgrade_meters_test.go
+++ b/packages/shared/pkg/telemetry/offline_upgrade_meters_test.go
@@ -1,0 +1,26 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// A metric shipped without a description/unit map entry silently emits an
+// undocumented series. Guard the offline-upgrade counter and duration histogram.
+func TestOfflineUpgradeMetersPopulated(t *testing.T) {
+	t.Parallel()
+
+	assert.NotEmptyf(t, counterDesc[OrchestratorEnvdOfflineUpgradeAttempts], "missing description for counter %s", OrchestratorEnvdOfflineUpgradeAttempts)
+	assert.NotEmptyf(t, counterUnits[OrchestratorEnvdOfflineUpgradeAttempts], "missing unit for counter %s", OrchestratorEnvdOfflineUpgradeAttempts)
+	assert.NotEmptyf(t, histogramDesc[OrchestratorEnvdOfflineUpgradeDurationName], "missing description for histogram %s", OrchestratorEnvdOfflineUpgradeDurationName)
+	assert.NotEmptyf(t, histogramUnits[OrchestratorEnvdOfflineUpgradeDurationName], "missing unit for histogram %s", OrchestratorEnvdOfflineUpgradeDurationName)
+
+	meter := noop.NewMeterProvider().Meter("github.com/e2b-dev/infra/packages/shared/pkg/telemetry")
+	_, err := GetCounter(meter, OrchestratorEnvdOfflineUpgradeAttempts)
+	require.NoError(t, err)
+	_, err = GetHistogram(meter, OrchestratorEnvdOfflineUpgradeDurationName)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Why

The same-PID live self-upgrade (envd's `/upgrade` handover) moves a sandbox's `envd` forward
*only* for `envd` that already carries the upgrade machinery (`MinEnvdVersionForUpgrade = 0.6.12`).
Everything older — including the pre-fsfreeze `< 0.6.6` cohort — is stuck on whatever `envd` it
was built with for the sandbox's entire life: there is no way to deliver an `envd` fix, feature,
or security patch to it, and a sandbox whose old `envd` is slow enough to *time out* on resume
becomes effectively un-resumable.

This reaches that cohort with a **version-agnostic** path: the old `envd` never has to cooperate.
When a *filesystem-only* snapshot (memory dropped, resume = cold boot) comes up, we rewrite
`/usr/bin/envd` in its rootfs before the VM boots, so it cold-boots on the new `envd`. The cost is
the in-memory state a filesystem-only pause already discards — nothing more.

## What

**Offline swap primitive** (`pkg/sandbox/rootfs/envd_swap_linux.go`). `SwapEnvdBinary` replaces
`/usr/bin/envd` inside the unmounted ext4 rootfs entirely in **userspace** via `debugfs`
(libext2fs) — `rm` + `write` + `sif` to restore an executable mode — never a host-kernel `mount`
of the tenant image. It runs under a `systemd-run` seccomp jail (empty root, `DynamicUser`, no
capabilities, no network, `@system-service` minus `@privileged`/`@resources`, `MemoryDenyWriteExecute`,
kernel-logs/cgroups/hostname/realtime protections), so parsing a hostile filesystem is contained, not a
host compromise — `systemd-analyze security` scores the unit **0.4 (SAFE)**, its residual exposure being
only the `disk` group and the one `/dev/nbdX` node the rewrite fundamentally needs. It operates on the
rootfs, which the cold-boot path exposes as an NBD block device
(`/dev/nbdX`) — `debugfs` edits its ext4 in place, and the jail is granted exactly that one device
node (`DeviceAllow`/`BindPaths`) with the staged binary bind-mounted read-only. A `^/dev/nbd[0-9]+$`
check guards that grant so the raw-block rewrite can't be pointed at a real disk, a partition, or a
traversal to a co-tenant device.

The swap is **transactional** against the never-brick guarantee. `debugfs -f` runs a script of
commands and exits 0 even if an individual command fails, so a naive `rm`-then-`write` could delete
the old envd, fail the `write` (e.g. ENOSPC), and still report success — a bricked rootfs. So
`SwapEnvdBinary` (a) `dump`s the original out to the host first, refusing to proceed if it can't;
(b) does the `rm`+`write`+`sif`; (c) verifies by reading `/usr/bin/envd` back and checking both its
content sha256 against the intended binary and that it is an executable regular file (`debugfs
stat`) — the process exit is not trusted, and a content-only check would miss a silent `sif`
failure that left it non-executable; and (d) **decides purely from the read-back state, never the
`debugfs` exit code** (a non-zero exit — timeout, kill, jail/device failure — says nothing reliable
about what is on disk): new binary → success; the *intact original* (swap never touched it) → boot
it with **no** rollback; *damaged/gone* (partial write, or removed then not rewritten, e.g. a kill
after `rm`) → rollback from the host backup; and *unreadable* rootfs (persistent jail failure)
→ `ErrOfflineSwapUnrecoverable`, on which the reboot hook fails the boot so `CreateSandbox` discards
the overlay rather than booting an unknown rootfs. This single state-driven decision avoids both
bricking (never boot a damaged/unknown envd) and breaking an intact rootfs (never run the rollback
`rm` when the original is already in place); a rollback that itself fails is also unrecoverable.

**Wired into cold-boot resume** (`pkg/sandbox/reboot.go`). `RebootSandbox` builds a `PreBootFn`
that runs the swap against the NBD-attached rootfs before Firecracker boots. A pure
`decideOfflineSwap` gates it on two conditions: the resolver returns an upgrade target, **and**
the snapshot's rootfs was captured frozen (`meta.IsFsQuiesced()`, from #3445) so it is
crash-consistent. A misconfigured/unstaged target is logged (not swapped); a resolved-but-unfrozen
snapshot is skipped and counted (`not_quiesced`). When the swap primitive returns
`ErrOfflineSwapUnrecoverable` (it couldn't confirm a bootable envd — see above), the hook fails the
boot so `CreateSandbox` discards the dirty overlay; every other failure is best-effort — it logs,
counts `swap_failed`, and boots the original envd. The swap is time-bounded on a cancel-free context
so a request cancellation can't kill `debugfs` mid-write.

**Reuses the merged upgrade decision** (`packages/shared/pkg/featureflags/flags.go`). A new
`ResolveEnvdOfflineUpgrade` forwards to the *same* pure `resolveEnvdUpgradePath` the live path uses
(built-with vs target version compare, upgrade-only, path-traversal-safe) — one decision, two
delivery mechanisms. It is keyed on a **sibling flag** `envd-offline-upgrade-target` (same
`off`/`promoted`/`<sha>` grammar as `envd-upgrade-target`) so the newer offline mechanism ramps
independently of the vetted live path, and threads the sandbox/template LD context for `%`-ramp
targeting.

**Metrics** (`packages/shared/pkg/telemetry/meters.go`):
`orchestrator.envd.offline_upgrade.attempts{result,from_version,to_version}` (result ∈
`success`/`swap_failed`/`not_quiesced`) and `.duration{result}`.

| Flag | Default | Guards |
|---|---|---|
| `envd-offline-upgrade-target` | `off` | whether the offline swap runs, and to which version (fed to the shared resolver) |

**Convergence (by design).** The gate keys on the snapshot's *built-with* version (there is no
running `envd` at cold-boot swap time), which the swap does not advance and pause does not
overwrite with the live version. So a re-resumed, already-upgraded snapshot resolves the upgrade
again and **re-fires the swap on every cold boot** — harmlessly (the on-disk binary is already the
target; `debugfs` replaces same-with-same). This matches the already-shipped live path, which
re-upgrades on every memory-resume. True cross-pause convergence (persist the running version at
pause) is a deliberately deferred, orthogonal follow-up.

## Validation

- **Unit** (all `-race`, `golangci-lint` clean):
  - resolver: `ResolveEnvdOfflineUpgrade` reads the sibling flag and is independent of the
    live-path flag (the two ramp separately);
  - convergence: built-with unchanged ⇒ swap re-fires; built-with == target ⇒ `same_version` no-op;
  - the gate: `decideOfflineSwap` swaps only when an upgrade is resolved **and** the rootfs is
    frozen, counts the `not_quiesced` skip, stays silent on benign no-ops, logs misconfigured
    targets — the frozen gate is what keeps a torn-journal rootfs from being rewritten;
  - swap primitive: the jailed `debugfs` device allowlist refuses anything but a bare `/dev/nbd*`
    (verified without root/debugfs) and the output cap holds;
  - a meter-map guard that both new metrics carry description + unit entries.
- **Jail hardening, node-verified**: `systemd-analyze security` on a live unit with the jail's exact
  property set scores **0.4 (SAFE)**; a fixture ext4 driven through the real `write`+`sif`+`stat`+`dump`
  sequence under that hardened jail on a dev node produced the expected inode (regular, mode `0755`,
  matching content sha), confirming the tightened syscall/mapping restrictions don't break `debugfs`.
- **Dev-cluster 2-cycle e2e, run twice** (before and after the `decideOfflineSwap` factor-out;
  identical results). One sandbox from an `envd`-0.6.5 template, `envd-offline-upgrade-target=vb`
  → `/fc-envd/envd.vb` (0.6.12), two `pause(memory:false)` → resume cycles:
  - in-guest `sha256(/usr/bin/envd)` / version: `a0810802…`/**0.6.5** → `8e05066c…`/**0.6.12** →
    `8e05066c…`/**0.6.12** (swapped on cycle 1, unchanged on cycle 2);
  - orchestrator log: exactly **2×** `swapped envd binary before reboot`, both
    `built_with=0.6.5 → envd.vb/0.6.12`;
  - Mimir: `orchestrator_envd_offline_upgrade_attempts_total{result="success",from_version="0.6.5",
    to_version="0.6.12"} = 2`.
- **Transactional swap, cluster-verified** (the swap primitive has no CI coverage — no `debugfs`
  in CI — so this was validated on a dev node):
  - *happy path*: an fs-only resume of an envd-0.6.5 snapshot swaps to 0.6.12 end-to-end (the
    jailed `debugfs` writes its backup + verify `dump`s successfully and the content-hash verify
    passes) — confirmed by the in-guest hash flip + the `swapped envd binary before reboot` log;
  - *rollback (content)*: with a forced `rm`-succeeds/`write`-fails injection, the verify caught the
    emptied binary (`got sha e3b0c442…` [empty] vs the 0.6.12 target) and the rollback restored the
    original — the guest booted and stayed responsive on **0.6.5**, never a rootfs without envd;
  - *rollback (mode)*: with a forced non-executable `sif 0100644` (content correct, mode wrong), the
    verify failed with `/usr/bin/envd is not an executable regular file after write` and the
    rollback again restored a bootable **0.6.5** — proving the mode-check catches a silent `sif`
    failure a content-only check would pass;
  - *intact-original (verify-then-decide)*: with a forced no-op swap (envd untouched), the state
    read-back matched the original, so it logged `swap did not apply; original left in place` and
    booted **0.6.5** with **no rollback** — proving an intact rootfs is never rm'd, and (with the
    rollback passes above) that the swap decision is driven by the read-back state, not the exit code.

## Key decisions

- **Userspace `debugfs` in a seccomp jail, not a host mount** — mounting a customer-controlled
  ext4 image on the host kernel exposes the node and co-tenants to the ext4 parser's CVE surface;
  the jailed userspace rewrite contains a crash.
- **Gate on `fs_quiesced` (#3445), no repair** — only rewrite rootfs known to be frozen at pause
  (crash-consistent). Legacy/sync-fallback snapshots are left on their `envd` and become eligible
  after their next freezing pause; there is deliberately no host-side journal repair.
- **Reuse the merged resolver + a sibling flag** — the "which version" decision is identical to the
  live path, so it shares `resolveEnvdUpgradePath`; a separate flag keeps the offline mechanism's
  rollout blast radius independent.
- **Transactional swap, best-effort resume** — `debugfs -f` exits 0 even when a scripted command
  fails, so the primitive backs the original out to the host, verifies the result by content sha
  after the swap, and rolls the original back on any mismatch; a swap failure boots the original
  `envd`, so the feature can only make a sandbox *newer*, never unbootable. (An atomic in-place
  rename via `debugfs ln` was rejected — its `ln`/`unlink` don't maintain inode link counts and
  would leave an fsck-dirty rootfs.)
- **Accept the idempotent per-resume re-fire** — matches the existing live-upgrade contract;
  cross-pause convergence is deferred rather than bundled here.
- **Deferred**: a CI-runnable integration test of the real `debugfs` rewrite (fixture ext4 → assert
  bytes/mode/no-other-inode-changed) — it needs `debugfs` + a loop image, so it is left as a
  build-tagged follow-up; the rewrite is currently covered by the dev-cluster e2e.
- Default `off`; no customer-facing API change; no `envd`/proto/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

