### PR TITLE
fix(storage): abort failed GCS multipart uploads instead of orphaning parts

### DIFF
--- a/packages/shared/pkg/storage/compress_upload.go
+++ b/packages/shared/pkg/storage/compress_upload.go
@@ -172,9 +172,8 @@ func compressStream(ctx context.Context, in io.Reader, cfg CompressConfig, uploa
 	if err := uploader.Start(ctx); err != nil {
 		return nil, [32]byte{}, fmt.Errorf("start upload: %w", err)
 	}
-	// Close aborts the upload unless it was committed. A failed abort leaves
-	// an orphaned multipart upload behind, so surface it instead of dropping
-	// it — it can't be returned, since Close runs after the result is fixed.
+	// Close aborts the upload unless it was committed; the deferred error
+	// can't be returned, only logged.
 	defer func() {
 		if err := uploader.Close(); err != nil {
 			logger.L().Warn(ctx, "failed to abort multipart upload", zap.Error(err))

--- a/packages/shared/pkg/storage/compress_upload.go
+++ b/packages/shared/pkg/storage/compress_upload.go
@@ -12,8 +12,10 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/units"
 )
 
@@ -170,7 +172,14 @@ func compressStream(ctx context.Context, in io.Reader, cfg CompressConfig, uploa
 	if err := uploader.Start(ctx); err != nil {
 		return nil, [32]byte{}, fmt.Errorf("start upload: %w", err)
 	}
-	defer uploader.Close()
+	// Close aborts the upload unless it was committed. A failed abort leaves
+	// an orphaned multipart upload behind, so surface it instead of dropping
+	// it — it can't be returned, since Close runs after the result is fixed.
+	defer func() {
+		if err := uploader.Close(); err != nil {
+			logger.L().Warn(ctx, "failed to abort multipart upload", zap.Error(err))
+		}
+	}()
 
 	// The read loop goroutine holds one slot for the duration of the stream;
 	// at least one additional slot is required for uploaders to make progress.

--- a/packages/shared/pkg/storage/gcp_multipart.go
+++ b/packages/shared/pkg/storage/gcp_multipart.go
@@ -30,6 +30,9 @@ import (
 
 const (
 	gcpMultipartUploadChunkSize = 50 * 1024 * 1024 // 50MB chunks
+	// gcpAbortUploadTimeout bounds the abort issued from Close, which runs on
+	// a context detached from the (usually already canceled) upload context.
+	gcpAbortUploadTimeout = 5 * time.Second
 )
 
 // RetryConfig holds the configuration for retry logic
@@ -192,6 +195,9 @@ type MultipartUploader struct {
 	uploadID string
 	mu       sync.Mutex
 	parts    []Part
+	// completed is guarded by mu: it is set by the sole commit point
+	// (completeUpload) and read by Close.
+	completed bool
 }
 
 var _ partUploader = (*MultipartUploader)(nil)
@@ -236,8 +242,23 @@ func (m *MultipartUploader) Complete(ctx context.Context) error {
 	return m.completeUpload(ctx, m.uploadID, parts)
 }
 
+// Close aborts an upload that was started but never committed, so the parts
+// already shipped don't linger in the bucket as an orphaned multipart upload.
 func (m *MultipartUploader) Close() error {
-	return nil
+	m.mu.Lock()
+	completed := m.completed
+	m.mu.Unlock()
+
+	if completed || m.uploadID == "" {
+		return nil
+	}
+
+	// The caller's context is usually already canceled by the failure that
+	// brought us here, so abort on a detached context with its own deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), gcpAbortUploadTimeout)
+	defer cancel()
+
+	return m.abortUpload(ctx, m.uploadID)
 }
 
 func NewMultipartUploaderWithRetryConfig(ctx context.Context, bucketName, objectName string, retryConfig RetryConfig, metadata ObjectMetadata) (*MultipartUploader, error) {
@@ -443,6 +464,42 @@ func (m *MultipartUploader) completeUpload(ctx context.Context, uploadID string,
 		return fmt.Errorf("failed to complete upload (status %d, code %s): %s", resp.StatusCode, apiErr.Code, apiErr.Message)
 	}
 
+	// Flagging the commit here (rather than in Complete) covers every caller
+	// of completeUpload, so no path can leave Close aborting a live object.
+	m.mu.Lock()
+	m.completed = true
+	m.mu.Unlock()
+
+	return nil
+}
+
+// abortUpload discards an in-flight multipart upload and the parts already
+// staged for it. GCS answers 204 on success and 404 when the upload is
+// already gone (completed or aborted), both of which mean nothing is left to
+// clean up.
+func (m *MultipartUploader) abortUpload(ctx context.Context, uploadID string) error {
+	url := fmt.Sprintf("%s/%s?uploadId=%s",
+		m.baseURL, m.objectName, uploadID)
+
+	req, err := retryablehttp.NewRequestWithContext(ctx, "DELETE", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create abort request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+m.token)
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("http request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+
+		return fmt.Errorf("failed to abort upload (status %d): %s", resp.StatusCode, string(body))
+	}
+
 	return nil
 }
 
@@ -472,6 +529,21 @@ func (m *MultipartUploader) UploadFileInParallel(ctx context.Context, filePath s
 	if err != nil {
 		return 0, fmt.Errorf("failed to initiate upload: %w", err)
 	}
+
+	// Publish the upload ID so Close can find it, and abort here on the way
+	// out: unlike the compressed path, this one is not wrapped in
+	// compressStream's deferred Close, so nothing else would clean up the
+	// staged parts. Close is a no-op once completeUpload has committed.
+	m.uploadID = uploadID
+	defer func() {
+		if abortErr := m.Close(); abortErr != nil { //nolint:contextcheck // Close aborts on a detached context by design, so the cleanup still lands when ctx is already canceled.
+			logger.L().Warn(ctx, "failed to abort GCS multipart upload",
+				zap.String("bucket", m.bucketName),
+				zap.String("object", m.objectName),
+				zap.Error(abortErr),
+			)
+		}
+	}()
 
 	// Hash on a sibling goroutine while parts upload — the read overlaps the
 	// upload, adding no wall-clock latency. Own file handle (separate from the

--- a/packages/shared/pkg/storage/gcp_multipart.go
+++ b/packages/shared/pkg/storage/gcp_multipart.go
@@ -30,9 +30,7 @@ import (
 
 const (
 	gcpMultipartUploadChunkSize = 50 * 1024 * 1024 // 50MB chunks
-	// gcpAbortUploadTimeout bounds the abort issued from Close, which runs on
-	// a context detached from the (usually already canceled) upload context.
-	gcpAbortUploadTimeout = 5 * time.Second
+	gcpAbortUploadTimeout       = 5 * time.Second
 )
 
 // RetryConfig holds the configuration for retry logic
@@ -195,8 +193,7 @@ type MultipartUploader struct {
 	uploadID string
 	mu       sync.Mutex
 	parts    []Part
-	// completed is guarded by mu: it is set by the sole commit point
-	// (completeUpload) and read by Close.
+	// completed is guarded by mu; set only by completeUpload, read by Close.
 	completed bool
 }
 
@@ -242,8 +239,8 @@ func (m *MultipartUploader) Complete(ctx context.Context) error {
 	return m.completeUpload(ctx, m.uploadID, parts)
 }
 
-// Close aborts an upload that was started but never committed, so the parts
-// already shipped don't linger in the bucket as an orphaned multipart upload.
+// Close aborts an upload that was started but never committed, discarding
+// its staged parts.
 func (m *MultipartUploader) Close() error {
 	m.mu.Lock()
 	completed := m.completed
@@ -253,8 +250,8 @@ func (m *MultipartUploader) Close() error {
 		return nil
 	}
 
-	// The caller's context is usually already canceled by the failure that
-	// brought us here, so abort on a detached context with its own deadline.
+	// The upload's context is usually already canceled here, so abort on a
+	// detached context with its own deadline.
 	ctx, cancel := context.WithTimeout(context.Background(), gcpAbortUploadTimeout)
 	defer cancel()
 
@@ -464,8 +461,8 @@ func (m *MultipartUploader) completeUpload(ctx context.Context, uploadID string,
 		return fmt.Errorf("failed to complete upload (status %d, code %s): %s", resp.StatusCode, apiErr.Code, apiErr.Message)
 	}
 
-	// Flagging the commit here (rather than in Complete) covers every caller
-	// of completeUpload, so no path can leave Close aborting a live object.
+	// Set here, not in Complete: UploadFileInParallel also commits through
+	// this path, and Close must never abort a live object.
 	m.mu.Lock()
 	m.completed = true
 	m.mu.Unlock()
@@ -473,10 +470,9 @@ func (m *MultipartUploader) completeUpload(ctx context.Context, uploadID string,
 	return nil
 }
 
-// abortUpload discards an in-flight multipart upload and the parts already
-// staged for it. GCS answers 204 on success and 404 when the upload is
-// already gone (completed or aborted), both of which mean nothing is left to
-// clean up.
+// abortUpload discards an in-flight multipart upload and its staged parts.
+// GCS answers 204 on success and 404 when the upload is already gone; both
+// mean nothing is left to clean up.
 func (m *MultipartUploader) abortUpload(ctx context.Context, uploadID string) error {
 	url := fmt.Sprintf("%s/%s?uploadId=%s",
 		m.baseURL, m.objectName, uploadID)
@@ -530,13 +526,12 @@ func (m *MultipartUploader) UploadFileInParallel(ctx context.Context, filePath s
 		return 0, fmt.Errorf("failed to initiate upload: %w", err)
 	}
 
-	// Publish the upload ID so Close can find it, and abort here on the way
-	// out: unlike the compressed path, this one is not wrapped in
-	// compressStream's deferred Close, so nothing else would clean up the
-	// staged parts. Close is a no-op once completeUpload has committed.
+	// Unlike the compressed path, nothing wraps this in compressStream's
+	// deferred Close, so abort here on failure; Close needs m.uploadID and is
+	// a no-op after commit.
 	m.uploadID = uploadID
 	defer func() {
-		if abortErr := m.Close(); abortErr != nil { //nolint:contextcheck // Close aborts on a detached context by design, so the cleanup still lands when ctx is already canceled.
+		if abortErr := m.Close(); abortErr != nil { //nolint:contextcheck // Close aborts on a detached context by design.
 			logger.L().Warn(ctx, "failed to abort GCS multipart upload",
 				zap.String("bucket", m.bucketName),
 				zap.String("object", m.objectName),

--- a/packages/shared/pkg/storage/gcp_multipart_test.go
+++ b/packages/shared/pkg/storage/gcp_multipart_test.go
@@ -97,8 +97,7 @@ func TestMultipartUploader_PartUploaderContract(t *testing.T) {
 }
 
 // abortRecordingUploader builds a test uploader whose part uploads always
-// fail, so the abort (DELETE ...?uploadId=) issued on the failure path can be
-// observed. Retries are kept negligible so the 500s don't stall the test.
+// fail, recording whether the failure path issued the abort DELETE.
 func abortRecordingUploader(t *testing.T, uploadID string, aborted *atomic.Bool) *MultipartUploader {
 	t.Helper()
 
@@ -119,9 +118,6 @@ func abortRecordingUploader(t *testing.T, uploadID string, aborted *atomic.Bool)
 	}, fastRetryConfig())
 }
 
-// TestGCPCompressedStoreFileAbortsMultipartUploadOnFailure mirrors the AWS
-// test of the same shape: a compressed upload that dies mid-flight must abort
-// the multipart upload instead of orphaning its parts in the bucket.
 func TestGCPCompressedStoreFileAbortsMultipartUploadOnFailure(t *testing.T) {
 	t.Parallel()
 
@@ -135,9 +131,8 @@ func TestGCPCompressedStoreFileAbortsMultipartUploadOnFailure(t *testing.T) {
 	require.True(t, aborted.Load(), "failed compressed upload should abort the multipart upload")
 }
 
-// TestGCPUploadFileInParallelAbortsOnPartFailure covers the uncompressed
-// >=50MB path, which initiates its own upload and has no deferred Close from
-// compressStream: a failed part must still abort the multipart upload.
+// The uncompressed >=50MB path has no deferred Close from compressStream and
+// must abort on its own.
 func TestGCPUploadFileInParallelAbortsOnPartFailure(t *testing.T) {
 	t.Parallel()
 
@@ -1374,9 +1369,7 @@ func TestGCSXMLPartUploaderContract(t *testing.T) {
 		"parts must reassemble in part-number order, not upload order")
 }
 
-// TestGCSXMLPartUploaderAbortOnClose mirrors TestS3PartUploaderAbortOnClose
-// for the XML uploader: Close on an incomplete upload must abort it against a
-// real S3/GCS-XML implementation, leaving no orphaned multipart upload behind.
+// Mirrors TestS3PartUploaderAbortOnClose for the GCS XML uploader.
 func TestGCSXMLPartUploaderAbortOnClose(t *testing.T) {
 	t.Parallel()
 

--- a/packages/shared/pkg/storage/gcp_multipart_test.go
+++ b/packages/shared/pkg/storage/gcp_multipart_test.go
@@ -68,6 +68,7 @@ func TestMultipartUploader_PartUploaderContract(t *testing.T) {
 	t.Parallel()
 
 	testPartUploaderContract(t, partUploaderTestAdapter{
+		abortsOnClose: true,
 		new: func(t *testing.T, recorder *partUploaderRecorder) partUploader {
 			t.Helper()
 
@@ -93,6 +94,60 @@ func TestMultipartUploader_PartUploaderContract(t *testing.T) {
 			})
 		},
 	})
+}
+
+// abortRecordingUploader builds a test uploader whose part uploads always
+// fail, so the abort (DELETE ...?uploadId=) issued on the failure path can be
+// observed. Retries are kept negligible so the 500s don't stall the test.
+func abortRecordingUploader(t *testing.T, uploadID string, aborted *atomic.Bool) *MultipartUploader {
+	t.Helper()
+
+	return createTestMultipartUploader(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.RawQuery == uploadsPath:
+			xmlData, _ := xml.Marshal(InitiateMultipartUploadResult{Bucket: testBucketName, Key: testObjectName, UploadID: uploadID})
+			w.WriteHeader(http.StatusOK)
+			w.Write(xmlData)
+		case r.Method == http.MethodPut && strings.Contains(r.URL.RawQuery, "partNumber="):
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == http.MethodDelete && r.URL.RawQuery == "uploadId="+uploadID:
+			aborted.Store(true)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected GCP multipart request: %s %s", r.Method, r.URL.String())
+		}
+	}, fastRetryConfig())
+}
+
+// TestGCPCompressedStoreFileAbortsMultipartUploadOnFailure mirrors the AWS
+// test of the same shape: a compressed upload that dies mid-flight must abort
+// the multipart upload instead of orphaning its parts in the bucket.
+func TestGCPCompressedStoreFileAbortsMultipartUploadOnFailure(t *testing.T) {
+	t.Parallel()
+
+	inputPath := writeTempFile(t, []byte(strings.Repeat("compressible-data", 1024)))
+	var aborted atomic.Bool
+	uploader := abortRecordingUploader(t, "compressed-abort-upload-id", &aborted)
+
+	_, _, err := storeFileCompressed(t.Context(), inputPath, testCompressConfig(), 4, PutOptions{},
+		func(ObjectMetadata) (partUploader, error) { return uploader, nil })
+	require.Error(t, err)
+	require.True(t, aborted.Load(), "failed compressed upload should abort the multipart upload")
+}
+
+// TestGCPUploadFileInParallelAbortsOnPartFailure covers the uncompressed
+// >=50MB path, which initiates its own upload and has no deferred Close from
+// compressStream: a failed part must still abort the multipart upload.
+func TestGCPUploadFileInParallelAbortsOnPartFailure(t *testing.T) {
+	t.Parallel()
+
+	inputPath := writeTempFile(t, []byte("parallel-upload-that-fails"))
+	var aborted atomic.Bool
+	uploader := abortRecordingUploader(t, "parallel-abort-upload-id", &aborted)
+
+	_, err := uploader.UploadFileInParallel(t.Context(), inputPath, 2, nil)
+	require.Error(t, err)
+	require.True(t, aborted.Load(), "failed parallel upload should abort the multipart upload")
 }
 
 func TestMultipartUploader_InitiateUpload_Success(t *testing.T) {
@@ -1317,6 +1372,28 @@ func TestGCSXMLPartUploaderContract(t *testing.T) {
 	got := anonymousGet(t, backend, key)
 	require.Equal(t, sha256.Sum256(want), sha256.Sum256(got),
 		"parts must reassemble in part-number order, not upload order")
+}
+
+// TestGCSXMLPartUploaderAbortOnClose mirrors TestS3PartUploaderAbortOnClose
+// for the XML uploader: Close on an incomplete upload must abort it against a
+// real S3/GCS-XML implementation, leaving no orphaned multipart upload behind.
+func TestGCSXMLPartUploaderAbortOnClose(t *testing.T) {
+	t.Parallel()
+
+	backend := gcsXMLBackend(t)
+	key := testKey("gcs-part-abort")
+	up := gcsXMLUploader(t, backend, key, nil, nil)
+
+	require.NoError(t, up.Start(t.Context()))
+	require.NoError(t, up.UploadPart(t.Context(), 1, []byte("abandoned-part")))
+	require.NoError(t, up.Close())
+
+	list, err := backend.newClient(t, nil).ListMultipartUploads(t.Context(), &s3.ListMultipartUploadsInput{
+		Bucket: aws.String(backend.bucket),
+		Prefix: aws.String(key),
+	})
+	require.NoError(t, err)
+	require.Empty(t, list.Uploads, "abort must leave no orphaned multipart upload")
 }
 
 // TestGCSXMLCompressedRoundTrip runs the production compressed upload path


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-715/storage-errored-uploads-should-abort

**Broken:** failed GCS multipart uploads never aborted their staged parts — every failed compressed memfile/rootfs upload leaked parts in the bucket indefinitely (billed, never reclaimed). AWS was unaffected (`manager.Uploader` aborts by default; `awsPartUploader.Close` aborts explicitly).

**Root cause:** two GCS-only leaks. (1) `MultipartUploader.Close()` was a literal `return nil` no-op since #2034 — the driver's `defer uploader.Close()` abort hook was wired all along but did nothing for GCS. (2) `UploadFileInParallel` (uncompressed >50 MB path) kept the upload ID local, returned bare on both error paths, and isn't wrapped by the driver's deferred `Close`, so fixing (1) alone wouldn't cover it.

**Fix:** `abortUpload` issues `DELETE ?uploadId=` against the GCS XML API (204 and 404 both success — 404 = already gone); `Close` mirrors `awsPartUploader.Close` (no-op once committed/never started, otherwise abort on a detached context with a 5s deadline, since the caller's context is usually already cancelled); commit flag set in `completeUpload` (single commit point, mutex-guarded) so `Close` can never abort a live object; `UploadFileInParallel` publishes the ID and aborts on the way out; `compress_upload.go` now logs `Close` errors (a failed abort = orphaned upload).

**Repro:** the contract subtest ("close aborts unfinished upload") existed but GCS never set `abortsOnClose`; flipping that flag alone turns it red today. Before the fix, 4 tests fail: the contract subtest, `TestGCPCompressedStoreFileAbortsMultipartUploadOnFailure`, `TestGCPUploadFileInParallelAbortsOnPartFailure`, and a MinIO-backed `TestGCSXMLPartUploaderAbortOnClose` that observes a genuinely orphaned upload.

**Verification:** all four pass after the fix; full `./pkg/storage/...` suite green incl. `-race`; MinIO/testcontainers tests actually ran (none skipped); `go build`, `go vet`, `gofmt` clean; repo-pinned `golangci-lint` v2.11.4 reports 0 issues.

**Not verified:** behaviour against real GCS — abort is validated against MinIO's S3/GCS-XML dialect. GCS documents 204 for the delete; the 404 tolerance is defensive.
