### PR TITLE
fix(orchestrator): treat a failed or signalled e2fsck as a failed integrity check

### DIFF
--- a/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
+++ b/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
@@ -40,6 +40,15 @@ const (
 	reservedBlocksPercentage = int64(0)
 )
 
+// e2fsck reports its outcome as a bitmask, so several conditions can be
+// combined in a single exit status. See the "EXIT CODE" section of e2fsck(8);
+// the statuses not named here (4 uncorrected errors, 8 operational error,
+// 16 usage error, 32 canceled, 128 shared-library error) are always failures.
+const (
+	e2fsckErrorsCorrected   = 1
+	e2fsckRebootRecommended = 2
+)
+
 func Make(ctx context.Context, rootfsPath string, sizeMb int64, blockSize int64) error {
 	ctx, tuneSpan := tracer.Start(ctx, "make-ext4")
 	defer tuneSpan.End()
@@ -245,24 +254,37 @@ func CheckIntegrity(ctx context.Context, rootfsPath string, fix bool) (out strin
 	}()
 
 	LogMetadata(ctx, rootfsPath)
-	accExitCode := 0
+	acceptedStatus := 0
 	args := "-nfv"
 	if fix {
-		// 0 - No errors
-		// 1 - File system errors corrected
-		// 2 - File system errors corrected, a system should be rebooted
-		accExitCode = 2
+		// Repairing runs unattended, so the statuses meaning "e2fsck fixed it"
+		// are expected rather than failures.
+		acceptedStatus = e2fsckErrorsCorrected | e2fsckRebootRecommended
 		args = "-pfv"
 	}
 	cmd := exec.CommandContext(ctx, "e2fsck", args, rootfsPath)
 	output, err := cmd.CombinedOutput()
-	if cmd.ProcessState != nil {
-		span.SetAttributes(attribute.Int("filesystem.e2fsck.exit_code", cmd.ProcessState.ExitCode()))
-	}
-	if err != nil {
-		exitCode := cmd.ProcessState.ExitCode()
 
-		if exitCode > accExitCode {
+	// ExitCode reports -1 when e2fsck never started (ProcessState is nil) or was
+	// terminated by a signal, so derive it defensively.
+	exitCode := -1
+	if cmd.ProcessState != nil {
+		exitCode = cmd.ProcessState.ExitCode()
+		span.SetAttributes(attribute.Int("filesystem.e2fsck.exit_code", exitCode))
+	}
+
+	if err != nil {
+		// A missing binary or a signal (OOM killer, context cancellation) means
+		// the filesystem was never fully checked. Reporting that as healthy would
+		// let a corrupted rootfs pass, so surface the underlying error instead of
+		// comparing the -1 placeholder against the accepted statuses.
+		if exitCode < 0 {
+			return string(output), fmt.Errorf("error running e2fsck: %w\n%s", err, output)
+		}
+
+		// e2fsck statuses are a bitmask, so test the bits rather than ordering
+		// them: any bit outside the accepted set is a real failure.
+		if exitCode&^acceptedStatus != 0 {
 			return string(output), fmt.Errorf("error running e2fsck [exit %d]\n%s", exitCode, output)
 		}
 	}

--- a/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
+++ b/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
@@ -40,10 +40,8 @@ const (
 	reservedBlocksPercentage = int64(0)
 )
 
-// e2fsck reports its outcome as a bitmask, so several conditions can be
-// combined in a single exit status. See the "EXIT CODE" section of e2fsck(8);
-// the statuses not named here (4 uncorrected errors, 8 operational error,
-// 16 usage error, 32 canceled, 128 shared-library error) are always failures.
+// e2fsck exit statuses are a bitmask (e2fsck(8), "EXIT CODE"); bits not
+// named here are always failures.
 const (
 	e2fsckErrorsCorrected   = 1
 	e2fsckRebootRecommended = 2
@@ -257,16 +255,12 @@ func CheckIntegrity(ctx context.Context, rootfsPath string, fix bool) (out strin
 	acceptedStatus := 0
 	args := "-nfv"
 	if fix {
-		// Repairing runs unattended, so the statuses meaning "e2fsck fixed it"
-		// are expected rather than failures.
 		acceptedStatus = e2fsckErrorsCorrected | e2fsckRebootRecommended
 		args = "-pfv"
 	}
 	cmd := exec.CommandContext(ctx, "e2fsck", args, rootfsPath)
 	output, err := cmd.CombinedOutput()
 
-	// ExitCode reports -1 when e2fsck never started (ProcessState is nil) or was
-	// terminated by a signal, so derive it defensively.
 	exitCode := -1
 	if cmd.ProcessState != nil {
 		exitCode = cmd.ProcessState.ExitCode()
@@ -274,16 +268,12 @@ func CheckIntegrity(ctx context.Context, rootfsPath string, fix bool) (out strin
 	}
 
 	if err != nil {
-		// A missing binary or a signal (OOM killer, context cancellation) means
-		// the filesystem was never fully checked. Reporting that as healthy would
-		// let a corrupted rootfs pass, so surface the underlying error instead of
-		// comparing the -1 placeholder against the accepted statuses.
+		// Negative means e2fsck never ran to completion (failed to start or was
+		// signaled); an unchecked filesystem must not pass as healthy.
 		if exitCode < 0 {
 			return string(output), fmt.Errorf("error running e2fsck: %w\n%s", err, output)
 		}
 
-		// e2fsck statuses are a bitmask, so test the bits rather than ordering
-		// them: any bit outside the accepted set is a real failure.
 		if exitCode&^acceptedStatus != 0 {
 			return string(output), fmt.Errorf("error running e2fsck [exit %d]\n%s", exitCode, output)
 		}

--- a/packages/orchestrator/pkg/template/build/core/filesystem/ext4_checkintegrity_test.go
+++ b/packages/orchestrator/pkg/template/build/core/filesystem/ext4_checkintegrity_test.go
@@ -11,9 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fakeBinDir creates a directory containing a fake `e2fsck` shell script and
-// points PATH at it, so CheckIntegrity resolves the fake instead of the real
-// binary. Passing an empty script body means "no e2fsck on PATH at all".
+// fakeBinDir points PATH at a directory whose only entry is a fake `e2fsck`
+// script; an empty script means no e2fsck on PATH at all.
 func fakeBinDir(t *testing.T, script string) string {
 	t.Helper()
 
@@ -74,25 +73,19 @@ func TestCheckIntegrityExitStatus(t *testing.T) { //nolint:paralleltest // t.Set
 			wantErr: false,
 		},
 		{
-			// e2fsck exit codes are a bitmask: 3 == 1|2 == "errors corrected"
-			// plus "reboot recommended". Both bits are accepted individually
-			// when fixing, so their combination must be accepted too.
+			// 3 == e2fsckErrorsCorrected|e2fsckRebootRecommended, both accepted bits at once.
 			name:    "combined corrected+reboot bitmask is accepted when fixing",
 			script:  "exit 3",
 			fix:     true,
 			wantErr: false,
 		},
 		{
-			// e2fsck killed by a signal (OOM killer, context cancellation)
-			// never finished checking the filesystem, so its silence must not
-			// be read as "healthy".
 			name:    "e2fsck killed by a signal is reported",
 			script:  "kill -9 $$",
 			fix:     true,
 			wantErr: true,
 		},
 		{
-			// e2fsck missing entirely means the filesystem was never checked.
 			name:    "e2fsck failing to start is reported",
 			script:  "",
 			fix:     true,

--- a/packages/orchestrator/pkg/template/build/core/filesystem/ext4_checkintegrity_test.go
+++ b/packages/orchestrator/pkg/template/build/core/filesystem/ext4_checkintegrity_test.go
@@ -1,0 +1,117 @@
+//go:build linux
+
+package filesystem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBinDir creates a directory containing a fake `e2fsck` shell script and
+// points PATH at it, so CheckIntegrity resolves the fake instead of the real
+// binary. Passing an empty script body means "no e2fsck on PATH at all".
+func fakeBinDir(t *testing.T, script string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	if script != "" {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "e2fsck"),
+			[]byte("#!/bin/sh\n"+script+"\n"),
+			0o755,
+		))
+	}
+	t.Setenv("PATH", dir)
+
+	return dir
+}
+
+func TestCheckIntegrityExitStatus(t *testing.T) {
+	// No t.Parallel: these subtests mutate PATH via t.Setenv.
+	tests := []struct {
+		name    string
+		script  string
+		fix     bool
+		wantErr bool
+	}{
+		{
+			name:    "clean filesystem is reported healthy",
+			script:  "exit 0",
+			fix:     true,
+			wantErr: false,
+		},
+		{
+			name:    "uncorrected errors are reported",
+			script:  "exit 4",
+			fix:     true,
+			wantErr: true,
+		},
+		{
+			name:    "operational error is reported",
+			script:  "exit 8",
+			fix:     true,
+			wantErr: true,
+		},
+		{
+			name:    "any non-zero status is reported when not fixing",
+			script:  "exit 1",
+			fix:     false,
+			wantErr: true,
+		},
+		{
+			name:    "corrected errors are accepted when fixing",
+			script:  "exit 1",
+			fix:     true,
+			wantErr: false,
+		},
+		{
+			name:    "corrected errors needing reboot are accepted when fixing",
+			script:  "exit 2",
+			fix:     true,
+			wantErr: false,
+		},
+		{
+			// e2fsck exit codes are a bitmask: 3 == 1|2 == "errors corrected"
+			// plus "reboot recommended". Both bits are accepted individually
+			// when fixing, so their combination must be accepted too.
+			name:    "combined corrected+reboot bitmask is accepted when fixing",
+			script:  "exit 3",
+			fix:     true,
+			wantErr: false,
+		},
+		{
+			// e2fsck killed by a signal (OOM killer, context cancellation)
+			// never finished checking the filesystem, so its silence must not
+			// be read as "healthy".
+			name:    "e2fsck killed by a signal is reported",
+			script:  "kill -9 $$",
+			fix:     true,
+			wantErr: true,
+		},
+		{
+			// e2fsck missing entirely means the filesystem was never checked.
+			name:    "e2fsck failing to start is reported",
+			script:  "",
+			fix:     true,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeBinDir(t, tt.script)
+
+			_, err := CheckIntegrity(context.Background(), "/tmp/does-not-matter.ext4", tt.fix)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/packages/orchestrator/pkg/template/build/core/filesystem/ext4_checkintegrity_test.go
+++ b/packages/orchestrator/pkg/template/build/core/filesystem/ext4_checkintegrity_test.go
@@ -30,8 +30,7 @@ func fakeBinDir(t *testing.T, script string) string {
 	return dir
 }
 
-func TestCheckIntegrityExitStatus(t *testing.T) {
-	// No t.Parallel: these subtests mutate PATH via t.Setenv.
+func TestCheckIntegrityExitStatus(t *testing.T) { //nolint:paralleltest // t.Setenv cannot be used with t.Parallel.
 	tests := []struct {
 		name    string
 		script  string
@@ -101,7 +100,7 @@ func TestCheckIntegrityExitStatus(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest // t.Setenv cannot be used with t.Parallel.
 		t.Run(tt.name, func(t *testing.T) {
 			fakeBinDir(t, tt.script)
 


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-1697

**Broken:** `filesystem.CheckIntegrity` could return nil for a rootfs that was never actually checked — a corrupted filesystem passed the integrity gate used by the OCI, base-provision, rootfs and resize-disk build phases.

**Root cause:** the guard `exitCode > accExitCode` misses `ExitCode() == -1` (e2fsck never started, or killed by a signal — OOM, context cancel), so the error was swallowed. The ordered `>` compare also misread e2fsck's bitmask statuses: status 3 (`1|2`, corrected + reboot) failed even though both bits are individually accepted.

**Fix:** treat -1 (not started / signalled) as a failed check; accept a status only when every set bit is accepted.

**Repro:** new `TestCheckIntegrityExitStatus` (fake `e2fsck` on PATH) — 3 of 9 cases fail on unmodified main (signal → nil error, start failure → nil error, status 3 spuriously rejected); the other 6 pin existing behaviour.

**Verification:** all 9 cases + full package suite pass; `gofmt`/`go vet` clean; `go build ./...` on `packages/orchestrator` OK. Run in a `golang:1.26` linux container (package is `//go:build linux`).

Note: the Linear issue predicts a nil-pointer panic — not reachable (`(*os.ProcessState).ExitCode()` guards a nil receiver, returns -1); silent success was the actual defect, and the nil case is still handled explicitly.
