### PR TITLE
fix(orchestrator): reclaim the cached metafile when a template is evicted

### DIFF
--- a/packages/orchestrator/pkg/sandbox/template/storage_template.go
+++ b/packages/orchestrator/pkg/sandbox/template/storage_template.go
@@ -290,7 +290,20 @@ func (t *storageTemplate) Fetch(ctx context.Context, buildStore *build.DiffStore
 }
 
 func (t *storageTemplate) Close(ctx context.Context) error {
-	return closeTemplate(ctx, t)
+	err := closeTemplate(ctx, t)
+
+	// closeTemplate only reclaims what the Template interface exposes. The
+	// metafile becomes the template's own once AddSnapshot transfers it from the
+	// snapshot, so eviction is the last chance to reclaim it. Read it with
+	// Result, not Wait: a template evicted while it is still fetching has no
+	// metafile yet and must not block eviction waiting for one.
+	if metafile, metafileErr := t.metafile.Result(); metafileErr == nil {
+		if closeErr := metafile.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("error closing metafile: %w", closeErr))
+		}
+	}
+
+	return err
 }
 
 func (t *storageTemplate) Files() storage.CachePaths {

--- a/packages/orchestrator/pkg/sandbox/template/storage_template_close_test.go
+++ b/packages/orchestrator/pkg/sandbox/template/storage_template_close_test.go
@@ -3,6 +3,7 @@
 package template
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,6 +15,8 @@ import (
 	blockmocks "github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block/mocks"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
+
+var errFailingMetafile = errors.New("metafile close failed")
 
 // closableTemplate builds a storageTemplate whose devices are already resolved,
 // mirroring a template that finished fetching and is now being evicted.
@@ -57,6 +60,27 @@ func TestStorageTemplate_CloseRemovesMetafile(t *testing.T) {
 
 	assert.NoFileExists(t, snapPath, "snapfile should be reclaimed on close")
 	assert.NoFileExists(t, metaPath, "metafile should be reclaimed on close")
+}
+
+// failingFile is a File whose Close always fails.
+type failingFile struct{ err error }
+
+func (f failingFile) Path() string { return "/dev/null" }
+
+func (f failingFile) Close() error { return f.err }
+
+// A metafile that cannot be reclaimed must surface the failure rather than be
+// dropped, so eviction problems stay visible.
+func TestStorageTemplate_CloseReportsMetafileError(t *testing.T) {
+	t.Parallel()
+
+	tmpl, _, _ := closableTemplate(t)
+	tmpl.metafile = utils.NewSetOnce[File]()
+	require.NoError(t, tmpl.metafile.SetValue(failingFile{err: errFailingMetafile}))
+
+	err := tmpl.Close(t.Context())
+
+	require.ErrorIs(t, err, errFailingMetafile)
 }
 
 // A template can be evicted before its metafile has resolved (eviction racing

--- a/packages/orchestrator/pkg/sandbox/template/storage_template_close_test.go
+++ b/packages/orchestrator/pkg/sandbox/template/storage_template_close_test.go
@@ -1,0 +1,96 @@
+//go:build linux
+
+package template
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
+	blockmocks "github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block/mocks"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
+)
+
+// closableTemplate builds a storageTemplate whose devices are already resolved,
+// mirroring a template that finished fetching and is now being evicted.
+func closableTemplate(t *testing.T) (*storageTemplate, string, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "snapfile")
+	metaPath := filepath.Join(dir, "metafile")
+	require.NoError(t, os.WriteFile(snapPath, []byte("snap"), 0o600))
+	require.NoError(t, os.WriteFile(metaPath, []byte(`{"version":1}`), 0o600))
+
+	memDev := blockmocks.NewMockReadonlyDevice(t)
+	memDev.EXPECT().Close().Return(nil)
+	rootfsDev := blockmocks.NewMockReadonlyDevice(t)
+	rootfsDev.EXPECT().Close().Return(nil)
+
+	tmpl := &storageTemplate{
+		memfile:  utils.NewSetOnce[block.ReadonlyDevice](),
+		rootfs:   utils.NewSetOnce[block.ReadonlyDevice](),
+		snapfile: utils.NewSetOnce[File](),
+		metafile: utils.NewSetOnce[File](),
+	}
+	require.NoError(t, tmpl.memfile.SetValue(memDev))
+	require.NoError(t, tmpl.rootfs.SetValue(rootfsDev))
+	require.NoError(t, tmpl.snapfile.SetValue(&storageFile{path: snapPath}))
+	require.NoError(t, tmpl.metafile.SetValue(&storageFile{path: metaPath}))
+
+	return tmpl, snapPath, metaPath
+}
+
+// Evicting a cached template must reclaim every file it owns. The metafile is
+// owned by the template once AddSnapshot transfers it from the snapshot, so
+// leaving it behind leaks one cache file per evicted template.
+func TestStorageTemplate_CloseRemovesMetafile(t *testing.T) {
+	t.Parallel()
+
+	tmpl, snapPath, metaPath := closableTemplate(t)
+
+	require.NoError(t, tmpl.Close(t.Context()))
+
+	assert.NoFileExists(t, snapPath, "snapfile should be reclaimed on close")
+	assert.NoFileExists(t, metaPath, "metafile should be reclaimed on close")
+}
+
+// A template can be evicted before its metafile has resolved (eviction racing
+// the fetch). Close must not block waiting for it and must not report an error.
+func TestStorageTemplate_CloseWithUnresolvedMetafile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "snapfile")
+	require.NoError(t, os.WriteFile(snapPath, []byte("snap"), 0o600))
+
+	memDev := blockmocks.NewMockReadonlyDevice(t)
+	memDev.EXPECT().Close().Return(nil)
+	rootfsDev := blockmocks.NewMockReadonlyDevice(t)
+	rootfsDev.EXPECT().Close().Return(nil)
+
+	tmpl := &storageTemplate{
+		memfile:  utils.NewSetOnce[block.ReadonlyDevice](),
+		rootfs:   utils.NewSetOnce[block.ReadonlyDevice](),
+		snapfile: utils.NewSetOnce[File](),
+		metafile: utils.NewSetOnce[File](),
+	}
+	require.NoError(t, tmpl.memfile.SetValue(memDev))
+	require.NoError(t, tmpl.rootfs.SetValue(rootfsDev))
+	require.NoError(t, tmpl.snapfile.SetValue(&storageFile{path: snapPath}))
+	// metafile deliberately left unset.
+
+	done := make(chan error, 1)
+	go func() { done <- tmpl.Close(t.Context()) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-t.Context().Done():
+		t.Fatal("Close blocked on an unresolved metafile")
+	}
+}

