### PR TITLE
fix(orchestrator): stop flushing Firecracker metrics after the VM exits

### DIFF
--- a/packages/orchestrator/pkg/sandbox/fc/fc_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/fc/fc_metrics.go
@@ -277,10 +277,9 @@ func runMetricsFlushLoop(
 		case <-exit:
 			return
 		case <-ticks:
-			// A select with several ready cases picks one at random, so a tick
-			// can win against an already-closed exit. Re-check before touching
-			// the API socket: Firecracker may already be gone, and the resulting
-			// "connection reset by peer" would look like a real API failure.
+			// select picks ready cases at random, so a tick can win against an
+			// already-closed exit; re-check or the flush hits a dead Firecracker
+			// and logs a spurious API failure.
 			select {
 			case <-exit:
 				return

--- a/packages/orchestrator/pkg/sandbox/fc/fc_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/fc/fc_metrics.go
@@ -263,6 +263,37 @@ func (p *Process) FlushAndReadBalloonMetrics(ctx context.Context) (BalloonMetric
 	}
 }
 
+// runMetricsFlushLoop asks Firecracker to flush its metrics on every tick until
+// the VM exits. It reports flush failures through onFlushErr.
+func runMetricsFlushLoop(
+	ctx context.Context,
+	exit <-chan struct{},
+	ticks <-chan time.Time,
+	flush func(context.Context) error,
+	onFlushErr func(error),
+) {
+	for {
+		select {
+		case <-exit:
+			return
+		case <-ticks:
+			// A select with several ready cases picks one at random, so a tick
+			// can win against an already-closed exit. Re-check before touching
+			// the API socket: Firecracker may already be gone, and the resulting
+			// "connection reset by peer" would look like a real API failure.
+			select {
+			case <-exit:
+				return
+			default:
+			}
+
+			if err := flush(ctx); err != nil {
+				onFlushErr(err)
+			}
+		}
+	}
+}
+
 // startMetricsReader opens the metrics FIFO and starts a goroutine that reads
 // Firecracker metrics lines and exports metrics via OTEL.
 // It must be called before setMetrics so that the FIFO is open for reading
@@ -280,19 +311,12 @@ func (p *Process) startMetricsReader(ctx context.Context) {
 		ticker := time.NewTicker(metricsFlushInterval)
 		defer ticker.Stop()
 
-		for {
-			select {
-			case <-p.Exit.Done():
-				return
-			case <-ticker.C:
-				if err := p.client.flushMetrics(ctx); err != nil {
-					logger.L().Warn(ctx, "failed to flush fc metrics",
-						zap.Error(err),
-						logger.WithSandboxID(sandboxID),
-					)
-				}
-			}
-		}
+		runMetricsFlushLoop(ctx, p.Exit.Done(), ticker.C, p.client.flushMetrics, func(err error) {
+			logger.L().Warn(ctx, "failed to flush fc metrics",
+				zap.Error(err),
+				logger.WithSandboxID(sandboxID),
+			)
+		})
 	}()
 
 	go func() {

--- a/packages/orchestrator/pkg/sandbox/fc/fc_metrics_flush_test.go
+++ b/packages/orchestrator/pkg/sandbox/fc/fc_metrics_flush_test.go
@@ -11,10 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// When Firecracker has exited, a tick that was already pending must not reach
-// the (now dead) API socket. Both channels are armed before every iteration so
-// the select genuinely has to choose between them; repeating drives the random
-// choice hard enough that an unguarded loop cannot stay silent.
+// A tick already pending when exit closes must not trigger a flush. Both
+// channels are ready on every iteration, so the select must choose between
+// them; repetition makes an unguarded loop fail despite the random pick.
 func TestRunMetricsFlushLoop_NoFlushAfterExit(t *testing.T) {
 	t.Parallel()
 
@@ -50,7 +49,6 @@ func TestRunMetricsFlushLoop_NoFlushAfterExit(t *testing.T) {
 	assert.Zero(t, flushes, "flushed Firecracker metrics after the VM had exited")
 }
 
-// While the VM is alive, ticks must still trigger flushes.
 func TestRunMetricsFlushLoop_FlushesWhileRunning(t *testing.T) {
 	t.Parallel()
 
@@ -89,7 +87,6 @@ func TestRunMetricsFlushLoop_FlushesWhileRunning(t *testing.T) {
 	}
 }
 
-// Flush failures while the VM is alive are still reported.
 func TestRunMetricsFlushLoop_ReportsFlushError(t *testing.T) {
 	t.Parallel()
 

--- a/packages/orchestrator/pkg/sandbox/fc/fc_metrics_flush_test.go
+++ b/packages/orchestrator/pkg/sandbox/fc/fc_metrics_flush_test.go
@@ -1,0 +1,117 @@
+//go:build linux
+
+package fc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// When Firecracker has exited, a tick that was already pending must not reach
+// the (now dead) API socket. Both channels are armed before every iteration so
+// the select genuinely has to choose between them; repeating drives the random
+// choice hard enough that an unguarded loop cannot stay silent.
+func TestRunMetricsFlushLoop_NoFlushAfterExit(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 1000
+
+	exit := make(chan struct{})
+	close(exit)
+
+	ticks := make(chan time.Time, 1)
+	flushes := 0
+
+	for range iterations {
+		// Re-arm the tick; the loop may or may not have consumed the last one.
+		select {
+		case <-ticks:
+		default:
+		}
+		ticks <- time.Now()
+
+		runMetricsFlushLoop(
+			t.Context(),
+			exit,
+			ticks,
+			func(context.Context) error {
+				flushes++
+
+				return nil
+			},
+			func(error) { t.Error("unexpected flush error") },
+		)
+	}
+
+	assert.Zero(t, flushes, "flushed Firecracker metrics after the VM had exited")
+}
+
+// While the VM is alive, ticks must still trigger flushes.
+func TestRunMetricsFlushLoop_FlushesWhileRunning(t *testing.T) {
+	t.Parallel()
+
+	exit := make(chan struct{})
+	ticks := make(chan time.Time)
+	flushed := make(chan struct{}, 1)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runMetricsFlushLoop(
+			t.Context(),
+			exit,
+			ticks,
+			func(context.Context) error {
+				flushed <- struct{}{}
+
+				return nil
+			},
+			func(error) { t.Error("unexpected flush error") },
+		)
+	}()
+
+	ticks <- time.Now()
+	select {
+	case <-flushed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tick did not trigger a flush")
+	}
+
+	close(exit)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop did not stop after exit")
+	}
+}
+
+// Flush failures while the VM is alive are still reported.
+func TestRunMetricsFlushLoop_ReportsFlushError(t *testing.T) {
+	t.Parallel()
+
+	exit := make(chan struct{})
+	ticks := make(chan time.Time)
+	errs := make(chan error, 1)
+
+	go runMetricsFlushLoop(
+		t.Context(),
+		exit,
+		ticks,
+		func(context.Context) error { return assert.AnError },
+		func(err error) { errs <- err },
+	)
+
+	ticks <- time.Now()
+	select {
+	case err := <-errs:
+		require.ErrorIs(t, err, assert.AnError)
+	case <-time.After(5 * time.Second):
+		t.Fatal("flush error was not reported")
+	}
+
+	close(exit)
+}


### PR DESCRIPTION
Fixes #3275

**Broken:** after a Firecracker VM exited, the metrics flusher could issue one more flush against the dead API socket, logging `failed to flush fc metrics ... connection reset by peer` — reads like a real FC API failure and gets noisy when many VMs exit at once.

**Root cause:** the loop selected on `p.Exit.Done()` and `ticker.C` together; when the VM exits with a tick already pending both cases are ready and Go picks uniformly at random, so ~half the time the tick won and flushed a socket that was already gone.

**Repro:** extracted the loop into `runMetricsFlushLoop`; new `TestRunMetricsFlushLoop_NoFlushAfterExit` arms a closed exit channel plus a pending tick, 1000 iterations. With the guard removed: 490/1000 flushes after exit (the expected ~50% coin flip); with the guard: 0.

**Verification:** all three tests pass incl. `-race -count=5` with no flakes; full `pkg/sandbox/fc` suite green; `gofmt`, `go vet`, `golangci-lint v2.11.4` clean. Run in a `golang:1.26` linux container.

Companion tests (`FlushesWhileRunning`, `ReportsFlushError`) pass before and after — ticks still flush while the VM is alive, flush errors are still reported.
