### PR TITLE
fix(orchestrator): recover lost ancestor entries when persisting headers

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build/storage_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff.go
@@ -220,6 +220,9 @@ func (b *File) createDiff(ctx context.Context, buildID uuid.UUID) (Diff, error) 
 				if err == nil && size == 0 {
 					size, err = upstream.Size(ctx)
 				}
+			} else {
+				// Report why the recovery failed, not just the object miss.
+				err = errors.Join(err, lerr)
 			}
 		}
 		if err != nil {

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff.go
@@ -23,6 +23,7 @@ import (
 const (
 	refreshCauseProactive        = "proactive"
 	refreshCausePeerTransitioned = "peer_transitioned"
+	refreshCauseZeroEntryMiss    = "zero_entry_miss"
 )
 
 // source carries the StorageDiff's current routing state. upstream is always
@@ -144,10 +145,11 @@ func (b *File) createDiff(ctx context.Context, buildID uuid.UUID) (Diff, error) 
 	switch {
 	case hasEntry:
 		// bd.FrameData is per-mapping trimmed, not the ancestor's full table —
-		// don't latch it; first read will refresh. Exception: a zero bd is the
-		// LoadHeader backfill marker for an uncompressed V3-or-older ancestor;
-		// UncompressedFullFrameTable IS that ancestor's full table, latch it
-		// to skip a refresh whose header file may not exist.
+		// don't latch it; first read will refresh. Exception: a zero bd marks
+		// an uncompressed V3-or-older ancestor; UncompressedFullFrameTable IS
+		// that ancestor's full table, latch it to skip a refresh whose header
+		// file may not exist. If the mark proves false, the size lookup below
+		// recovers via the build's own header.
 		upstream, dataPath, err = b.openDataFile(ctx, buildID, bd.FrameData.CompressionType())
 		if err != nil {
 			return nil, err
@@ -207,6 +209,19 @@ func (b *File) createDiff(ctx context.Context, buildID uuid.UUID) (Diff, error) 
 
 	if size == 0 {
 		size, err = upstream.Size(ctx)
+		if hasEntry && initialFT == storage.UncompressedFullFrameTable && errors.Is(err, storage.ErrObjectNotExist) {
+			// The zero entry claimed an uncompressed V3-era ancestor, but the
+			// suffix-less object does not exist: the entry is a gap persisted
+			// as zero by older releases. Resolve the build's own header like
+			// the no-entry branch instead of failing every fault permanently.
+			loaded, lerr := refreshHeader(ctx, b.persistence, buildID, b.fileType, refreshCauseZeroEntryMiss)
+			if lerr == nil {
+				upstream, size, initialFT, dataPath, err = openFromLoadedHeader(ctx, b.persistence, loaded, b.fileType)
+				if err == nil && size == 0 {
+					size, err = upstream.Size(ctx)
+				}
+			}
+		}
 		if err != nil {
 			return nil, fmt.Errorf("createDiff: size lookup for build %s: %w", buildID, err)
 		}

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff.go
@@ -48,6 +48,21 @@ func isPeerRouted(v any) bool {
 	return ok
 }
 
+// zeroEntryRefreshCause maps a size lookup that a zero Builds entry could not
+// answer to the cause of the header refresh that recovers it, or "" when the
+// error is not recoverable that way.
+func zeroEntryRefreshCause(err error) string {
+	var transErr *storage.PeerTransitionedError
+	switch {
+	case errors.Is(err, storage.ErrObjectNotExist):
+		return refreshCauseZeroEntryMiss
+	case errors.As(err, &transErr):
+		return refreshCausePeerTransitioned
+	default:
+		return ""
+	}
+}
+
 type StorageDiff struct {
 	chunker           *block.Chunker
 	cachePath         string
@@ -209,12 +224,12 @@ func (b *File) createDiff(ctx context.Context, buildID uuid.UUID) (Diff, error) 
 
 	if size == 0 {
 		size, err = upstream.Size(ctx)
-		if hasEntry && initialFT == storage.UncompressedFullFrameTable && errors.Is(err, storage.ErrObjectNotExist) {
+		if cause := zeroEntryRefreshCause(err); hasEntry && initialFT == storage.UncompressedFullFrameTable && cause != "" {
 			// The zero entry claimed an uncompressed V3-era ancestor, but the
-			// suffix-less object does not exist: the entry is a gap persisted
-			// as zero by older releases. Resolve the build's own header like
-			// the no-entry branch instead of failing every fault permanently.
-			loaded, lerr := refreshHeader(ctx, b.persistence, buildID, b.fileType, refreshCauseZeroEntryMiss)
+			// basic-name object cannot answer: it does not exist, or the peer
+			// serving it is gone. Resolve the build's own header like the
+			// no-entry branch instead of failing every fault permanently.
+			loaded, lerr := refreshHeader(ctx, b.persistence, buildID, b.fileType, cause)
 			if lerr == nil {
 				upstream, size, initialFT, dataPath, err = openFromLoadedHeader(ctx, b.persistence, loaded, b.fileType)
 				if err == nil && size == 0 {

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff_test.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff_test.go
@@ -624,6 +624,76 @@ func TestStorageDiff_StaleZeroEntryRecoversFromOwnHeader(t *testing.T) {
 	require.Equal(t, payload[:readLen], runRead(t, bHeader, provider))
 }
 
+// Same stale zero entry, but the ancestor is still peer-routed: a peer miss
+// reports PeerTransitionedError, never ErrObjectNotExist, so the recovery has
+// to treat it as the no-entry branch does — refresh the build's own header —
+// instead of failing the read for the length of the transition window.
+func TestStorageDiff_StaleZeroEntryRecoversAfterPeerTransition(t *testing.T) {
+	t.Parallel()
+
+	const (
+		frameSizeKB = 256
+		payloadSize = 256 * 1024
+	)
+	readLen := testBlockSize
+
+	ctx := t.Context()
+	aID := uuid.New()
+	payload := bytes.Repeat([]byte("peer-zero-"), payloadSize/len("peer-zero-")+1)[:payloadSize]
+
+	aFrameTable, compressed, _, err := storage.CompressBytes(ctx, payload, storage.CompressConfig{
+		Enabled:            true,
+		Type:               storage.CompressionZstd.String(),
+		Level:              2,
+		EncoderConcurrency: 1,
+		FrameEncodeWorkers: 1,
+		FrameSizeKB:        frameSizeKB,
+		MinPartSizeMB:      50,
+	})
+	require.NoError(t, err)
+
+	aHeader := buildHeader(t, aID, payloadSize, aID)
+	aHeader.SetBuild(aID, header.BuildData{Size: int64(payloadSize), FrameData: aFrameTable.Table()})
+	aHeaderBytes, err := header.SerializeHeader(aHeader)
+	require.NoError(t, err)
+
+	bHeader := buildHeader(t, uuid.New(), payloadSize, aID)
+	bHeader.SetBuild(aID, header.BuildData{})
+
+	aPaths := storage.Paths{BuildID: aID.String()}
+	provider := storage.NewMockStorageProvider(t)
+
+	// The zero entry opens the suffix-less name through the peer-routing
+	// provider; the peer is already gone, so Size signals the transition.
+	peerSeekable := storage.NewMockSeekable(t)
+	peerSeekable.EXPECT().
+		Size(mock.Anything).
+		Return(int64(0), &storage.PeerTransitionedError{}).Once()
+	provider.EXPECT().
+		OpenSeekable(mock.Anything, aPaths.DataFile(storage.MemfileName, storage.CompressionNone)).
+		Return(peerRoutedSeekable{Seekable: peerSeekable}, nil).Once()
+
+	headerBlob := storage.NewMockBlob(t)
+	headerBlob.EXPECT().
+		WriteTo(mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, w io.Writer) (int64, error) {
+			return io.Copy(w, bytes.NewReader(aHeaderBytes))
+		}).Once()
+	provider.EXPECT().
+		OpenBlob(mock.Anything, aPaths.HeaderFile(storage.MemfileName)).
+		Return(headerBlob, nil).Once()
+
+	compressedSeekable := storage.NewMockSeekable(t)
+	compressedSeekable.EXPECT().
+		OpenRangeReader(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(decompressingRangeReader(compressed))
+	provider.EXPECT().
+		OpenSeekable(mock.Anything, aPaths.DataFile(storage.MemfileName, storage.CompressionZstd)).
+		Return(compressedSeekable, nil).Once()
+
+	require.Equal(t, payload[:readLen], runRead(t, bHeader, provider))
+}
+
 // loadHeaderThroughStorage round-trips h via LoadHeader so the deserialize plus
 // backfill path runs as it does on a resume. Hand-built headers skip the backfill,
 // which is why the rest of this file's coverage passed while production was broken.

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff_test.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff_test.go
@@ -552,6 +552,78 @@ func TestStorageDiff_AbsentEntryOnV4ResolvesFromOwnHeader(t *testing.T) {
 	require.Equal(t, payload[:readLen], runRead(t, bHeader, provider))
 }
 
+// A zero Builds entry for a zstd ancestor: older releases fabricated zero
+// entries for gaps at load time, and a pause serialized them into descendant
+// headers as real entries — on the wire indistinguishable from the legit V3
+// uncompressed sentinel. The claimed suffix-less object does not exist, so
+// instead of failing the size lookup permanently, createDiff must fall back
+// to the build's own header and read the compressed object.
+func TestStorageDiff_StaleZeroEntryRecoversFromOwnHeader(t *testing.T) {
+	t.Parallel()
+
+	const (
+		frameSizeKB = 256
+		payloadSize = 256 * 1024
+	)
+	readLen := testBlockSize
+
+	ctx := t.Context()
+	aID := uuid.New()
+	payload := bytes.Repeat([]byte("stale-zero-"), payloadSize/len("stale-zero-")+1)[:payloadSize]
+
+	aFrameTable, compressed, _, err := storage.CompressBytes(ctx, payload, storage.CompressConfig{
+		Enabled:            true,
+		Type:               storage.CompressionZstd.String(),
+		Level:              2,
+		EncoderConcurrency: 1,
+		FrameEncodeWorkers: 1,
+		FrameSizeKB:        frameSizeKB,
+		MinPartSizeMB:      50,
+	})
+	require.NoError(t, err)
+
+	aHeader := buildHeader(t, aID, payloadSize, aID)
+	aHeader.SetBuild(aID, header.BuildData{Size: int64(payloadSize), FrameData: aFrameTable.Table()})
+	aHeaderBytes, err := header.SerializeHeader(aHeader)
+	require.NoError(t, err)
+
+	// Current header carries the stale zero entry for A.
+	bHeader := buildHeader(t, uuid.New(), payloadSize, aID)
+	bHeader.SetBuild(aID, header.BuildData{})
+
+	aPaths := storage.Paths{BuildID: aID.String()}
+	provider := storage.NewMockStorageProvider(t)
+
+	// The zero entry resolves to the suffix-less name, whose size lookup 404s.
+	rawSeekable := storage.NewMockSeekable(t)
+	rawSeekable.EXPECT().
+		Size(mock.Anything).
+		Return(int64(0), storage.ErrObjectNotExist).Once()
+	provider.EXPECT().
+		OpenSeekable(mock.Anything, aPaths.DataFile(storage.MemfileName, storage.CompressionNone)).
+		Return(rawSeekable, nil).Once()
+
+	headerBlob := storage.NewMockBlob(t)
+	headerBlob.EXPECT().
+		WriteTo(mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, w io.Writer) (int64, error) {
+			return io.Copy(w, bytes.NewReader(aHeaderBytes))
+		}).Once()
+	provider.EXPECT().
+		OpenBlob(mock.Anything, aPaths.HeaderFile(storage.MemfileName)).
+		Return(headerBlob, nil).Once()
+
+	compressedSeekable := storage.NewMockSeekable(t)
+	compressedSeekable.EXPECT().
+		OpenRangeReader(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(decompressingRangeReader(compressed))
+	provider.EXPECT().
+		OpenSeekable(mock.Anything, aPaths.DataFile(storage.MemfileName, storage.CompressionZstd)).
+		Return(compressedSeekable, nil).Once()
+
+	require.Equal(t, payload[:readLen], runRead(t, bHeader, provider))
+}
+
 // loadHeaderThroughStorage round-trips h via LoadHeader so the deserialize plus
 // backfill path runs as it does on a resume. Hand-built headers skip the backfill,
 // which is why the rest of this file's coverage passed while production was broken.

--- a/packages/orchestrator/pkg/sandbox/build_upload_test.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_test.go
@@ -5,6 +5,7 @@ package sandbox
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"testing"
 
@@ -213,6 +214,42 @@ func TestAppendAncestorBuilds_LeavesGapAbsentWithoutStoredHeader(t *testing.T) {
 	dst := map[uuid.UUID]headers.BuildData{}
 	require.NoError(t, gapUpload(t, provider).appendAncestorBuilds(t.Context(), dst, mappingTo(t, 4096, ancestorID, 4096), build.Memfile))
 	require.NotContains(t, dst, ancestorID)
+}
+
+// A transient failure loading the ancestor's header must not fail the pause:
+// the heal is an optimization, and leaving the gap absent is what every release
+// before it did — createDiff still resolves the build's own header per fault.
+func TestAppendAncestorBuilds_TransientLoadFailureKeepsUploadAlive(t *testing.T) {
+	t.Parallel()
+
+	ancestorID := uuid.New()
+	provider := storage.NewMockStorageProvider(t)
+	provider.EXPECT().
+		OpenBlob(mock.Anything, storage.Paths{BuildID: ancestorID.String()}.HeaderFile(storage.MemfileName)).
+		Return(nil, errors.New("storage unavailable")).Once()
+
+	dst := map[uuid.UUID]headers.BuildData{}
+	require.NoError(t, gapUpload(t, provider).appendAncestorBuilds(t.Context(), dst, mappingTo(t, 4096, ancestorID, 4096), build.Memfile))
+	require.NotContains(t, dst, ancestorID)
+}
+
+// A load failure on an already-cancelled context still fails: continuing would
+// bury the real cause under a store-header error further down the pause.
+func TestAppendAncestorBuilds_CancelledContextFailsUpload(t *testing.T) {
+	t.Parallel()
+
+	ancestorID := uuid.New()
+	provider := storage.NewMockStorageProvider(t)
+	provider.EXPECT().
+		OpenBlob(mock.Anything, storage.Paths{BuildID: ancestorID.String()}.HeaderFile(storage.MemfileName)).
+		Return(nil, context.Canceled).Once()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	dst := map[uuid.UUID]headers.BuildData{}
+	err := gapUpload(t, provider).appendAncestorBuilds(ctx, dst, mappingTo(t, 4096, ancestorID, 4096), build.Memfile)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 // An entry already carried through the source header is kept as-is, with no

--- a/packages/orchestrator/pkg/sandbox/build_upload_test.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_test.go
@@ -3,6 +3,9 @@
 package sandbox
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"testing"
 
 	"github.com/google/uuid"
@@ -13,6 +16,7 @@ import (
 	blockmocks "github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block/mocks"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/build"
 	templatemocks "github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/template/mocks"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/template/peerclient"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	headers "github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
@@ -149,6 +153,78 @@ func TestAppendAncestorBuilds_NilDstSkipsSynthesis(t *testing.T) {
 	u := &Upload{buildID: uuid.New(), uploads: uploads}
 	err := u.appendAncestorBuilds(t.Context(), nil, mappingTo(t, 4096, ancestorID, 4096), build.Memfile)
 	require.NoError(t, err)
+}
+
+// gapUpload builds an Upload whose ancestor is neither cached locally nor
+// peer-served, so Wait returns nil — the inherited-gap case.
+func gapUpload(t *testing.T, provider storage.StorageProvider) *Upload {
+	t.Helper()
+	uploads, _ := newUploads(t)
+	uploads.p2p = peerclient.NopResolver()
+
+	return &Upload{buildID: uuid.New(), uploads: uploads, store: provider}
+}
+
+// A mapping-referenced build missing from both dst and the local cache (a gap
+// inherited from the source header) must not be persisted as a gap — the entry
+// is recovered from the build's own stored header so it stops propagating to
+// descendant headers.
+func TestAppendAncestorBuilds_RecoversInheritedGapFromStoredHeader(t *testing.T) {
+	t.Parallel()
+
+	ancestorID := uuid.New()
+	ancestorHeader, err := headers.NewHeader(
+		&headers.Metadata{Version: headers.MetadataVersionV4, BlockSize: 4096, Size: 4096, BuildId: ancestorID, BaseBuildId: ancestorID},
+		nil,
+	)
+	require.NoError(t, err)
+	want := headers.BuildData{Size: 12345}
+	ancestorHeader.SetBuild(ancestorID, want)
+	ancestorHeaderBytes, err := headers.SerializeHeader(ancestorHeader)
+	require.NoError(t, err)
+
+	provider := storage.NewMockStorageProvider(t)
+	headerBlob := storage.NewMockBlob(t)
+	headerBlob.EXPECT().
+		WriteTo(mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, w io.Writer) (int64, error) {
+			return io.Copy(w, bytes.NewReader(ancestorHeaderBytes))
+		}).Once()
+	provider.EXPECT().
+		OpenBlob(mock.Anything, storage.Paths{BuildID: ancestorID.String()}.HeaderFile(storage.MemfileName)).
+		Return(headerBlob, nil).Once()
+
+	dst := map[uuid.UUID]headers.BuildData{}
+	require.NoError(t, gapUpload(t, provider).appendAncestorBuilds(t.Context(), dst, mappingTo(t, 4096, ancestorID, 4096), build.Memfile))
+	require.Equal(t, want, dst[ancestorID])
+}
+
+// A gap whose build has no stored header (legacy uncompressed build) stays
+// absent — the read path resolves it — and must not fail the upload.
+func TestAppendAncestorBuilds_LeavesGapAbsentWithoutStoredHeader(t *testing.T) {
+	t.Parallel()
+
+	ancestorID := uuid.New()
+	provider := storage.NewMockStorageProvider(t)
+	provider.EXPECT().
+		OpenBlob(mock.Anything, storage.Paths{BuildID: ancestorID.String()}.HeaderFile(storage.MemfileName)).
+		Return(nil, storage.ErrObjectNotExist).Once()
+
+	dst := map[uuid.UUID]headers.BuildData{}
+	require.NoError(t, gapUpload(t, provider).appendAncestorBuilds(t.Context(), dst, mappingTo(t, 4096, ancestorID, 4096), build.Memfile))
+	require.NotContains(t, dst, ancestorID)
+}
+
+// An entry already carried through the source header is kept as-is, with no
+// storage round-trip (the mock provider fails on any unexpected call).
+func TestAppendAncestorBuilds_ExistingEntrySkipsStorage(t *testing.T) {
+	t.Parallel()
+
+	ancestorID := uuid.New()
+	want := headers.BuildData{Size: 777}
+	dst := map[uuid.UUID]headers.BuildData{ancestorID: want}
+	require.NoError(t, gapUpload(t, storage.NewMockStorageProvider(t)).appendAncestorBuilds(t.Context(), dst, mappingTo(t, 4096, ancestorID, 4096), build.Memfile))
+	require.Equal(t, want, dst[ancestorID])
 }
 
 // A filesystem-only snapshot has no memfile, so its MemorySnapshot.BlockSize is

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -9,9 +9,11 @@ import (
 	"os"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/build"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	headers "github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 )
@@ -154,8 +156,9 @@ func (u *Upload) uploadFramed(
 //
 // When Wait returns nil for a build dst still lacks (a gap inherited from the
 // source header), the entry is recovered from the build's own stored header so
-// the gap stops propagating to descendant headers; only builds with no header
-// file (legacy uncompressed) stay absent, resolved by the read path.
+// the gap stops propagating to descendant headers; builds with no header file
+// (legacy uncompressed) stay absent, resolved by the read path. The heal is
+// best-effort: a failed load leaves the gap rather than failing the pause.
 //
 // Local ancestors resolve from the in-memory futures map without I/O;
 // cross-orch ancestors take a single remote storage round-trip. Sequential —
@@ -192,7 +195,18 @@ func (u *Upload) appendAncestorBuilds(
 				continue
 			}
 			if err != nil {
-				return fmt.Errorf("recover ancestor %s/%s build data: %w", buildID, fileType, err)
+				// createDiff resolves an absent entry on its own, so don't fail
+				// a snapshot over the heal — unless the context is already done.
+				if ctx.Err() != nil {
+					return fmt.Errorf("recover ancestor %s/%s build data: %w", buildID, fileType, err)
+				}
+				logger.L().Warn(ctx, "ancestor build data recovery failed, persisting header with the gap",
+					logger.WithBuildID(buildID.String()),
+					zap.String("file_type", string(fileType)),
+					zap.Error(err),
+				)
+
+				continue
 			}
 		}
 

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -4,6 +4,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -151,6 +152,11 @@ func (u *Upload) uploadFramed(
 //
 // V3 callers pass dst=nil — they need the barrier but have no Builds map.
 //
+// When Wait returns nil for a build dst still lacks (a gap inherited from the
+// source header), the entry is recovered from the build's own stored header so
+// the gap stops propagating to descendant headers; only builds with no header
+// file (legacy uncompressed) stay absent, resolved by the read path.
+//
 // Local ancestors resolve from the in-memory futures map without I/O;
 // cross-orch ancestors take a single remote storage round-trip. Sequential —
 // the critical path is the slowest pending Wait either way.
@@ -174,8 +180,20 @@ func (u *Upload) appendAncestorBuilds(
 		if err != nil {
 			return fmt.Errorf("wait for ancestor %s/%s: %w", buildID, fileType, err)
 		}
-		if h == nil || dst == nil {
+		if dst == nil {
 			continue
+		}
+		if h == nil {
+			if _, ok := dst[buildID]; ok {
+				continue
+			}
+			h, _, err = headers.LoadHeader(ctx, u.store, storage.Paths{BuildID: buildID.String()}.HeaderFile(string(fileType)))
+			if errors.Is(err, storage.ErrObjectNotExist) {
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("recover ancestor %s/%s build data: %w", buildID, fileType, err)
+			}
 		}
 
 		if bd, ok := h.Builds[buildID]; ok {

--- a/packages/orchestrator/pkg/sandbox/uploads.go
+++ b/packages/orchestrator/pkg/sandbox/uploads.go
@@ -104,7 +104,8 @@ func (u *Uploads) Start(buildID uuid.UUID) (*utils.ErrorOnce, error) {
 
 // Wait returns the parent's post-upload header, or (nil, nil) when the
 // ancestor was never opened locally and no peer is mid-upload — the caller
-// already carries its BuildData through srcHeader.Builds.
+// usually carries its BuildData through srcHeader.Builds already, and
+// appendAncestorBuilds recovers it from the build's stored header otherwise.
 func (u *Uploads) Wait(ctx context.Context, buildID uuid.UUID, t build.DiffType) (*header.Header, error) {
 	ctx, span := tracer.Start(ctx, "wait-for-parent-upload", trace.WithAttributes(
 		telemetry.WithBuildID(buildID.String()),


### PR DESCRIPTION
Two complementary fixes for headers whose mapping references builds their `Builds` map lost. #3447 stopped load-time fabrication of zero entries for such gaps; this PR closes the two paths it left open.

## Write path: stop persisting inherited gaps

A pause carries its source header's `Builds` map forward, so an entry lost once (e.g. the live header was peer-served/incomplete when an earlier pause persisted it) propagates to every descendant header, and each descendant diff pays a proactive header refresh per gap forever. Now, when `appendAncestorBuilds` resolves nothing locally and the entry is still missing, it recovers the entry from the referenced build's own stored header before the diff header is persisted — gaps heal on the next pause instead of being inherited, at the cost of one header GET per still-missing entry (normally zero). Builds with no stored header (legacy uncompressed) stay absent and keep resolving on the read path. The heal lives in `appendAncestorBuilds` rather than `StoreHeader` because that's where the ancestor barrier, storage handle, and file type already are.

## Read path: recover stale zero entries

Before #3447, the fabricated zero entries were also *serialized* whenever a pause ran on a header loaded from storage — baked into descendant headers as real entries, on the wire indistinguishable from the legit V3 uncompressed sentinel. For a compressed ancestor the claimed suffix-less object does not exist, and `createDiff` failed the size lookup permanently; #3447 only helps when the entry is absent. Now a zero entry whose basic-name object is missing falls back to the build's own header (same recovery as the no-entry branch, telemetry cause `zero_entry_miss`). Legit V3 sentinels are unaffected — their object exists, so no extra roundtrip.

Stored zero entries are re-persisted by later pauses (indistinguishable from V3 sentinels without a per-pause probe), but reads now always recover; rewriting them is fleet hygiene, not orchestrator logic.

`orchestrator.storage.diff.frame_table_refresh` (cause=proactive) should trend down as affected lineages pause past the write-path fix; cause=zero_entry_miss counts the baked-zero recoveries.

## Tests

- gap recovered from the build's stored header at upload; missing header file leaves the gap absent without failing the upload; present entries cause no storage round-trip
- stale zero entry: size-lookup 404 falls back to the build's own header and serves the compressed object; the healthy-sentinel latch test still passes unchanged
- negative controls: reverting either production change fails the corresponding test