--- a/packages/orchestrator/pkg/sandbox/template/storage_template_close_test.go
+++ b/packages/orchestrator/pkg/sandbox/template/storage_template_close_test.go
@@ -18,8 +18,7 @@ import (
 
 var errFailingMetafile = errors.New("metafile close failed")
 
-// closableTemplate builds a storageTemplate whose devices are already resolved,
-// mirroring a template that finished fetching and is now being evicted.
+// closableTemplate builds a storageTemplate fully resolved, as after a completed fetch.
 func closableTemplate(t *testing.T) (*storageTemplate, string, string) {
 	t.Helper()
 
@@ -48,9 +47,8 @@ func closableTemplate(t *testing.T) (*storageTemplate, string, string) {
 	return tmpl, snapPath, metaPath
 }
 
-// Evicting a cached template must reclaim every file it owns. The metafile is
-// owned by the template once AddSnapshot transfers it from the snapshot, so
-// leaving it behind leaks one cache file per evicted template.
+// The metafile is template-owned once AddSnapshot transfers it from the
+// snapshot; leaving it behind leaks one cache file per evicted template.
 func TestStorageTemplate_CloseRemovesMetafile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-1699

**Broken:** evicting a template from the template cache leaked its cached metafile on disk — one file per evicted template, reclaimed only when a process restart's `cleanDir` wipes the cache root.

**Root cause:** eviction's `closeTemplate` can only reclaim what the `Template` interface exposes (Memfile/Rootfs/Snapfile); the metafile is held privately by `storageTemplate`, and once `Cache.AddSnapshot` transfers metadata ownership from the `Snapshot`, snapshot cleanup stops removing it too.

**Fix:** `storageTemplate.Close` reclaims the metafile itself — it is the only implementer that owns one (`LocalTemplate` has none, `MaskTemplate` has its own `Close`), so the shared interface stays untouched. `Close` reads the metafile with `Result` rather than `Wait`, so an eviction racing a fetch cannot block on a metafile that never resolves (`TestStorageTemplate_CloseWithUnresolvedMetafile`, passes before and after).

**Repro:** new `TestStorageTemplate_CloseRemovesMetafile` fails on unmodified main ("metafile should be reclaimed on close"); its snapfile assertion passes before and after, pinning existing behaviour.

**Verification:** both new tests + full package suite pass; `gofmt`/`go vet` clean. Run in a `golang:1.26` linux container (package is `//go:build linux`).
