### PR TITLE
fix(orchestrator): remove the cache file when a diff turns out to be empty

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build/local_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/local_diff.go
@@ -79,9 +79,8 @@ func (f *LocalDiffFile) CloseToDiff(
 	}
 
 	if size.Size() == 0 {
-		// NoDiff carries no path, so this is the last reference to the cache file
-		// and nothing registers it in the DiffStore. Reclaim it here or it orphans
-		// exactly like the partial file the deferred cleanup above removes.
+		// NoDiff carries no path and nothing registers this file in the DiffStore,
+		// so this is the last chance to reclaim it.
 		if rmErr := os.Remove(f.cachePath); rmErr != nil && !os.IsNotExist(rmErr) {
 			return nil, fmt.Errorf("failed to remove empty diff file: %w", rmErr)
 		}

--- a/packages/orchestrator/pkg/sandbox/build/local_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/local_diff.go
@@ -79,6 +79,13 @@ func (f *LocalDiffFile) CloseToDiff(
 	}
 
 	if size.Size() == 0 {
+		// NoDiff carries no path, so this is the last reference to the cache file
+		// and nothing registers it in the DiffStore. Reclaim it here or it orphans
+		// exactly like the partial file the deferred cleanup above removes.
+		if rmErr := os.Remove(f.cachePath); rmErr != nil && !os.IsNotExist(rmErr) {
+			return nil, fmt.Errorf("failed to remove empty diff file: %w", rmErr)
+		}
+
 		return &NoDiff{}, nil
 	}
 

--- a/packages/orchestrator/pkg/sandbox/build/local_diff_test.go
+++ b/packages/orchestrator/pkg/sandbox/build/local_diff_test.go
@@ -34,3 +34,23 @@ func TestLocalDiffFileCloseToDiffRemovesPartialOnError(t *testing.T) {
 	require.Nil(t, diff)
 	require.NoFileExists(t, cachePath, "partial diff file must be removed on materialization failure")
 }
+
+// An empty diff is reported as NoDiff, which owns no path, so CloseToDiff is the
+// only place that can reclaim the zero-length cache file it created. Leaving it
+// behind orphans a file the DiffStore never learns about, so disk-pressure
+// eviction cannot reclaim it either.
+func TestLocalDiffFileCloseToDiffRemovesEmptyCacheFile(t *testing.T) {
+	t.Parallel()
+
+	f, err := NewLocalDiffFile(t.TempDir(), "build-test-id", Rootfs)
+	require.NoError(t, err)
+
+	cachePath := f.cachePath
+	require.FileExists(t, cachePath)
+
+	// Nothing written, so CloseToDiff takes the zero-size NoDiff branch.
+	diff, err := f.CloseToDiff(blockSize)
+	require.NoError(t, err)
+	require.IsType(t, &NoDiff{}, diff)
+	require.NoFileExists(t, cachePath, "empty diff cache file must be removed")
+}

--- a/packages/orchestrator/pkg/sandbox/build/local_diff_test.go
+++ b/packages/orchestrator/pkg/sandbox/build/local_diff_test.go
@@ -35,10 +35,8 @@ func TestLocalDiffFileCloseToDiffRemovesPartialOnError(t *testing.T) {
 	require.NoFileExists(t, cachePath, "partial diff file must be removed on materialization failure")
 }
 
-// An empty diff is reported as NoDiff, which owns no path, so CloseToDiff is the
-// only place that can reclaim the zero-length cache file it created. Leaving it
-// behind orphans a file the DiffStore never learns about, so disk-pressure
-// eviction cannot reclaim it either.
+// TestLocalDiffFileCloseToDiffRemovesEmptyCacheFile verifies the zero-size NoDiff
+// branch removes the cache file: NoDiff owns no path, so nothing downstream can.
 func TestLocalDiffFileCloseToDiffRemovesEmptyCacheFile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-1698

**Broken:** when a sandbox diff turns out empty, `LocalDiffFile.CloseToDiff` returns `NoDiff` and leaves its zero-length cache file on disk. Nothing reclaims it — `NoDiff` carries no path and the file is never registered in the `DiffStore`, so disk-pressure eviction can't see it; the orphan persists until process restart.

**Root cause:** the deferred cleanup that removes the partial cache file is gated on `e != nil`, and the zero-size branch returns `(&NoDiff{}, nil)`, so it never fires.

**Fix:** remove the cache file on the empty-diff path, mirroring the existing partial-file cleanup incl. tolerating `os.IsNotExist` (a file already gone is not an error).

**Repro:** new `TestLocalDiffFileCloseToDiffRemovesEmptyCacheFile` fails on unmodified main ("empty diff cache file must be removed"); the existing error-path test passes before and after.

**Verification:** both tests pass; full `pkg/sandbox/build` suite green; `gofmt`, `go vet`, `golangci-lint v2.11.4` clean. Run in a `golang:1.26` linux container (package is `//go:build linux`).
