### PR TITLE
fix(envd): report process-start resource exhaustion as resource_exhausted

### DIFF
--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -53,6 +53,12 @@ type Handler struct {
 	cmd *exec.Cmd
 	tty *os.File
 
+	// startCmd forks cmd. Injected for testability so the spawn-failure path can
+	// be exercised without actually exhausting the host; production passes
+	// (*exec.Cmd).Start. Set by New, which is the only constructor whose handler
+	// is ever started — a re-adopted handler has no cmd and never Starts.
+	startCmd func(*exec.Cmd) error
+
 	cancel context.CancelFunc
 
 	outCtx    context.Context //nolint:containedctx // todo: refactor so this can be removed
@@ -275,6 +281,7 @@ func New(
 	h := &Handler{
 		Config:    req.GetProcess(),
 		cmd:       cmd,
+		startCmd:  (*exec.Cmd).Start,
 		Tag:       req.Tag,
 		DataEvent: outMultiplex,
 		cancel:    cancel,
@@ -299,7 +306,9 @@ func New(
 			Rows: uint16(req.GetPty().GetSize().GetRows()),
 		})
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("error starting pty with command '%s' in dir '%s' with '%d' cols and '%d' rows: %w", userCmd, cmd.Dir, req.GetPty().GetSize().GetCols(), req.GetPty().GetSize().GetRows(), err))
+			startErr := fmt.Errorf("error starting pty with command '%s' in dir '%s' with '%d' cols and '%d' rows: %w", userCmd, cmd.Dir, req.GetPty().GetSize().GetCols(), req.GetPty().GetSize().GetRows(), err)
+
+			return nil, connect.NewError(StartErrorCode(startErr), startErr)
 		}
 
 		outWg.Go(func() {
@@ -547,7 +556,7 @@ func (p *Handler) WriteTty(data []byte) error {
 func (p *Handler) Start(requestTimeout time.Duration) (uint32, error) {
 	// Pty is already started in the New method
 	if p.tty == nil {
-		err := p.cmd.Start()
+		err := p.startCmd(p.cmd)
 		if err != nil {
 			return 0, fmt.Errorf("error starting process '%s': %w", p.userCommand(), err)
 		}

--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -53,10 +53,8 @@ type Handler struct {
 	cmd *exec.Cmd
 	tty *os.File
 
-	// startCmd forks cmd. Injected for testability so the spawn-failure path can
-	// be exercised without actually exhausting the host; production passes
-	// (*exec.Cmd).Start. Set by New, which is the only constructor whose handler
-	// is ever started — a re-adopted handler has no cmd and never Starts.
+	// startCmd is (*exec.Cmd).Start in production; injected so tests can exercise
+	// spawn failures. Only New sets it — re-adopted handlers have no cmd and never Start.
 	startCmd func(*exec.Cmd) error
 
 	cancel context.CancelFunc

--- a/packages/envd/internal/services/process/handler/start_error.go
+++ b/packages/envd/internal/services/process/handler/start_error.go
@@ -8,38 +8,22 @@ import (
 	"connectrpc.com/connect"
 )
 
-// StartErrorCode maps a failure to spawn a process to the Connect code the
-// client should see.
-//
-// A spawn fails for two fundamentally different reasons and they must not
-// share a code. A malformed request — unknown binary, non-existent cwd — is
-// the caller's fault and is permanent: the identical request will never
-// succeed, so CodeInvalidArgument is correct. Running out of process capacity
-// is neither. fork/exec returns EAGAIN once the sandbox reaches RLIMIT_NPROC,
-// its cgroup pids.max or the kernel's pid_max, and the very same request
-// succeeds again as soon as any process in the sandbox exits. Reporting that
-// as CodeInvalidArgument tells every SDK the request was bad and must not be
-// retried, which is both wrong and undebuggable: the user sees a permanent
-// "bad request" for a command that is perfectly valid. CodeResourceExhausted
-// names what actually happened and is the code SDK retry policies key on.
-//
-// The default stays CodeInvalidArgument, so behaviour is unchanged for every
-// failure that is not resource exhaustion or a spent request context.
+// StartErrorCode maps a spawn failure to the Connect code the client should
+// see. Resource exhaustion is transient and retryable, so it maps to
+// CodeResourceExhausted — the code SDK retry policies key on — never
+// CodeInvalidArgument, which marks the request permanently bad. Anything
+// unrecognized stays CodeInvalidArgument.
 func StartErrorCode(err error) connect.Code {
 	switch {
-	// EAGAIN: fork(2) hit RLIMIT_NPROC, the cgroup's pids.max or pid_max.
-	// ENOMEM: the kernel could not allocate the new task.
-	// EMFILE/ENFILE: the per-process or system-wide fd limit was reached while
-	// setting up the child's pipes or opening /dev/ptmx.
-	// ENOSPC: /dev/ptmx is out of pseudoterminals (kernel.pty.max).
+	// EAGAIN: fork hit RLIMIT_NPROC / pids.max; EMFILE/ENFILE: fd limits while
+	// wiring the child's pipes; ENOSPC: out of ptys (/dev/ptmx, kernel.pty.max).
 	case errors.Is(err, syscall.EAGAIN),
 		errors.Is(err, syscall.ENOMEM),
 		errors.Is(err, syscall.EMFILE),
 		errors.Is(err, syscall.ENFILE),
 		errors.Is(err, syscall.ENOSPC):
 		return connect.CodeResourceExhausted
-	// exec.CommandContext fails the spawn with the context's error when the
-	// request timeout expires before the fork happens.
+	// exec.CommandContext fails the spawn with the context's error if the request timed out pre-fork.
 	case errors.Is(err, context.DeadlineExceeded):
 		return connect.CodeDeadlineExceeded
 	case errors.Is(err, context.Canceled):

--- a/packages/envd/internal/services/process/handler/start_error.go
+++ b/packages/envd/internal/services/process/handler/start_error.go
@@ -1,0 +1,50 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"syscall"
+
+	"connectrpc.com/connect"
+)
+
+// StartErrorCode maps a failure to spawn a process to the Connect code the
+// client should see.
+//
+// A spawn fails for two fundamentally different reasons and they must not
+// share a code. A malformed request — unknown binary, non-existent cwd — is
+// the caller's fault and is permanent: the identical request will never
+// succeed, so CodeInvalidArgument is correct. Running out of process capacity
+// is neither. fork/exec returns EAGAIN once the sandbox reaches RLIMIT_NPROC,
+// its cgroup pids.max or the kernel's pid_max, and the very same request
+// succeeds again as soon as any process in the sandbox exits. Reporting that
+// as CodeInvalidArgument tells every SDK the request was bad and must not be
+// retried, which is both wrong and undebuggable: the user sees a permanent
+// "bad request" for a command that is perfectly valid. CodeResourceExhausted
+// names what actually happened and is the code SDK retry policies key on.
+//
+// The default stays CodeInvalidArgument, so behaviour is unchanged for every
+// failure that is not resource exhaustion or a spent request context.
+func StartErrorCode(err error) connect.Code {
+	switch {
+	// EAGAIN: fork(2) hit RLIMIT_NPROC, the cgroup's pids.max or pid_max.
+	// ENOMEM: the kernel could not allocate the new task.
+	// EMFILE/ENFILE: the per-process or system-wide fd limit was reached while
+	// setting up the child's pipes or opening /dev/ptmx.
+	// ENOSPC: /dev/ptmx is out of pseudoterminals (kernel.pty.max).
+	case errors.Is(err, syscall.EAGAIN),
+		errors.Is(err, syscall.ENOMEM),
+		errors.Is(err, syscall.EMFILE),
+		errors.Is(err, syscall.ENFILE),
+		errors.Is(err, syscall.ENOSPC):
+		return connect.CodeResourceExhausted
+	// exec.CommandContext fails the spawn with the context's error when the
+	// request timeout expires before the fork happens.
+	case errors.Is(err, context.DeadlineExceeded):
+		return connect.CodeDeadlineExceeded
+	case errors.Is(err, context.Canceled):
+		return connect.CodeCanceled
+	default:
+		return connect.CodeInvalidArgument
+	}
+}

--- a/packages/envd/internal/services/process/handler/start_error_test.go
+++ b/packages/envd/internal/services/process/handler/start_error_test.go
@@ -1,0 +1,161 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rpc "github.com/e2b-dev/infra/packages/envd/internal/services/spec/process"
+)
+
+// eagainStartError is shaped exactly like the error a real spawn failure
+// produces: os/exec returns *fs.PathError{Op: "fork/exec"} carrying the errno,
+// and Handler.Start wraps it with %w.
+func eagainStartError() error {
+	return fmt.Errorf("error starting process '%s': %w", "sleep 1", &fs.PathError{Op: "fork/exec", Path: "/bin/sh", Err: syscall.EAGAIN})
+}
+
+// A sandbox that runs out of process capacity must not be told its request was
+// invalid — EAGAIN is transient and retryable, so it maps to
+// CodeResourceExhausted. Everything that is genuinely the caller's fault keeps
+// mapping to CodeInvalidArgument.
+func TestStartErrorCode(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		err  error
+		name string
+		want connect.Code
+	}{
+		{
+			name: "fork/exec EAGAIN is resource exhaustion",
+			err:  eagainStartError(),
+			want: connect.CodeResourceExhausted,
+		},
+		{
+			name: "pty spawn EAGAIN is resource exhaustion",
+			err:  fmt.Errorf("error starting pty with command '%s' in dir '%s' with '%d' cols and '%d' rows: %w", "sleep 1", "/home/user", 80, 24, &fs.PathError{Op: "fork/exec", Path: "/bin/sh", Err: syscall.EAGAIN}),
+			want: connect.CodeResourceExhausted,
+		},
+		{
+			name: "bare EAGAIN is resource exhaustion",
+			err:  syscall.EAGAIN,
+			want: connect.CodeResourceExhausted,
+		},
+		{
+			name: "ENOMEM is resource exhaustion",
+			err:  fmt.Errorf("wrapped: %w", syscall.ENOMEM),
+			want: connect.CodeResourceExhausted,
+		},
+		{
+			name: "EMFILE is resource exhaustion",
+			err:  fmt.Errorf("wrapped: %w", syscall.EMFILE),
+			want: connect.CodeResourceExhausted,
+		},
+		{
+			name: "ENFILE is resource exhaustion",
+			err:  fmt.Errorf("wrapped: %w", syscall.ENFILE),
+			want: connect.CodeResourceExhausted,
+		},
+		{
+			name: "out of ptys is resource exhaustion",
+			err:  fmt.Errorf("error starting pty: %w", &fs.PathError{Op: "open", Path: "/dev/ptmx", Err: syscall.ENOSPC}),
+			want: connect.CodeResourceExhausted,
+		},
+		{
+			name: "expired request timeout is a deadline",
+			err:  fmt.Errorf("error starting process '%s': %w", "sleep 1", context.DeadlineExceeded),
+			want: connect.CodeDeadlineExceeded,
+		},
+		{
+			name: "cancelled request is a cancellation",
+			err:  fmt.Errorf("error starting process '%s': %w", "sleep 1", context.Canceled),
+			want: connect.CodeCanceled,
+		},
+		// Regression guards: the fix must not reclassify anything that is
+		// genuinely a bad request.
+		{
+			name: "missing binary stays invalid argument",
+			err:  fmt.Errorf("error starting process '%s': %w", "nope", &exec.Error{Name: "nope", Err: exec.ErrNotFound}),
+			want: connect.CodeInvalidArgument,
+		},
+		{
+			name: "missing cwd stays invalid argument",
+			err:  fmt.Errorf("error starting process '%s': %w", "sleep 1", &fs.PathError{Op: "chdir", Path: "/nope", Err: syscall.ENOENT}),
+			want: connect.CodeInvalidArgument,
+		},
+		{
+			name: "permission denied stays invalid argument",
+			err:  fmt.Errorf("error starting process '%s': %w", "sleep 1", &fs.PathError{Op: "fork/exec", Path: "/bin/sh", Err: syscall.EACCES}),
+			want: connect.CodeInvalidArgument,
+		},
+		{
+			name: "opaque error stays invalid argument",
+			err:  errors.New("something went wrong"),
+			want: connect.CodeInvalidArgument,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := StartErrorCode(tc.err)
+			assert.Equalf(t, tc.want, got, "got %s, want %s", got, tc.want)
+		})
+	}
+}
+
+// What the SDK client actually observes on the wire is the code carried by the
+// *connect.Error, so assert on that rather than on the classifier alone.
+func TestStartErrorClientObservedCode(t *testing.T) {
+	t.Parallel()
+
+	exhausted := eagainStartError()
+	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(connect.NewError(StartErrorCode(exhausted), exhausted)))
+
+	badRequest := fmt.Errorf("error starting process '%s': %w", "nope", &exec.Error{Name: "nope", Err: exec.ErrNotFound})
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(connect.NewError(StartErrorCode(badRequest), badRequest)))
+}
+
+// Handler.Start must wrap the spawn failure so the errno survives to the
+// classifier — a %v instead of %w here would silently turn every exhausted
+// sandbox back into an invalid_argument.
+func TestHandlerStartPreservesErrno(t *testing.T) {
+	t.Parallel()
+
+	newHandler := func(t *testing.T, startErr error) *Handler {
+		t.Helper()
+
+		return &Handler{
+			Config:   &rpc.ProcessConfig{Cmd: "sleep", Args: []string{"200"}},
+			cmd:      exec.CommandContext(t.Context(), "/bin/sh", "-c", "sleep 200"),
+			startCmd: func(*exec.Cmd) error { return startErr },
+		}
+	}
+
+	t.Run("EAGAIN surfaces as resource exhausted", func(t *testing.T) {
+		t.Parallel()
+
+		pid, err := newHandler(t, &fs.PathError{Op: "fork/exec", Path: "/bin/sh", Err: syscall.EAGAIN}).Start(0)
+		require.ErrorIs(t, err, syscall.EAGAIN)
+		assert.Zero(t, pid)
+		assert.Contains(t, err.Error(), "sleep 200")
+		assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(connect.NewError(StartErrorCode(err), err)))
+	})
+
+	t.Run("missing binary stays invalid argument", func(t *testing.T) {
+		t.Parallel()
+
+		pid, err := newHandler(t, &exec.Error{Name: "nope", Err: exec.ErrNotFound}).Start(0)
+		require.Error(t, err)
+		assert.Zero(t, pid)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(connect.NewError(StartErrorCode(err), err)))
+	})
+}

