### PR TITLE
feat(orch): separate egress DSCP for template builds and sandboxes

### DIFF
--- a/packages/orchestrator/pkg/sandbox/network/dscp_egress_test.go
+++ b/packages/orchestrator/pkg/sandbox/network/dscp_egress_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/vishvananda/netns"
 )
 
-func dscp(v uint8) *uint8 { return &v }
+func dscp(v uint8) *uint8 { return new(v) }
 
 // TestConfig_EgressDSCP covers how the two configured classes resolve. Build
 // sandboxes get their own value when one is set and otherwise inherit the

--- a/packages/orchestrator/pkg/sandbox/network/dscp_egress_test.go
+++ b/packages/orchestrator/pkg/sandbox/network/dscp_egress_test.go
@@ -221,6 +221,42 @@ func TestApplyEgressDSCP_RestampsSlotRule(t *testing.T) { //nolint:paralleltest 
 	require.Emptyf(t, dscpMangleRules(t, slot.NamespaceID()), "DSCP 0 must leave no mangle rule in %s", slot.NamespaceID())
 }
 
+// TestApplyEgressDSCP_FailedRestampIsNotCached covers the partial failure: the
+// old rule is deleted but installing the new one fails. The slot must not cache
+// the class it no longer stamps, otherwise recycle would see a match, skip the
+// restamp, and return a silently unmarked slot to the pool.
+//
+// The failure is induced with an out-of-range class, which the DSCP target
+// rejects, so the delete succeeds and only the append fails.
+func TestApplyEgressDSCP_FailedRestampIsNotCached(t *testing.T) { //nolint:paralleltest // mutates the caller's netns via LockOSThread + netns.Set; cannot run in parallel
+	if os.Geteuid() != 0 {
+		t.Skip("requires root for netns + iptables")
+	}
+
+	config, err := ParseConfig()
+	require.NoError(t, err)
+	config.SandboxEgressDSCP = 8
+
+	const idx = 30002 // high, fixed: avoid collision with the pool's low-index Populate
+	slot, err := NewSlot("dscp-failed-restamp-test", idx, config, NewNoopEgressProxy())
+	require.NoError(t, err)
+
+	require.NoError(t, slot.CreateNetwork(t.Context()))
+	t.Cleanup(func() { _ = slot.RemoveNetwork() })
+
+	requireSingleDSCPRule(t, slot, "0x08")
+
+	// 200 is outside the 6-bit DSCP range, so the append is rejected after the
+	// existing rule has already been removed.
+	require.Error(t, slot.ApplyEgressDSCP(t.Context(), 200))
+	require.Empty(t, dscpMangleRules(t, slot.NamespaceID()), "the old rule must be gone after a failed restamp")
+
+	// Recycling back to the sandbox class has to reinstall the rule rather than
+	// treat the slot as already correct.
+	require.NoError(t, slot.ApplyEgressDSCP(t.Context(), config.EgressDSCP(EgressClassSandbox)))
+	requireSingleDSCPRule(t, slot, "0x08")
+}
+
 // requireSingleDSCPRule asserts the slot's netns holds exactly one DSCP mangle
 // rule, on the vpeer uplink, setting the given class.
 func requireSingleDSCPRule(t *testing.T, slot *Slot, wantDSCP string) {

--- a/packages/orchestrator/pkg/sandbox/network/dscp_egress_test.go
+++ b/packages/orchestrator/pkg/sandbox/network/dscp_egress_test.go
@@ -13,6 +13,141 @@ import (
 	"github.com/vishvananda/netns"
 )
 
+func dscp(v uint8) *uint8 { return &v }
+
+// TestConfig_EgressDSCP covers how the two configured classes resolve. Build
+// sandboxes get their own value when one is set and otherwise inherit the
+// sandbox value, so a deployment that only sets SANDBOX_EGRESS_DSCP is
+// unaffected by this split.
+func TestConfig_EgressDSCP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		config      Config
+		wantSandbox uint8
+		wantBuild   uint8
+	}{
+		{
+			name:        "unset build value falls back to the sandbox value",
+			config:      Config{SandboxEgressDSCP: 8},
+			wantSandbox: 8,
+			wantBuild:   8,
+		},
+		{
+			name:        "build value overrides for builds only",
+			config:      Config{SandboxEgressDSCP: 8, BuildSandboxEgressDSCP: dscp(16)},
+			wantSandbox: 8,
+			wantBuild:   16,
+		},
+		{
+			name:        "explicit zero disables marking for builds only",
+			config:      Config{SandboxEgressDSCP: 8, BuildSandboxEgressDSCP: dscp(0)},
+			wantSandbox: 8,
+			wantBuild:   0,
+		},
+		{
+			name:        "builds can be marked while sandboxes are not",
+			config:      Config{SandboxEgressDSCP: 0, BuildSandboxEgressDSCP: dscp(16)},
+			wantSandbox: 0,
+			wantBuild:   16,
+		},
+		{
+			name:        "both disabled by default",
+			config:      Config{},
+			wantSandbox: 0,
+			wantBuild:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.wantSandbox, tt.config.EgressDSCP(EgressClassSandbox))
+			require.Equal(t, tt.wantBuild, tt.config.EgressDSCP(EgressClassBuild))
+		})
+	}
+}
+
+func TestConfig_Validate_EgressDSCPRange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr string
+	}{
+		{name: "both unset", config: Config{}},
+		{name: "both at the top of the range", config: Config{SandboxEgressDSCP: 63, BuildSandboxEgressDSCP: dscp(63)}},
+		{
+			name:    "sandbox value out of range",
+			config:  Config{SandboxEgressDSCP: 64},
+			wantErr: "SANDBOX_EGRESS_DSCP=64 out of range (0..63)",
+		},
+		{
+			name:    "build value out of range",
+			config:  Config{BuildSandboxEgressDSCP: dscp(255)},
+			wantErr: "BUILD_SANDBOX_EGRESS_DSCP=255 out of range (0..63)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.config.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+// TestParseConfig_BuildEgressDSCP pins the env semantics the fallback relies on:
+// an absent BUILD_SANDBOX_EGRESS_DSCP must leave the pointer nil rather than
+// decode as 0, which would silently disable marking for every build.
+func TestParseConfig_BuildEgressDSCP(t *testing.T) { //nolint:paralleltest // t.Setenv
+	// Inherited by every subtest.
+	t.Setenv("SANDBOX_EGRESS_DSCP", "8")
+
+	t.Run("absent leaves the build value unset", func(t *testing.T) { //nolint:paralleltest // t.Setenv
+		config, err := ParseConfig()
+		require.NoError(t, err)
+		require.Nil(t, config.BuildSandboxEgressDSCP)
+		require.Equal(t, uint8(8), config.EgressDSCP(EgressClassBuild))
+	})
+
+	t.Run("explicit zero is distinct from absent", func(t *testing.T) { //nolint:paralleltest // t.Setenv
+		t.Setenv("BUILD_SANDBOX_EGRESS_DSCP", "0")
+
+		config, err := ParseConfig()
+		require.NoError(t, err)
+		require.NotNil(t, config.BuildSandboxEgressDSCP)
+		require.Equal(t, uint8(0), config.EgressDSCP(EgressClassBuild))
+	})
+
+	t.Run("set value is used for builds", func(t *testing.T) { //nolint:paralleltest // t.Setenv
+		t.Setenv("BUILD_SANDBOX_EGRESS_DSCP", "16")
+
+		config, err := ParseConfig()
+		require.NoError(t, err)
+		require.Equal(t, uint8(8), config.EgressDSCP(EgressClassSandbox))
+		require.Equal(t, uint8(16), config.EgressDSCP(EgressClassBuild))
+	})
+
+	t.Run("out of range fails loudly", func(t *testing.T) { //nolint:paralleltest // t.Setenv
+		t.Setenv("BUILD_SANDBOX_EGRESS_DSCP", "64")
+
+		_, err := ParseConfig()
+		require.ErrorContains(t, err, "BUILD_SANDBOX_EGRESS_DSCP=64 out of range (0..63)")
+	})
+}
+
 // TestCreateNetwork_TagsEgressWithDSCP verifies that CreateNetwork installs the
 // mangle/POSTROUTING rule that stamps DSCP CS1 (8) on every packet leaving the
 // sandbox netns through the vpeer uplink (eth0).
@@ -41,6 +176,61 @@ func TestCreateNetwork_TagsEgressWithDSCP(t *testing.T) { //nolint:paralleltest 
 	require.Lenf(t, rules, 1, "want exactly one DSCP mangle rule in %s, got %v", slot.NamespaceID(), rules)
 	require.Containsf(t, rules[0], "-o "+slot.VpeerName(), "DSCP rule must match the vpeer uplink: %s", rules[0])
 	require.Containsf(t, rules[0], "--set-dscp 0x08", "DSCP rule must set CS1 (8): %s", rules[0])
+}
+
+// TestApplyEgressDSCP_RestampsSlotRule verifies the per-tenant re-stamp on a
+// real slot: the pool hands out slots that were created before their tenant was
+// known, so a build sandbox has to swap the mangle rule installed by
+// CreateNetwork and the pool has to swap it back before the slot is reused.
+//
+// Like TestCreateNetwork_TagsEgressWithDSCP this drives the real netns/iptables
+// path and skips without root.
+func TestApplyEgressDSCP_RestampsSlotRule(t *testing.T) { //nolint:paralleltest // mutates the caller's netns via LockOSThread + netns.Set; cannot run in parallel
+	if os.Geteuid() != 0 {
+		t.Skip("requires root for netns + iptables")
+	}
+
+	config, err := ParseConfig()
+	require.NoError(t, err)
+	config.SandboxEgressDSCP = 8             // regular sandboxes: CS1
+	config.BuildSandboxEgressDSCP = dscp(16) // template builds: CS2
+
+	const idx = 30001 // high, fixed: avoid collision with the pool's low-index Populate
+	slot, err := NewSlot("dscp-restamp-test", idx, config, NewNoopEgressProxy())
+	require.NoError(t, err)
+
+	require.NoError(t, slot.CreateNetwork(t.Context()))
+	t.Cleanup(func() { _ = slot.RemoveNetwork() })
+
+	requireSingleDSCPRule(t, slot, "0x08") // CreateNetwork seeds the sandbox class
+
+	// A build sandbox takes the slot.
+	require.NoError(t, slot.ApplyEgressDSCP(t.Context(), config.EgressDSCP(EgressClassBuild)))
+	requireSingleDSCPRule(t, slot, "0x10")
+
+	// Re-applying the same class must not duplicate the rule.
+	require.NoError(t, slot.ApplyEgressDSCP(t.Context(), config.EgressDSCP(EgressClassBuild)))
+	requireSingleDSCPRule(t, slot, "0x10")
+
+	// The pool recycles the slot back to the sandbox class.
+	require.NoError(t, slot.ApplyEgressDSCP(t.Context(), config.EgressDSCP(EgressClassSandbox)))
+	requireSingleDSCPRule(t, slot, "0x08")
+
+	// 0 removes the rule outright.
+	require.NoError(t, slot.ApplyEgressDSCP(t.Context(), 0))
+	require.Emptyf(t, dscpMangleRules(t, slot.NamespaceID()), "DSCP 0 must leave no mangle rule in %s", slot.NamespaceID())
+}
+
+// requireSingleDSCPRule asserts the slot's netns holds exactly one DSCP mangle
+// rule, on the vpeer uplink, setting the given class.
+func requireSingleDSCPRule(t *testing.T, slot *Slot, wantDSCP string) {
+	t.Helper()
+
+	rules := dscpMangleRules(t, slot.NamespaceID())
+
+	require.Lenf(t, rules, 1, "want exactly one DSCP mangle rule in %s, got %v", slot.NamespaceID(), rules)
+	require.Containsf(t, rules[0], "-o "+slot.VpeerName(), "DSCP rule must match the vpeer uplink: %s", rules[0])
+	require.Containsf(t, rules[0], "--set-dscp "+wantDSCP, "DSCP rule must set %s: %s", wantDSCP, rules[0])
 }
 
 // dscpMangleRules returns the mangle/POSTROUTING rules that reference the DSCP

--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -273,8 +273,10 @@ func (s *Slot) CreateNetwork(ctx context.Context) (retErr error) {
 	}
 
 	// Marker for downstream L3 firewalls. 0 disables; see SANDBOX_EGRESS_DSCP.
-	if s.config.SandboxEgressDSCP > 0 {
-		err = tables.Append("mangle", "POSTROUTING", "-o", s.VpeerName(), "-j", "DSCP", "--set-dscp", strconv.Itoa(int(s.config.SandboxEgressDSCP)))
+	// Slots are pooled, so this seeds the regular-sandbox class; Pool.Get
+	// re-stamps it via ApplyEgressDSCP when a build sandbox takes the slot.
+	if dscp := s.config.EgressDSCP(EgressClassSandbox); dscp > 0 {
+		err = tables.Append("mangle", "POSTROUTING", s.dscpMangleRuleArgs(dscp)...)
 		if err != nil {
 			return fmt.Errorf("error creating DSCP mangle rule on vpeer: %w", err)
 		}

--- a/packages/orchestrator/pkg/sandbox/network/pool.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool.go
@@ -261,26 +261,35 @@ func (p *Pool) Get(ctx context.Context, network *orchestrator.SandboxNetworkConf
 		}
 	}
 
-	// Slots are pooled and created before their tenant is known, so the DSCP
-	// class the slot was built with only matches a regular sandbox. Re-stamp it
-	// for a build. This is a no-op (and costs no netns round-trip) whenever the
-	// two configured values agree, which is the default.
-	err := slot.ApplyEgressDSCP(ctx, p.config.EgressDSCP(class))
-	if err == nil {
-		err = slot.ConfigureInternet(ctx, network)
-	}
-
-	if err != nil {
+	if err := p.configureSlot(ctx, slot, network, class); err != nil {
 		// Return the slot to the pool if configuring it fails. The slot was
 		// never handed out, so nobody listens for its release notification.
 		if rerr := p.ReturnAsync(context.WithoutCancel(ctx), slot, func(context.Context, string) {}, 0); rerr != nil {
 			logger.L().Error(ctx, "failed to return slot to the pool", zap.Error(rerr), zap.Int("slot_index", slot.Idx))
 		}
 
-		return nil, fmt.Errorf("error setting slot internet access: %w", err)
+		return nil, err
 	}
 
 	return slot, nil
+}
+
+// configureSlot applies the tenant-specific setup a pooled slot needs before it
+// is handed out.
+func (p *Pool) configureSlot(ctx context.Context, slot *Slot, network *orchestrator.SandboxNetworkConfig, class EgressClass) error {
+	// Slots are created before their tenant is known, so the DSCP class the
+	// slot was built with only matches a regular sandbox. Re-stamp it for a
+	// build. This is a no-op (and costs no netns round-trip) whenever the two
+	// configured values agree, which is the default.
+	if err := slot.ApplyEgressDSCP(ctx, p.config.EgressDSCP(class)); err != nil {
+		return fmt.Errorf("error setting slot egress DSCP: %w", err)
+	}
+
+	if err := slot.ConfigureInternet(ctx, network); err != nil {
+		return fmt.Errorf("error setting slot internet access: %w", err)
+	}
+
+	return nil
 }
 
 // returnSlot recycles a slot that was used by a sandbox. It waits returnDelay

--- a/packages/orchestrator/pkg/sandbox/network/pool.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool.go
@@ -84,11 +84,53 @@ type Config struct {
 
 	// 0 disables; valid range 0..63 (DSCP is 6 bits). CS1=8 is the canonical Scavenger class (RFC 3662).
 	SandboxEgressDSCP uint8 `env:"SANDBOX_EGRESS_DSCP" envDefault:"0"`
+
+	// Egress DSCP for template-build sandboxes. Unset (the pointer is nil, not 0)
+	// inherits SANDBOX_EGRESS_DSCP, so single-value deployments keep their
+	// current behaviour; setting it to 0 explicitly disables marking for builds
+	// while regular sandboxes stay marked. Same 0..63 range.
+	BuildSandboxEgressDSCP *uint8 `env:"BUILD_SANDBOX_EGRESS_DSCP"`
+}
+
+// EgressClass selects which of the configured egress DSCP values applies to a
+// sandbox. It mirrors sandbox.SandboxType, which this package cannot reference
+// because the sandbox package depends on it (see SandboxType.EgressClass).
+type EgressClass uint8
+
+const (
+	// EgressClassSandbox is a regular, customer-facing sandbox.
+	EgressClassSandbox EgressClass = iota
+	// EgressClassBuild is a template-build sandbox.
+	EgressClassBuild
+)
+
+func (c EgressClass) String() string {
+	if c == EgressClassBuild {
+		return "build"
+	}
+
+	return "sandbox"
+}
+
+const maxDSCP = 63 // DSCP is the top 6 bits of the IPv4 TOS / IPv6 traffic-class byte.
+
+// EgressDSCP returns the DSCP class to stamp on egress for the given kind of
+// sandbox. 0 means "leave the field alone".
+func (c Config) EgressDSCP(class EgressClass) uint8 {
+	if class == EgressClassBuild && c.BuildSandboxEgressDSCP != nil {
+		return *c.BuildSandboxEgressDSCP
+	}
+
+	return c.SandboxEgressDSCP
 }
 
 func (c Config) Validate() error {
-	if c.SandboxEgressDSCP > 63 {
-		return fmt.Errorf("SANDBOX_EGRESS_DSCP=%d out of range (0..63)", c.SandboxEgressDSCP)
+	if c.SandboxEgressDSCP > maxDSCP {
+		return fmt.Errorf("SANDBOX_EGRESS_DSCP=%d out of range (0..%d)", c.SandboxEgressDSCP, maxDSCP)
+	}
+
+	if c.BuildSandboxEgressDSCP != nil && *c.BuildSandboxEgressDSCP > maxDSCP {
+		return fmt.Errorf("BUILD_SANDBOX_EGRESS_DSCP=%d out of range (0..%d)", *c.BuildSandboxEgressDSCP, maxDSCP)
 	}
 
 	return nil
@@ -192,7 +234,7 @@ func (p *Pool) Populate(ctx context.Context) {
 	}
 }
 
-func (p *Pool) Get(ctx context.Context, network *orchestrator.SandboxNetworkConfig) (*Slot, error) {
+func (p *Pool) Get(ctx context.Context, network *orchestrator.SandboxNetworkConfig, class EgressClass) (*Slot, error) {
 	var slot *Slot
 
 	select {
@@ -219,10 +261,18 @@ func (p *Pool) Get(ctx context.Context, network *orchestrator.SandboxNetworkConf
 		}
 	}
 
-	err := slot.ConfigureInternet(ctx, network)
+	// Slots are pooled and created before their tenant is known, so the DSCP
+	// class the slot was built with only matches a regular sandbox. Re-stamp it
+	// for a build. This is a no-op (and costs no netns round-trip) whenever the
+	// two configured values agree, which is the default.
+	err := slot.ApplyEgressDSCP(ctx, p.config.EgressDSCP(class))
+	if err == nil {
+		err = slot.ConfigureInternet(ctx, network)
+	}
+
 	if err != nil {
-		// Return the slot to the pool if configuring internet fails. The slot
-		// was never handed out, so nobody listens for its release notification.
+		// Return the slot to the pool if configuring it fails. The slot was
+		// never handed out, so nobody listens for its release notification.
 		if rerr := p.ReturnAsync(context.WithoutCancel(ctx), slot, func(context.Context, string) {}, 0); rerr != nil {
 			logger.L().Error(ctx, "failed to return slot to the pool", zap.Error(rerr), zap.Int("slot_index", slot.Idx))
 		}
@@ -303,6 +353,11 @@ func (p *Pool) ReturnAsync(ctx context.Context, slot *Slot, releasedFn ReleaseNo
 // recycle resets the slot's internet configuration and puts it back into the
 // reused pool, or cleans it up if the pool is full or closed.
 func (p *Pool) recycle(ctx context.Context, slot *Slot) error {
+	// Undo any build-specific DSCP before the next tenant can inherit it.
+	if err := slot.ApplyEgressDSCP(ctx, p.config.EgressDSCP(EgressClassSandbox)); err != nil {
+		return p.cleanupWith(ctx, slot, fmt.Errorf("error resetting slot egress DSCP: %w", err))
+	}
+
 	if err := slot.ResetInternet(ctx); err != nil {
 		return p.cleanupWith(ctx, slot, fmt.Errorf("error resetting slot internet access: %w", err))
 	}

--- a/packages/orchestrator/pkg/sandbox/network/slot.go
+++ b/packages/orchestrator/pkg/sandbox/network/slot.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 
 	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/coreos/go-iptables/iptables"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -67,6 +68,12 @@ type Slot struct {
 
 	// firewallCustomRules is used to track if custom firewall rules are set for the slot and need a cleanup.
 	firewallCustomRules atomic.Bool
+
+	// egressDSCP is the DSCP class the slot's mangle rule currently stamps on
+	// egress (0 = no rule installed). Seeded in NewSlot from the regular-sandbox
+	// config value, which is what CreateNetwork installs and what a slot
+	// reclaimed at startup already carries; ApplyEgressDSCP moves it.
+	egressDSCP atomic.Uint32
 
 	vPeerIp net.IP
 	vEthIp  net.IP
@@ -145,6 +152,8 @@ func NewSlot(key string, idx int, config Config, egressProxy EgressProxy) (*Slot
 		config:      config,
 		egressProxy: egressProxy,
 	}
+
+	slot.egressDSCP.Store(uint32(config.EgressDSCP(EgressClassSandbox)))
 
 	return slot, nil
 }
@@ -246,6 +255,69 @@ func (s *Slot) CloseFirewall() error {
 		return fmt.Errorf("error closing firewall: %w", err)
 	}
 	s.Firewall = nil
+
+	return nil
+}
+
+// dscpMangleRuleArgs builds the mangle/POSTROUTING rule that stamps the given
+// DSCP class on everything leaving the sandbox netns through the vpeer uplink.
+func (s *Slot) dscpMangleRuleArgs(dscp uint8) []string {
+	return []string{"-o", s.VpeerName(), "-j", "DSCP", "--set-dscp", strconv.Itoa(int(dscp))}
+}
+
+// ApplyEgressDSCP re-stamps the slot's egress DSCP rule, so a template-build
+// sandbox can be marked differently from a regular one even though slots are
+// pre-created by the pool before their tenant is known. 0 removes the rule.
+//
+// It returns without touching the netns when the slot already stamps dscp,
+// which is every start under the default configuration (both classes resolve to
+// the same value) and keeps this off the sandbox cold-start critical path.
+func (s *Slot) ApplyEgressDSCP(ctx context.Context, dscp uint8) error {
+	current := uint8(s.egressDSCP.Load())
+	if current == dscp {
+		return nil
+	}
+
+	ctx, span := tracer.Start(ctx, "slot-egress-dscp-apply", trace.WithAttributes(
+		attribute.String("namespace_id", s.NamespaceID()),
+		attribute.Int("dscp", int(dscp)),
+	))
+	defer span.End()
+
+	n, err := ns.GetNS(filepath.Join(NetNamespacesDir, s.NamespaceID()))
+	if err != nil {
+		return fmt.Errorf("failed to get slot network namespace '%s': %w", s.NamespaceID(), err)
+	}
+	defer n.Close()
+
+	err = n.Do(func(_ ns.NetNS) error {
+		tables, err := iptables.New()
+		if err != nil {
+			return fmt.Errorf("error initializing iptables: %w", err)
+		}
+
+		// No guest traffic flows over the uplink at either call site (the slot
+		// is acquired before the VM boots and recycled after it is gone), so
+		// the gap between the two operations is not observable.
+		if current > 0 {
+			if err := tables.DeleteIfExists("mangle", "POSTROUTING", s.dscpMangleRuleArgs(current)...); err != nil {
+				return fmt.Errorf("error removing DSCP %d mangle rule on vpeer: %w", current, err)
+			}
+		}
+
+		if dscp > 0 {
+			if err := tables.AppendUnique("mangle", "POSTROUTING", s.dscpMangleRuleArgs(dscp)...); err != nil {
+				return fmt.Errorf("error creating DSCP %d mangle rule on vpeer: %w", dscp, err)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed execution in network namespace '%s': %w", s.NamespaceID(), err)
+	}
+
+	s.egressDSCP.Store(uint32(dscp))
 
 	return nil
 }

--- a/packages/orchestrator/pkg/sandbox/network/slot.go
+++ b/packages/orchestrator/pkg/sandbox/network/slot.go
@@ -304,6 +304,12 @@ func (s *Slot) ApplyEgressDSCP(ctx context.Context, dscp uint8) error {
 			if err := tables.DeleteIfExists("mangle", "POSTROUTING", s.dscpMangleRuleArgs(current)...); err != nil {
 				return fmt.Errorf("error removing DSCP %d mangle rule on vpeer: %w", current, err)
 			}
+
+			// Record the slot as unmarked before attempting the append. If that
+			// fails, the cache must not keep claiming a rule that is no longer
+			// installed, or recycle would see a match, skip the restamp and put
+			// a silently unmarked slot back into the pool.
+			s.egressDSCP.Store(0)
 		}
 
 		if dscp > 0 {

--- a/packages/orchestrator/pkg/sandbox/network/slot.go
+++ b/packages/orchestrator/pkg/sandbox/network/slot.go
@@ -278,7 +278,8 @@ func (s *Slot) ApplyEgressDSCP(ctx context.Context, dscp uint8) error {
 		return nil
 	}
 
-	ctx, span := tracer.Start(ctx, "slot-egress-dscp-apply", trace.WithAttributes(
+	// The netns work below is synchronous and takes no context of its own.
+	_, span := tracer.Start(ctx, "slot-egress-dscp-apply", trace.WithAttributes(
 		attribute.String("namespace_id", s.NamespaceID()),
 		attribute.Int("dscp", int(dscp)),
 	))

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -194,6 +194,18 @@ func (t SandboxType) String() string {
 	return string(t)
 }
 
+// EgressClass maps the sandbox type onto the network package's egress class, so
+// build and regular sandboxes can be marked with different DSCP values. The
+// network package cannot use SandboxType directly because this package depends
+// on it. The empty type, like String, is treated as a regular sandbox.
+func (t SandboxType) EgressClass() network.EgressClass {
+	if t == SandboxTypeBuild {
+		return network.EgressClassBuild
+	}
+
+	return network.EgressClassSandbox
+}
+
 type RuntimeMetadata struct {
 	TemplateID  string
 	SandboxID   string
@@ -504,7 +516,7 @@ func (f *Factory) CreateSandbox(
 
 	lifecycleID := uuid.NewString()
 
-	ipsPromise := getNetworkSlot(ctx, f.networkPool, cleanup, config.Network, f.Sandboxes.NetworkReleased)
+	ipsPromise := getNetworkSlot(ctx, f.networkPool, cleanup, config.Network, f.Sandboxes.NetworkReleased, runtime.SandboxType.EgressClass())
 
 	sandboxFiles := template.Files().NewSandboxFiles(runtime.SandboxID)
 	cleanup.Add(ctx, cleanupFiles(f.config, sandboxFiles))
@@ -963,7 +975,7 @@ func (f *Factory) ResumeSandbox(
 	}()
 
 	// Slot initialization
-	ipsPromise := getNetworkSlot(ctx, f.networkPool, cleanup, config.Network, f.Sandboxes.NetworkReleased)
+	ipsPromise := getNetworkSlot(ctx, f.networkPool, cleanup, config.Network, f.Sandboxes.NetworkReleased, runtime.SandboxType.EgressClass())
 
 	// Rootfs initialization
 	overlayPromise := utils.NewPromise(func() (rootfs.Provider, error) {
@@ -2212,12 +2224,13 @@ func getNetworkSlot(
 	cleanup *Cleanup,
 	networkConfig *orchestrator.SandboxNetworkConfig,
 	networkReleased network.ReleaseNotify,
+	egressClass network.EgressClass,
 ) *utils.Promise[*network.Slot] {
 	return utils.NewPromise(func() (*network.Slot, error) {
 		ctx, span := tracer.Start(ctx, "get network-slot")
 		defer span.End()
 
-		slot, err := networkPool.Get(ctx, networkConfig)
+		slot, err := networkPool.Get(ctx, networkConfig, egressClass)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get network slot: %w", err)
 		}

--- a/packages/orchestrator/pkg/tcpfirewall/handlers.go
+++ b/packages/orchestrator/pkg/tcpfirewall/handlers.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/network"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sandbox_network "github.com/e2b-dev/infra/packages/shared/pkg/sandbox-network"
 )
@@ -28,13 +28,15 @@ const (
 	noHostnameValue = ""
 )
 
-// Set by Proxy.New() from network.Config.SandboxEgressDSCP << 2. 0 = disabled.
-var sandboxEgressTOS atomic.Uint32
+// egressTOS converts a configured DSCP class into the IPv4 TOS / IPv6
+// traffic-class byte, which carries DSCP in its top 6 bits. 0 = disabled.
+func egressTOS(networkConfig network.Config, sbx *sandbox.Sandbox) int {
+	return int(networkConfig.EgressDSCP(sbx.Runtime.SandboxType.EgressClass())) << 2
+}
 
 // Sets both IP_TOS and IPV6_TCLASS because Happy Eyeballs may pick either family.
 // Tolerates ENOPROTOOPT from the non-matching one.
-func markDSCP(c syscall.RawConn) error {
-	tos := int(sandboxEgressTOS.Load())
+func markDSCP(c syscall.RawConn, tos int) error {
 	if tos == 0 {
 		return nil
 	}
@@ -56,7 +58,7 @@ func markDSCP(c syscall.RawConn) error {
 }
 
 // domainHandler handles connections with hostname information (HTTP Host header or TLS SNI).
-func domainHandler(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, logger logger.Logger, metrics *Metrics, protocol Protocol) {
+func domainHandler(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, logger logger.Logger, metrics *Metrics, protocol Protocol, tos int) {
 	// Get hostname from tcpproxy's wrapped connection (HTTP Host or TLS SNI).
 	// Hostname can be empty, e.g. for https://1.1.1.1 like requests.
 	var hostname string
@@ -89,18 +91,18 @@ func domainHandler(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int
 	// After connecting, we verify the connected IP is not internal/private.
 	if matchType == MatchTypeDomain {
 		upstreamAddr := net.JoinHostPort(hostname, fmt.Sprintf("%d", dstPort))
-		proxyWithIPVerification(ctx, conn, upstreamAddr, logger, metrics, protocol)
+		proxyWithIPVerification(ctx, conn, upstreamAddr, logger, metrics, protocol, tos)
 
 		return
 	}
 
 	// For non-domain matches, use the original destination IP
 	upstreamAddr := net.JoinHostPort(dstIP.String(), fmt.Sprintf("%d", dstPort))
-	proxy(ctx, conn, upstreamAddr, metrics, protocol)
+	proxy(ctx, conn, upstreamAddr, metrics, protocol, tos)
 }
 
 // cidrOnlyHandler handles connections without hostname information.
-func cidrOnlyHandler(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, logger logger.Logger, metrics *Metrics, protocol Protocol) {
+func cidrOnlyHandler(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, logger logger.Logger, metrics *Metrics, protocol Protocol, tos int) {
 	// No hostname available for CIDR-only handler
 	allowed, matchType, err := isEgressAllowed(sbx, noHostnameValue, dstIP)
 	if err != nil {
@@ -122,11 +124,11 @@ func cidrOnlyHandler(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort i
 
 	upstreamAddr := net.JoinHostPort(dstIP.String(), fmt.Sprintf("%d", dstPort))
 
-	proxy(ctx, conn, upstreamAddr, metrics, protocol)
+	proxy(ctx, conn, upstreamAddr, metrics, protocol, tos)
 }
 
 // proxy proxies the connection to the upstream address.
-func proxy(ctx context.Context, conn net.Conn, upstreamAddr string, metrics *Metrics, protocol Protocol) {
+func proxy(ctx context.Context, conn net.Conn, upstreamAddr string, metrics *Metrics, protocol Protocol, tos int) {
 	tracker := metrics.TrackConnection(protocol)
 	defer tracker.Close(ctx)
 
@@ -137,7 +139,7 @@ func proxy(ctx context.Context, conn net.Conn, upstreamAddr string, metrics *Met
 			dialer := &net.Dialer{
 				Timeout: upstreamDialTimeout,
 				Control: func(_, _ string, c syscall.RawConn) error {
-					return markDSCP(c)
+					return markDSCP(c, tos)
 				},
 			}
 
@@ -154,7 +156,7 @@ func proxy(ctx context.Context, conn net.Conn, upstreamAddr string, metrics *Met
 //
 // The ControlContext callback is called after DNS resolution but before the TCP connect()
 // syscall, so no TCP handshake occurs to internal IPs.
-func proxyWithIPVerification(ctx context.Context, conn net.Conn, upstreamAddr string, logger logger.Logger, metrics *Metrics, protocol Protocol) {
+func proxyWithIPVerification(ctx context.Context, conn net.Conn, upstreamAddr string, logger logger.Logger, metrics *Metrics, protocol Protocol, tos int) {
 	tracker := metrics.TrackConnection(protocol)
 	defer tracker.Close(ctx)
 
@@ -190,7 +192,7 @@ func proxyWithIPVerification(ctx context.Context, conn net.Conn, upstreamAddr st
 						return fmt.Errorf("hostname resolved to internal IP %s", resolvedIP)
 					}
 
-					return markDSCP(c)
+					return markDSCP(c, tos)
 				},
 			}
 

--- a/packages/orchestrator/pkg/tcpfirewall/handlers_test.go
+++ b/packages/orchestrator/pkg/tcpfirewall/handlers_test.go
@@ -3,10 +3,13 @@
 package tcpfirewall
 
 import (
+	"fmt"
 	"net"
+	"syscall"
 	"testing"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/network"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	sandbox_network "github.com/e2b-dev/infra/packages/shared/pkg/sandbox-network"
 )
@@ -458,6 +461,152 @@ func TestAlwaysDeniedCIDRs(t *testing.T) {
 			got := isIPInAlwaysDeniedCIDRs(ip)
 			if got != tt.want {
 				t.Errorf("isIPInDeniedCIDRs(%s) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+
+func dscp(v uint8) *uint8 { return &v }
+
+func sandboxOfType(t sandbox.SandboxType) *sandbox.Sandbox {
+	return &sandbox.Sandbox{Metadata: &sandbox.Metadata{Runtime: sandbox.RuntimeMetadata{SandboxType: t}}}
+}
+
+// TestEgressTOS covers the per-sandbox-class DSCP selection the upstream dialer
+// stamps on its socket: template builds can be marked differently from regular
+// sandboxes, and a build with no value of its own inherits the sandbox one.
+func TestEgressTOS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		sandboxDSCP uint8
+		buildDSCP   *uint8
+		sandboxType sandbox.SandboxType
+		want        int
+	}{
+		{
+			name:        "build sandbox uses the build value",
+			sandboxDSCP: 8,
+			buildDSCP:   dscp(16),
+			sandboxType: sandbox.SandboxTypeBuild,
+			want:        16 << 2, // 0x40
+		},
+		{
+			name:        "regular sandbox keeps the sandbox value when a build value is set",
+			sandboxDSCP: 8,
+			buildDSCP:   dscp(16),
+			sandboxType: sandbox.SandboxTypeSandbox,
+			want:        8 << 2, // 0x20
+		},
+		{
+			name:        "unset build value falls back to the sandbox value",
+			sandboxDSCP: 8,
+			sandboxType: sandbox.SandboxTypeBuild,
+			want:        8 << 2,
+		},
+		{
+			name:        "build value of 0 disables marking for builds only",
+			sandboxDSCP: 8,
+			buildDSCP:   dscp(0),
+			sandboxType: sandbox.SandboxTypeBuild,
+			want:        0,
+		},
+		{
+			name:        "sandbox value of 0 disables marking while builds stay marked",
+			sandboxDSCP: 0,
+			buildDSCP:   dscp(16),
+			sandboxType: sandbox.SandboxTypeSandbox,
+			want:        0,
+		},
+		{
+			name:        "both unset disables marking",
+			sandboxType: sandbox.SandboxTypeBuild,
+			want:        0,
+		},
+		{
+			name:        "empty sandbox type is treated as a regular sandbox",
+			sandboxDSCP: 8,
+			buildDSCP:   dscp(16),
+			sandboxType: "",
+			want:        8 << 2,
+		},
+		{
+			name:        "max DSCP maps to the top of the TOS byte",
+			sandboxDSCP: 0,
+			buildDSCP:   dscp(63),
+			sandboxType: sandbox.SandboxTypeBuild,
+			want:        63 << 2, // 0xFC
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := network.Config{SandboxEgressDSCP: tt.sandboxDSCP, BuildSandboxEgressDSCP: tt.buildDSCP}
+
+			if got := egressTOS(cfg, sandboxOfType(tt.sandboxType)); got != tt.want {
+				t.Errorf("egressTOS() = %#x, want %#x", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMarkDSCP_SetsSocketTOS dials a real loopback socket through the same
+// Control hook the upstream dialer uses and reads IP_TOS back off the fd, so the
+// DSCP-to-TOS shift is checked against the kernel rather than against itself.
+func TestMarkDSCP_SetsSocketTOS(t *testing.T) {
+	t.Parallel()
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+
+	for _, tos := range []int{0, 8 << 2, 16 << 2, 63 << 2} {
+		t.Run(fmt.Sprintf("tos_%#x", tos), func(t *testing.T) {
+			t.Parallel()
+
+			dialer := &net.Dialer{
+				Control: func(_, _ string, c syscall.RawConn) error { return markDSCP(c, tos) },
+			}
+
+			conn, err := dialer.DialContext(t.Context(), "tcp4", ln.Addr().String())
+			if err != nil {
+				t.Fatalf("dial: %v", err)
+			}
+			t.Cleanup(func() { _ = conn.Close() })
+
+			raw, err := conn.(*net.TCPConn).SyscallConn()
+			if err != nil {
+				t.Fatalf("syscall conn: %v", err)
+			}
+
+			var got int
+			var sockErr error
+			if err := raw.Control(func(fd uintptr) {
+				got, sockErr = syscall.GetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TOS)
+			}); err != nil {
+				t.Fatalf("control: %v", err)
+			}
+			if sockErr != nil {
+				t.Fatalf("getsockopt IP_TOS: %v", sockErr)
+			}
+
+			if got != tos {
+				t.Errorf("IP_TOS = %#x, want %#x", got, tos)
 			}
 		})
 	}

--- a/packages/orchestrator/pkg/tcpfirewall/handlers_test.go
+++ b/packages/orchestrator/pkg/tcpfirewall/handlers_test.go
@@ -466,7 +466,7 @@ func TestAlwaysDeniedCIDRs(t *testing.T) {
 	}
 }
 
-func dscp(v uint8) *uint8 { return &v }
+func dscp(v uint8) *uint8 { return new(v) }
 
 func sandboxOfType(t sandbox.SandboxType) *sandbox.Sandbox {
 	return &sandbox.Sandbox{Metadata: &sandbox.Metadata{Runtime: sandbox.RuntimeMetadata{SandboxType: t}}}
@@ -559,7 +559,7 @@ func TestEgressTOS(t *testing.T) {
 func TestMarkDSCP_SetsSocketTOS(t *testing.T) {
 	t.Parallel()
 
-	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp4", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}

--- a/packages/orchestrator/pkg/tcpfirewall/proxy.go
+++ b/packages/orchestrator/pkg/tcpfirewall/proxy.go
@@ -38,22 +38,25 @@ type Proxy struct {
 	tlsPort   uint16 // For port 443 traffic - TLS SNI inspection
 	otherPort uint16 // For all other ports - CIDR-only, no protocol inspection
 
+	// networkConfig supplies the per-sandbox-class egress DSCP; the TOS byte is
+	// resolved per connection, once the sandbox behind it is known.
+	networkConfig network.Config
+
 	proxyRules []proxyRule
 	proxy      *tcpproxy.Proxy
 }
 
 func New(logger logger.Logger, networkConfig network.Config, sandboxes *sandbox.Map, meterProvider metric.MeterProvider, featureFlags *featureflags.Client) *Proxy {
-	sandboxEgressTOS.Store(uint32(networkConfig.SandboxEgressDSCP) << 2)
-
 	p := &Proxy{
-		httpPort:     networkConfig.SandboxTCPFirewallHTTPPort,
-		tlsPort:      networkConfig.SandboxTCPFirewallTLSPort,
-		otherPort:    networkConfig.SandboxTCPFirewallOtherPort,
-		logger:       logger,
-		sandboxes:    sandboxes,
-		metrics:      NewMetrics(meterProvider),
-		limiter:      connlimit.NewConnectionLimiter(),
-		featureFlags: featureFlags,
+		httpPort:      networkConfig.SandboxTCPFirewallHTTPPort,
+		tlsPort:       networkConfig.SandboxTCPFirewallTLSPort,
+		otherPort:     networkConfig.SandboxTCPFirewallOtherPort,
+		networkConfig: networkConfig,
+		logger:        logger,
+		sandboxes:     sandboxes,
+		metrics:       NewMetrics(meterProvider),
+		limiter:       connlimit.NewConnectionLimiter(),
+		featureFlags:  featureFlags,
 	}
 
 	p.proxyRules = []proxyRule{
@@ -100,16 +103,16 @@ func (p *Proxy) Start(ctx context.Context) error {
 	otherAddr := fmt.Sprintf("0.0.0.0:%d", p.otherPort)
 
 	// HTTP listener (port 80 traffic): inspect Host header for domain allowlist
-	p.proxy.AddHTTPHostMatchRoute(httpAddr, func(_ context.Context, _ string) bool { return true }, newConnectionHandler(ctx, domainHandler, ProtocolHTTP, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags))
-	p.proxy.AddRoute(httpAddr, newConnectionHandler(ctx, cidrOnlyHandler, ProtocolHTTP, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags))
+	p.proxy.AddHTTPHostMatchRoute(httpAddr, func(_ context.Context, _ string) bool { return true }, newConnectionHandler(ctx, domainHandler, ProtocolHTTP, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags, p.networkConfig))
+	p.proxy.AddRoute(httpAddr, newConnectionHandler(ctx, cidrOnlyHandler, ProtocolHTTP, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags, p.networkConfig))
 
 	// TLS listener (port 443 traffic): inspect SNI for domain allowlist
-	p.proxy.AddSNIMatchRoute(tlsAddr, func(_ context.Context, _ string) bool { return true }, newConnectionHandler(ctx, domainHandler, ProtocolTLS, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags))
-	p.proxy.AddRoute(tlsAddr, newConnectionHandler(ctx, cidrOnlyHandler, ProtocolTLS, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags))
+	p.proxy.AddSNIMatchRoute(tlsAddr, func(_ context.Context, _ string) bool { return true }, newConnectionHandler(ctx, domainHandler, ProtocolTLS, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags, p.networkConfig))
+	p.proxy.AddRoute(tlsAddr, newConnectionHandler(ctx, cidrOnlyHandler, ProtocolTLS, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags, p.networkConfig))
 
 	// Other listener (all other ports): CIDR-only check, no protocol inspection
 	// This prevents blocking on server-first protocols like SSH
-	p.proxy.AddRoute(otherAddr, newConnectionHandler(ctx, cidrOnlyHandler, ProtocolOther, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags))
+	p.proxy.AddRoute(otherAddr, newConnectionHandler(ctx, cidrOnlyHandler, ProtocolOther, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags, p.networkConfig))
 
 	p.logger.Info(ctx, "TCP firewall proxy started",
 		zap.Uint16("http_port", p.httpPort),
@@ -188,7 +191,9 @@ func (p *Proxy) SupportsBYOP() bool {
 }
 
 // handlerFunc is the signature for connection handlers.
-type handlerFunc func(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, logger logger.Logger, metrics *Metrics, protocol Protocol)
+// tos is the IPv4 TOS / IPv6 traffic-class byte to stamp on the upstream
+// socket, resolved per connection from the sandbox's egress DSCP class.
+type handlerFunc func(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, logger logger.Logger, metrics *Metrics, protocol Protocol, tos int)
 
 var _ tcpproxy.Target = (*connectionHandler)(nil)
 
@@ -196,25 +201,27 @@ var _ tcpproxy.Target = (*connectionHandler)(nil)
 type connectionHandler struct {
 	ctx context.Context //nolint:containedctx // base context for request tracing
 
-	handler      handlerFunc
-	protocol     Protocol
-	metrics      *Metrics
-	limiter      *connlimit.ConnectionLimiter
-	logger       logger.Logger
-	sandboxes    *sandbox.Map
-	featureFlags *featureflags.Client
+	handler       handlerFunc
+	protocol      Protocol
+	metrics       *Metrics
+	limiter       *connlimit.ConnectionLimiter
+	logger        logger.Logger
+	sandboxes     *sandbox.Map
+	featureFlags  *featureflags.Client
+	networkConfig network.Config
 }
 
-func newConnectionHandler(ctx context.Context, handler handlerFunc, protocol Protocol, metrics *Metrics, limiter *connlimit.ConnectionLimiter, logger logger.Logger, sandboxes *sandbox.Map, featureFlags *featureflags.Client) *connectionHandler {
+func newConnectionHandler(ctx context.Context, handler handlerFunc, protocol Protocol, metrics *Metrics, limiter *connlimit.ConnectionLimiter, logger logger.Logger, sandboxes *sandbox.Map, featureFlags *featureflags.Client, networkConfig network.Config) *connectionHandler {
 	return &connectionHandler{
-		ctx:          ctx,
-		handler:      handler,
-		protocol:     protocol,
-		metrics:      metrics,
-		limiter:      limiter,
-		logger:       logger,
-		sandboxes:    sandboxes,
-		featureFlags: featureFlags,
+		ctx:           ctx,
+		handler:       handler,
+		protocol:      protocol,
+		metrics:       metrics,
+		limiter:       limiter,
+		logger:        logger,
+		sandboxes:     sandboxes,
+		featureFlags:  featureFlags,
+		networkConfig: networkConfig,
 	}
 }
 
@@ -272,10 +279,13 @@ func (t *connectionHandler) HandleConn(conn net.Conn) {
 	t.metrics.RecordConnection(ctx, t.protocol)
 
 	// Wrap the handler to release the connection slot when done
-	wrappedHandler := func(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, l logger.Logger, metrics *Metrics, protocol Protocol) {
+	wrappedHandler := func(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, l logger.Logger, metrics *Metrics, protocol Protocol, tos int) {
 		defer t.limiter.Release(limiterKey)
-		t.handler(ctx, conn, dstIP, dstPort, sbx, l, metrics, protocol)
+		t.handler(ctx, conn, dstIP, dstPort, sbx, l, metrics, protocol, tos)
 	}
 
-	wrappedHandler(ctx, conn, ip, port, sbx, sbxLogger, t.metrics, t.protocol)
+	// Resolved here rather than at Proxy.New: one orchestrator serves both
+	// template builds and regular sandboxes, so the DSCP class depends on which
+	// sandbox opened this connection.
+	wrappedHandler(ctx, conn, ip, port, sbx, sbxLogger, t.metrics, t.protocol, egressTOS(t.networkConfig, sbx))
 }


### PR DESCRIPTION
## Problem

One orchestrator process runs both template builds and customer sandboxes. `SANDBOX_EGRESS_DSCP` is a single value, so a downstream L3 firewall / shaper cannot tell build egress apart from sandbox egress.

The tcpfirewall marking point made this structural: `sandboxEgressTOS` was a **package-level `atomic.Uint32`** stored once in `Proxy.New`. A process-wide global can only ever hold one value, so no configuration could have expressed two.

## Mechanism

DSCP is now resolved **per sandbox**, at both marking points:

- **tcpfirewall (socket `IP_TOS` / `IPV6_TCLASS`).** The global is gone. `connectionHandler.HandleConn` already looks the sandbox up by source address, so the TOS is resolved there and threaded into `markDSCP` as an argument. Costs a parameter on `handlerFunc`; buys no hidden global and parallel-safe tests.
- **`mangle/POSTROUTING` rule (UDP/ICMP, and TCP when not proxied).** Installed by `CreateNetwork`, but slots are **pooled and created before their tenant is known**, so it cannot be static. `Pool.Get` re-stamps it for a build via the existing `ns.GetNS` + `n.Do` pattern; `recycle` restores the sandbox class so the next tenant cannot inherit it. Both return before entering the netns when the value already matches, so the default config adds **zero** work to sandbox cold start.

`network` cannot import `sandbox` (the dependency runs the other way), so it gets an `EgressClass` enum and `SandboxType.EgressClass()` maps onto it.

## Config surface

| Env | Default | Meaning |
|---|---|---|
| `SANDBOX_EGRESS_DSCP` | `0` | Unchanged. Regular sandboxes, and the fallback for builds. |
| `BUILD_SANDBOX_EGRESS_DSCP` | *unset* | Template-build sandboxes. |

**Fallback:** the new field is a `*uint8`, so *unset* (nil) and *explicitly 0* differ. Unset inherits `SANDBOX_EGRESS_DSCP` — existing deployments are unchanged. Explicit `0` disables marking for builds only. `0 = disabled` holds for both. Both validated `0..63`; out of range fails `ParseConfig` at startup.

## Verified on a real KVM host

Single-box dev orchestrator, `SANDBOX_EGRESS_DSCP=8` (CS1) and `BUILD_SANDBOX_EGRESS_DSCP=16` (CS2). `tcpdump` on the uplink, plus a 1 Hz scan of all sandbox netns.

**Template build** (`e2b template create`, build step opening TCP to `1.1.1.1:80`):
- netns: exactly **one** of 32 at `--set-dscp 0x10`, the other 31 at `0x08`; after the build **all** back to `0x08` (recycle restores).
- wire: `125` TCP + `20` UDP packets at `tos 0x40` (= DSCP 16 `<<` 2).
- `IP (tos 0x40, ...) 10.0.2.15.55514 > 1.1.1.1.80: Flags [S]` — the proxy's upstream socket.

**Regular sandbox** (same template, same destination):
- netns: no `0x10` anywhere.
- wire: `75` TCP + `26` UDP packets at `tos 0x20` (= DSCP 8 `<<` 2), **zero** at `0x40`.
- `IP (tos 0x20, ...) 10.0.2.15.42898 > 1.1.1.1.80: Flags [S]`

(Inbound replies show `tos 0x8` — Cloudflare's own marking, not ours.)

The two root-gated netns/iptables tests **ran, not skipped**, on that host.

## Tests

Class resolution, fallback, explicit-0, out-of-range, and the `*uint8` env semantics the fallback depends on (absent must not decode as 0). `markDSCP` is checked against the kernel — dial a real socket, read `IP_TOS` back off the fd (`0x20`, `0x40`, `0xfc`). `TestApplyEgressDSCP_RestampsSlotRule` drives a real slot through create → build class → idempotent re-apply → recycle → 0.

<sub>On the Codecov patch number: most of the uncovered lines are the netns/iptables bodies of `ApplyEgressDSCP` and the `Pool.Get`/`recycle` wiring. Those are exercised by the root-gated tests, which skip on the unit-test runners and only run on a privileged host — where they pass (above). The pure logic (class resolution, fallback, validation, env parsing, TOS conversion) is covered by ordinary unit tests.</sub>
