### PR TITLE
fix(api): allow listing tags of public templates cross-team

### DIFF
--- a/packages/api/internal/handlers/template_tags.go
+++ b/packages/api/internal/handlers/template_tags.go
@@ -320,7 +320,7 @@ func (a *APIStore) GetTemplatesTemplateIDTags(c *gin.Context, templateID api.Tem
 		return
 	}
 
-	aliasInfo, err := a.templateCache.ResolveAlias(ctx, identifier, team.Slug)
+	aliasInfo, metadata, err := a.templateCache.ResolveAliasWithMetadata(ctx, identifier, team.Slug)
 	if err != nil {
 		apiErr := templatecache.ErrorToAPIError(err, identifier)
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
@@ -329,7 +329,8 @@ func (a *APIStore) GetTemplatesTemplateIDTags(c *gin.Context, templateID api.Tem
 		return
 	}
 
-	if aliasInfo.TeamID != team.ID {
+	// Public templates are readable cross-team, matching how they can be used everywhere else.
+	if aliasInfo.TeamID != team.ID && !metadata.Public {
 		a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You don't have access to sandbox template '%s'", templateID))
 		telemetry.ReportError(ctx, "no access to the template", nil, telemetry.WithTemplateID(aliasInfo.TemplateID))
 

--- a/packages/api/internal/handlers/template_tags_test.go
+++ b/packages/api/internal/handlers/template_tags_test.go
@@ -1,0 +1,150 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apispec "github.com/e2b-dev/infra/packages/api/internal/api"
+	templatecache "github.com/e2b-dev/infra/packages/api/internal/cache/templates"
+	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
+	"github.com/e2b-dev/infra/packages/auth/pkg/types"
+	authqueries "github.com/e2b-dev/infra/packages/db/pkg/auth/queries"
+	"github.com/e2b-dev/infra/packages/db/pkg/testutils"
+	testqueries "github.com/e2b-dev/infra/packages/db/pkg/testutils/queries"
+	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
+)
+
+func newTemplateTagsStore(t *testing.T, testDB *testutils.Database) *APIStore {
+	t.Helper()
+
+	return &APIStore{
+		sqlcDB:        testDB.SqlcClient,
+		authDB:        testDB.AuthDb,
+		templateCache: templatecache.NewTemplateCache(testDB.SqlcClient, redis_utils.SetupInstance(t)),
+	}
+}
+
+func listTemplateTagsForTeam(
+	t *testing.T,
+	store *APIStore,
+	teamID uuid.UUID,
+	teamSlug string,
+	templateRef string,
+) *apispec.GetTemplatesTemplateIDTagsResponse {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequestWithContext(t.Context(), http.MethodGet, fmt.Sprintf("/templates/%s/tags", templateRef), nil)
+	auth.SetTeamInfoForTest(t, c, &types.Team{
+		Team: &authqueries.Team{
+			ID:   teamID,
+			Slug: teamSlug,
+		},
+	})
+
+	store.GetTemplatesTemplateIDTags(c, templateRef)
+
+	res, err := apispec.ParseGetTemplatesTemplateIDTagsResponse(w.Result())
+	require.NoError(t, err)
+
+	return res
+}
+
+// createPrivateTestTemplate seeds a non-public template.
+// testutils.CreateTestTemplate hardcodes public = true, so private templates
+// have to be inserted directly.
+func createPrivateTestTemplate(t *testing.T, testDB *testutils.Database, teamID uuid.UUID) string {
+	t.Helper()
+	templateID := "base-env-" + uuid.New().String()
+
+	err := testDB.TestQueries.InsertTestEnv(t.Context(), testqueries.InsertTestEnvParams{
+		ID:     templateID,
+		TeamID: teamID,
+		Public: false,
+		Source: "template",
+	})
+	require.NoError(t, err, "Failed to create private test template")
+
+	return templateID
+}
+
+func TestGetTemplateTagsAsOwnerTeam(t *testing.T) {
+	t.Parallel()
+
+	testDB := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, testDB)
+	teamSlug := testutils.GetTeamSlug(t, ctx, testDB, teamID)
+	templateID := testutils.CreateTestTemplate(t, testDB, teamID)
+
+	buildID := testutils.CreateTestBuild(t, ctx, testDB, templateID, "uploaded")
+	testutils.CreateTestBuildAssignment(t, ctx, testDB, templateID, buildID, "dev")
+
+	store := newTemplateTagsStore(t, testDB)
+
+	res := listTemplateTagsForTeam(t, store, teamID, teamSlug, templateID)
+
+	require.Equal(t, http.StatusOK, res.StatusCode(), string(res.Body))
+	require.NotNil(t, res.JSON200)
+	require.Len(t, *res.JSON200, 1)
+	assert.Equal(t, "dev", (*res.JSON200)[0].Tag)
+	assert.Equal(t, buildID, (*res.JSON200)[0].BuildID)
+}
+
+// TestGetTemplateTagsPublicTemplateAsForeignTeam covers EN-617: a public
+// template is usable cross-team, so listing its tags must not be owner-only.
+func TestGetTemplateTagsPublicTemplateAsForeignTeam(t *testing.T) {
+	t.Parallel()
+
+	testDB := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	ownerTeamID := testutils.CreateTestTeam(t, testDB)
+	foreignTeamID := testutils.CreateTestTeam(t, testDB)
+	foreignTeamSlug := testutils.GetTeamSlug(t, ctx, testDB, foreignTeamID)
+
+	// CreateTestTemplate seeds a public template.
+	templateID := testutils.CreateTestTemplate(t, testDB, ownerTeamID)
+	buildID := testutils.CreateTestBuild(t, ctx, testDB, templateID, "uploaded")
+	testutils.CreateTestBuildAssignment(t, ctx, testDB, templateID, buildID, "dev")
+
+	store := newTemplateTagsStore(t, testDB)
+
+	res := listTemplateTagsForTeam(t, store, foreignTeamID, foreignTeamSlug, templateID)
+
+	require.Equal(t, http.StatusOK, res.StatusCode(), string(res.Body))
+	require.NotNil(t, res.JSON200)
+	require.Len(t, *res.JSON200, 1)
+	assert.Equal(t, "dev", (*res.JSON200)[0].Tag)
+	assert.Equal(t, buildID, (*res.JSON200)[0].BuildID)
+}
+
+func TestGetTemplateTagsPrivateTemplateAsForeignTeam(t *testing.T) {
+	t.Parallel()
+
+	testDB := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	ownerTeamID := testutils.CreateTestTeam(t, testDB)
+	foreignTeamID := testutils.CreateTestTeam(t, testDB)
+	foreignTeamSlug := testutils.GetTeamSlug(t, ctx, testDB, foreignTeamID)
+
+	templateID := createPrivateTestTemplate(t, testDB, ownerTeamID)
+	buildID := testutils.CreateTestBuild(t, ctx, testDB, templateID, "uploaded")
+	testutils.CreateTestBuildAssignment(t, ctx, testDB, templateID, buildID, "dev")
+
+	store := newTemplateTagsStore(t, testDB)
+
+	res := listTemplateTagsForTeam(t, store, foreignTeamID, foreignTeamSlug, templateID)
+
+	require.Equal(t, http.StatusForbidden, res.StatusCode(), string(res.Body))
+}

--- a/packages/api/internal/handlers/template_tags_test.go
+++ b/packages/api/internal/handlers/template_tags_test.go
@@ -58,9 +58,7 @@ func listTemplateTagsForTeam(
 	return res
 }
 
-// createPrivateTestTemplate seeds a non-public template.
-// testutils.CreateTestTemplate hardcodes public = true, so private templates
-// have to be inserted directly.
+// createPrivateTestTemplate inserts directly: testutils.CreateTestTemplate hardcodes public = true.
 func createPrivateTestTemplate(t *testing.T, testDB *testutils.Database, teamID uuid.UUID) string {
 	t.Helper()
 	templateID := "base-env-" + uuid.New().String()
@@ -100,8 +98,7 @@ func TestGetTemplateTagsAsOwnerTeam(t *testing.T) {
 	assert.Equal(t, buildID, (*res.JSON200)[0].BuildID)
 }
 
-// TestGetTemplateTagsPublicTemplateAsForeignTeam covers EN-617: a public
-// template is usable cross-team, so listing its tags must not be owner-only.
+// EN-617: public templates are usable cross-team, so listing their tags must not be owner-only.
 func TestGetTemplateTagsPublicTemplateAsForeignTeam(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-617/public-templates-cannot-have-tags-listed-by-other-teams

**Broken:** `GET /templates/{templateID}/tags` returned 403 for any template owned by another team — even public ones, which every other path (sandbox create, build-from, alias resolution) allows cross-team. SDK helpers like `Template.get_tags(...)` fail against any public template the caller doesn't own.

**Root cause:** the handler resolved via `ResolveAlias`, whose `AliasInfo` doesn't carry `Public`, then gated on ownership alone; the flag lives in `TemplateMetadata`, which the handler never fetched (`template_request_build_v3.go` and `template_alias.go` already use `ResolveAliasWithMetadata` for this).

**Fix:** resolve alias + metadata together; allow the read when the caller owns the template or it is public. `POST`/`DELETE /templates/tags` stay owner-only; status codes unchanged.

**Verification:** new `template_tags_test.go` (testcontainers, postgres + redis): owner → 200, foreign team + public → 200, foreign team + private → 403. On unmodified main only the public case fails (403 with the exact reported error), the other two pass — so the test isn't trivially red. All three pass after the fix; `go build`, `go vet`, `gofmt` clean; repo-pinned `golangci-lint` v2.11.4 reports 0 issues.