--- a/packages/envd/internal/services/process/handler/start_error_test.go
+++ b/packages/envd/internal/services/process/handler/start_error_test.go
@@ -16,17 +16,12 @@ import (
 	rpc "github.com/e2b-dev/infra/packages/envd/internal/services/spec/process"
 )
 
-// eagainStartError is shaped exactly like the error a real spawn failure
-// produces: os/exec returns *fs.PathError{Op: "fork/exec"} carrying the errno,
-// and Handler.Start wraps it with %w.
+// eagainStartError mirrors a real spawn failure: os/exec returns
+// *fs.PathError{Op: "fork/exec"} carrying the errno, wrapped with %w by Handler.Start.
 func eagainStartError() error {
 	return fmt.Errorf("error starting process '%s': %w", "sleep 1", &fs.PathError{Op: "fork/exec", Path: "/bin/sh", Err: syscall.EAGAIN})
 }
 
-// A sandbox that runs out of process capacity must not be told its request was
-// invalid — EAGAIN is transient and retryable, so it maps to
-// CodeResourceExhausted. Everything that is genuinely the caller's fault keeps
-// mapping to CodeInvalidArgument.
 func TestStartErrorCode(t *testing.T) {
 	t.Parallel()
 
@@ -80,8 +75,6 @@ func TestStartErrorCode(t *testing.T) {
 			err:  fmt.Errorf("error starting process '%s': %w", "sleep 1", context.Canceled),
 			want: connect.CodeCanceled,
 		},
-		// Regression guards: the fix must not reclassify anything that is
-		// genuinely a bad request.
 		{
 			name: "missing binary stays invalid argument",
 			err:  fmt.Errorf("error starting process '%s': %w", "nope", &exec.Error{Name: "nope", Err: exec.ErrNotFound}),
@@ -112,8 +105,7 @@ func TestStartErrorCode(t *testing.T) {
 	}
 }
 
-// What the SDK client actually observes on the wire is the code carried by the
-// *connect.Error, so assert on that rather than on the classifier alone.
+// Asserts on the code carried by *connect.Error — what the client observes on the wire.
 func TestStartErrorClientObservedCode(t *testing.T) {
 	t.Parallel()
 
@@ -124,9 +116,8 @@ func TestStartErrorClientObservedCode(t *testing.T) {
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(connect.NewError(StartErrorCode(badRequest), badRequest)))
 }
 
-// Handler.Start must wrap the spawn failure so the errno survives to the
-// classifier — a %v instead of %w here would silently turn every exhausted
-// sandbox back into an invalid_argument.
+// Handler.Start must wrap the spawn failure with %w — %v would silently turn
+// every exhausted sandbox back into invalid_argument.
 func TestHandlerStartPreservesErrno(t *testing.T) {
 	t.Parallel()
 

--- a/packages/envd/internal/services/process/start.go
+++ b/packages/envd/internal/services/process/start.go
@@ -174,7 +174,7 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 	if err != nil {
 		s.snapshotMu.RUnlock()
 
-		return connect.NewError(connect.CodeInvalidArgument, err)
+		return connect.NewError(handler.StartErrorCode(err), err)
 	}
 
 	// Drop any retained exit left over from a previous process that used this


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-833/eagain-on-process-start-in-envd-returns-invalid-argument-to-client

**Broken:** spawn failures from resource exhaustion reach SDK clients as `invalid_argument` (permanent, never-retry) — per the issue, 10 000 background `sleep`s in one sandbox start returning "invalid argument" once `fork(2)` hits EAGAIN (`RLIMIT_NPROC` / cgroup `pids.max` / `pid_max`), though the identical request succeeds as soon as any process exits.

**Root cause:** both spawn sites hardcode `connect.CodeInvalidArgument` for every failure — `start.go` around `cmd.Start()` (non-PTY) and `handler.go` around `pty.StartWithSize` (PTY); envd has no central error mapper, so the errno never reaches the client.

**Fix:** pure classifier `StartErrorCode` used at both sites: EAGAIN/ENOMEM/EMFILE/ENFILE → `resource_exhausted`, plus ENOSPC (what `open("/dev/ptmx")` returns when `kernel.pty.max` is exhausted); a request context already spent at spawn → `deadline_exceeded`/`canceled` (deliberate behaviour change beyond EAGAIN — flag it if you'd rather I narrow the diff); everything else stays `invalid_argument` (unknown binary, bad cwd unaffected). `Handler.startCmd` is injected like the existing `lookPath` (struct field, `t.Parallel()`-safe); `Readopt` leaves it nil — safe, a readopted handler has `cmd == nil` and is never Started.

**Repro:** error shape confirmed on a real kernel — as uid 1000 with `RLIMIT_NPROC=1` (root is exempt), `cmd.Start()` returns `*fs.PathError{Op:"fork/exec", Err: EAGAIN}`, `errors.Is(err, EAGAIN)` = true.

**Verification:** new `start_error_test.go` — 13-case table over realistically wrapped errors (incl. the verbatim PTY wrap string), client-observed `connect.CodeOf` assertions, and real `Handler.Start` through the stubbed seam guarding the `%w` wrap. Reverting only the classifier body: 11 genuine failures while all four `invalid_argument` regression guards still pass. Full `./internal/services/process/...` suite green incl. `-race`, and as root in a Linux container with zero skips; `go build`/`go vet`/`gofmt` clean on darwin and `GOOS=linux`; `golangci-lint` v2.11.4 with `GOOS=linux` (what CI runs) reports 0 issues.

**Not verified:** no end-to-end RPC assertion that a real sandbox exhaustion returns `resource_exhausted` over the wire (needs root; forcing real EAGAIN breaks the harness) — the chain is covered in overlapping pieces instead; the single line in `start.go` is verified by reading; the PTY site is covered via the classifier's exact wrap string, not by driving `pty.StartWithSize` to failure.
