### PR TITLE
fix(orchestrator): stop retrying an unsupported memory.peak reset every second

### DIFF
--- a/packages/clickhouse/pkg/hoststats/hoststats.go
+++ b/packages/clickhouse/pkg/hoststats/hoststats.go
@@ -27,7 +27,7 @@ type SandboxHostStat struct {
 	CgroupCPUUserUsec   uint64 `ch:"cgroup_cpu_user_usec"`      // cumulative, microseconds
 	CgroupCPUSystemUsec uint64 `ch:"cgroup_cpu_system_usec"`    // cumulative, microseconds
 	CgroupMemoryUsage   uint64 `ch:"cgroup_memory_usage_bytes"` // current, bytes
-	CgroupMemoryPeak    uint64 `ch:"cgroup_memory_peak_bytes"`  // interval peak, bytes (reset after each sample)
+	CgroupMemoryPeak    uint64 `ch:"cgroup_memory_peak_bytes"`  // interval peak, bytes; the sandbox lifetime peak on hosts whose kernel cannot reset memory.peak (Linux < 6.12)
 
 	// Pre-computed deltas between consecutive samples.
 	DeltaCgroupCPUUsageUsec  uint64 `ch:"delta_cgroup_cpu_usage_usec"`

--- a/packages/orchestrator/pkg/sandbox/cgroup/manager.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/manager.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
+	"syscall"
 	"time"
 
 	"go.uber.org/zap"
@@ -33,6 +35,24 @@ const (
 	cgroupKillPollInterval = 100 * time.Millisecond
 )
 
+// memoryPeakResetUnsupported latches once the kernel has rejected a memory.peak
+// reset write. Resetting the per-FD peak by writing to memory.peak requires
+// Linux 6.12+; older kernels register no write handler for that file and fail
+// every write with EINVAL. The property is per-kernel, so a single failure
+// proves it for every sandbox on this host — latch it, log once, and stop
+// attempting the write instead of spamming one warning per sandbox per sample.
+var memoryPeakResetUnsupported atomic.Bool
+
+// writeMemoryPeakReset performs the actual reset write. It is a package-level
+// variable so tests can inject failures without a real cgroup filesystem
+// (a regular file happily accepts the write, and an O_RDONLY file returns
+// EBADF rather than the EINVAL a pre-6.12 kernel returns).
+var writeMemoryPeakReset = func(memoryPeakFile *os.File) error {
+	_, err := memoryPeakFile.WriteString("0")
+
+	return err
+}
+
 // Stats contains resource usage statistics from a cgroup
 type Stats struct {
 	CPUUsageUsec  uint64 // microseconds
@@ -40,7 +60,10 @@ type Stats struct {
 	CPUSystemUsec uint64 // microseconds
 
 	MemoryUsageBytes uint64 // bytes
-	MemoryPeakBytes  uint64 // bytes, reset after each GetStats() call
+	// MemoryPeakBytes is the peak since the previous GetStats() call. On
+	// kernels without memory.peak reset support (Linux < 6.12) the reset is
+	// not possible, and this degrades to the lifetime peak of the cgroup.
+	MemoryPeakBytes uint64 // bytes
 }
 
 // CgroupHandle represents a created cgroup for a sandbox.
@@ -391,7 +414,10 @@ func (m *managerImpl) Create(ctx context.Context, cgroupName string) (*CgroupHan
 		return nil, fmt.Errorf("failed to open cgroup directory: %w", err)
 	}
 
-	// O_RDWR FD must stay open for per-FD peak reset across GetStats() calls
+	// O_RDWR FD must stay open for per-FD peak reset across GetStats() calls.
+	// A successful open says nothing about reset support: pre-6.12 kernels
+	// expose memory.peak as 0444, but CAP_DAC_OVERRIDE lets root open it O_RDWR
+	// anyway, and only the write itself then fails. See resetMemoryPeak.
 	memPeakPath := filepath.Join(cgroupPath, "memory.peak")
 	memoryPeakFile, peakErr := os.OpenFile(memPeakPath, os.O_RDWR, 0)
 	if peakErr != nil {
@@ -415,7 +441,7 @@ func (m *managerImpl) Create(ctx context.Context, cgroupName string) (*CgroupHan
 		zap.String("cgroup_name", cgroupName),
 		zap.String("path", cgroupPath),
 		zap.Int("fd", handle.GetFD()),
-		zap.Bool("peak_reset_available", memoryPeakFile != nil))
+		zap.Bool("memory_peak_open", memoryPeakFile != nil))
 
 	return handle, nil
 }
@@ -511,6 +537,7 @@ func (m *managerImpl) getStatsForPath(ctx context.Context, cgroupPath string, me
 //   - Read requires file position 0 (seq_file), so we seek before reading.
 //   - Write resets the per-FD peak to current memory usage. The kernel ignores
 //     both the written content and the file offset, so no seek before write is needed.
+//     The write handler only exists on Linux 6.12+ — see resetMemoryPeak.
 func (m *managerImpl) readAndResetMemoryPeak(ctx context.Context, memoryPeakFile *os.File) (uint64, error) {
 	if _, err := memoryPeakFile.Seek(0, io.SeekStart); err != nil {
 		return 0, fmt.Errorf("failed to seek memory.peak for read: %w", err)
@@ -527,12 +554,47 @@ func (m *managerImpl) readAndResetMemoryPeak(ctx context.Context, memoryPeakFile
 		return 0, fmt.Errorf("failed to parse memory.peak value %q: %w", strings.TrimSpace(string(buf[:n])), parseErr)
 	}
 
-	// Reset per-FD peak for next interval
-	if _, err := memoryPeakFile.WriteString("0"); err != nil {
-		logger.L().Warn(ctx, "failed to reset memory.peak, interval peak semantics degraded", zap.Error(err))
-	}
+	resetMemoryPeak(ctx, memoryPeakFile)
 
 	return peakBytes, nil
+}
+
+// resetMemoryPeak resets the per-FD peak so the next read reports the peak of
+// the next interval only. A failure is never fatal: the peak that was already
+// read stays valid, it just widens to cover more than one interval.
+//
+// Kernels older than 6.12 have no write handler for memory.peak and reject
+// every write with EINVAL. That is a permanent property of the running kernel,
+// so the first such failure latches memoryPeakResetUnsupported: it is logged
+// once and no further write is attempted for the lifetime of the process.
+// Any other error is treated as transient and retried on the next sample.
+func resetMemoryPeak(ctx context.Context, memoryPeakFile *os.File) {
+	if memoryPeakResetUnsupported.Load() {
+		return
+	}
+
+	err := writeMemoryPeakReset(memoryPeakFile)
+	if err == nil {
+		return
+	}
+
+	if !peakResetUnsupported(err) {
+		logger.L().Warn(ctx, "failed to reset memory.peak, interval peak semantics degraded", zap.Error(err))
+
+		return
+	}
+
+	if memoryPeakResetUnsupported.CompareAndSwap(false, true) {
+		logger.L().Warn(ctx, "memory.peak reset unsupported (requires kernel 6.12+); reporting lifetime peak instead of interval peak", zap.Error(err))
+	}
+}
+
+// peakResetUnsupported reports whether err means the kernel does not implement
+// the memory.peak reset write at all, as opposed to a transient write failure.
+func peakResetUnsupported(err error) bool {
+	return errors.Is(err, syscall.EINVAL) ||
+		errors.Is(err, syscall.ENOTSUP) ||
+		errors.Is(err, syscall.EOPNOTSUPP)
 }
 
 // cgroupPath returns the filesystem path for a sandbox's cgroup

--- a/packages/orchestrator/pkg/sandbox/cgroup/manager.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/manager.go
@@ -35,18 +35,13 @@ const (
 	cgroupKillPollInterval = 100 * time.Millisecond
 )
 
-// memoryPeakResetUnsupported latches once the kernel has rejected a memory.peak
-// reset write. Resetting the per-FD peak by writing to memory.peak requires
-// Linux 6.12+; older kernels register no write handler for that file and fail
-// every write with EINVAL. The property is per-kernel, so a single failure
-// proves it for every sandbox on this host — latch it, log once, and stop
-// attempting the write instead of spamming one warning per sandbox per sample.
+// memoryPeakResetUnsupported latches once the kernel rejects a memory.peak
+// reset write: reset support is per-kernel (Linux 6.12+), so one failure
+// proves it for every sandbox on this host. See resetMemoryPeak.
 var memoryPeakResetUnsupported atomic.Bool
 
-// writeMemoryPeakReset performs the actual reset write. It is a package-level
-// variable so tests can inject failures without a real cgroup filesystem
-// (a regular file happily accepts the write, and an O_RDONLY file returns
-// EBADF rather than the EINVAL a pre-6.12 kernel returns).
+// writeMemoryPeakReset is injectable for tests: a regular file accepts the
+// write, so a pre-6.12 kernel's EINVAL cannot be provoked without a real cgroup.
 var writeMemoryPeakReset = func(memoryPeakFile *os.File) error {
 	_, err := memoryPeakFile.WriteString("0")
 
@@ -60,9 +55,8 @@ type Stats struct {
 	CPUSystemUsec uint64 // microseconds
 
 	MemoryUsageBytes uint64 // bytes
-	// MemoryPeakBytes is the peak since the previous GetStats() call. On
-	// kernels without memory.peak reset support (Linux < 6.12) the reset is
-	// not possible, and this degrades to the lifetime peak of the cgroup.
+	// MemoryPeakBytes is the peak since the previous GetStats() call — or the
+	// cgroup's lifetime peak on kernels without memory.peak reset (Linux < 6.12).
 	MemoryPeakBytes uint64 // bytes
 }
 
@@ -537,7 +531,6 @@ func (m *managerImpl) getStatsForPath(ctx context.Context, cgroupPath string, me
 //   - Read requires file position 0 (seq_file), so we seek before reading.
 //   - Write resets the per-FD peak to current memory usage. The kernel ignores
 //     both the written content and the file offset, so no seek before write is needed.
-//     The write handler only exists on Linux 6.12+ — see resetMemoryPeak.
 func (m *managerImpl) readAndResetMemoryPeak(ctx context.Context, memoryPeakFile *os.File) (uint64, error) {
 	if _, err := memoryPeakFile.Seek(0, io.SeekStart); err != nil {
 		return 0, fmt.Errorf("failed to seek memory.peak for read: %w", err)
@@ -559,15 +552,12 @@ func (m *managerImpl) readAndResetMemoryPeak(ctx context.Context, memoryPeakFile
 	return peakBytes, nil
 }
 
-// resetMemoryPeak resets the per-FD peak so the next read reports the peak of
-// the next interval only. A failure is never fatal: the peak that was already
-// read stays valid, it just widens to cover more than one interval.
-//
-// Kernels older than 6.12 have no write handler for memory.peak and reject
-// every write with EINVAL. That is a permanent property of the running kernel,
-// so the first such failure latches memoryPeakResetUnsupported: it is logged
-// once and no further write is attempted for the lifetime of the process.
-// Any other error is treated as transient and retried on the next sample.
+// resetMemoryPeak resets the per-FD peak so the next read covers one interval.
+// Failure is never fatal — the peak already read stays valid, just widens to
+// span more than one interval. Pre-6.12 kernels have no memory.peak write
+// handler and fail every write with EINVAL; that is permanent, so the first
+// such failure latches memoryPeakResetUnsupported (logged once, never
+// retried). Other errors are transient and retried on the next sample.
 func resetMemoryPeak(ctx context.Context, memoryPeakFile *os.File) {
 	if memoryPeakResetUnsupported.Load() {
 		return

--- a/packages/orchestrator/pkg/sandbox/cgroup/peak_reset_test.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/peak_reset_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
-// Values written into the fake cgroup files and expected back out of them.
 const (
 	fakeCPUUsageUsec  uint64 = 123456789
 	fakeCPUUserUsec   uint64 = 100000000
@@ -28,16 +27,14 @@ const (
 	fakeMemoryPeak    uint64 = 805306368
 )
 
-// peakWriteError builds the error shape the kernel produces for the reset
-// write, i.e. what os.File.WriteString returns: the errno wrapped in a
-// *os.PathError ("write /sys/fs/cgroup/e2b/sbx-x/memory.peak: invalid argument").
+// peakWriteError wraps errno the way os.File.WriteString does — inside a
+// *os.PathError — so tests exercise the errors.Is unwrap.
 func peakWriteError(errno syscall.Errno) error {
 	return &os.PathError{Op: "write", Path: "/sys/fs/cgroup/e2b/sbx-test/memory.peak", Err: errno}
 }
 
-// stubPeakReset replaces the memory.peak reset write with a stub returning
-// writeErr and returns its call counter. The process-wide latch is cleared
-// before the test and restored afterwards, since it outlives any single test.
+// stubPeakReset stubs the reset write; the process-wide latch outlives any
+// single test, so it is cleared before and after.
 func stubPeakReset(t *testing.T, writeErr error) *atomic.Int64 {
 	t.Helper()
 
@@ -59,8 +56,6 @@ func stubPeakReset(t *testing.T, writeErr error) *atomic.Int64 {
 	return calls
 }
 
-// observeWarnings swaps the global logger for an in-memory one so the number
-// of emitted warnings can be asserted.
 func observeWarnings(t *testing.T) *observer.ObservedLogs {
 	t.Helper()
 
@@ -70,8 +65,6 @@ func observeWarnings(t *testing.T) *observer.ObservedLogs {
 	return logs
 }
 
-// fakeCgroupDir builds a directory holding the cgroup v2 files getStatsForPath
-// reads and returns its path plus an open memory.peak FD.
 func fakeCgroupDir(t *testing.T) (string, *os.File) {
 	t.Helper()
 
@@ -103,11 +96,6 @@ func assertParsedStats(t *testing.T, stats *Stats) {
 	assert.Equal(t, fakeMemoryPeak, stats.MemoryPeakBytes, "the peak read must be reported regardless of reset support")
 }
 
-// Kernels older than 6.12 have no write handler for memory.peak and reject
-// every reset with EINVAL. The first failure must latch so the warning is
-// emitted once per process and the doomed write is never retried — instead of
-// once per sandbox per sample, forever.
-//
 //nolint:paralleltest // mutates the process-wide reset latch and the global logger
 func TestGetStatsPeakResetUnsupportedLatchesAfterOneWarning(t *testing.T) {
 	calls := stubPeakReset(t, peakWriteError(syscall.EINVAL))
@@ -129,8 +117,7 @@ func TestGetStatsPeakResetUnsupportedLatchesAfterOneWarning(t *testing.T) {
 	require.Len(t, warnings, 1, "unsupported reset must be logged exactly once per process")
 	assert.Contains(t, warnings[0].Message, "kernel 6.12+")
 
-	// The latch is a property of the kernel, so it must hold for every other
-	// sandbox on this host too, not just the FD that discovered it.
+	// The latch is per-kernel, so it must hold for a second sandbox's FD too.
 	otherPath, otherPeakFile := fakeCgroupDir(t)
 	stats, err := mgr.getStatsForPath(t.Context(), otherPath, otherPeakFile)
 	require.NoError(t, err)

--- a/packages/orchestrator/pkg/sandbox/cgroup/peak_reset_test.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/peak_reset_test.go
@@ -1,0 +1,233 @@
+//go:build linux
+
+package cgroup
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+)
+
+// Values written into the fake cgroup files and expected back out of them.
+const (
+	fakeCPUUsageUsec  uint64 = 123456789
+	fakeCPUUserUsec   uint64 = 100000000
+	fakeCPUSystemUsec uint64 = 23456789
+	fakeMemoryCurrent uint64 = 536870912
+	fakeMemoryPeak    uint64 = 805306368
+)
+
+// peakWriteError builds the error shape the kernel produces for the reset
+// write, i.e. what os.File.WriteString returns: the errno wrapped in a
+// *os.PathError ("write /sys/fs/cgroup/e2b/sbx-x/memory.peak: invalid argument").
+func peakWriteError(errno syscall.Errno) error {
+	return &os.PathError{Op: "write", Path: "/sys/fs/cgroup/e2b/sbx-test/memory.peak", Err: errno}
+}
+
+// stubPeakReset replaces the memory.peak reset write with a stub returning
+// writeErr and returns its call counter. The process-wide latch is cleared
+// before the test and restored afterwards, since it outlives any single test.
+func stubPeakReset(t *testing.T, writeErr error) *atomic.Int64 {
+	t.Helper()
+
+	calls := &atomic.Int64{}
+
+	original := writeMemoryPeakReset
+	memoryPeakResetUnsupported.Store(false)
+	writeMemoryPeakReset = func(*os.File) error {
+		calls.Add(1)
+
+		return writeErr
+	}
+
+	t.Cleanup(func() {
+		writeMemoryPeakReset = original
+		memoryPeakResetUnsupported.Store(false)
+	})
+
+	return calls
+}
+
+// observeWarnings swaps the global logger for an in-memory one so the number
+// of emitted warnings can be asserted.
+func observeWarnings(t *testing.T) *observer.ObservedLogs {
+	t.Helper()
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	t.Cleanup(logger.ReplaceGlobals(t.Context(), logger.NewTracedLoggerFromCore(core)))
+
+	return logs
+}
+
+// fakeCgroupDir builds a directory holding the cgroup v2 files getStatsForPath
+// reads and returns its path plus an open memory.peak FD.
+func fakeCgroupDir(t *testing.T) (string, *os.File) {
+	t.Helper()
+
+	cgroupPath := t.TempDir()
+
+	for name, content := range map[string]string{
+		"cpu.stat":       fmt.Sprintf("usage_usec %d\nuser_usec %d\nsystem_usec %d\n", fakeCPUUsageUsec, fakeCPUUserUsec, fakeCPUSystemUsec),
+		"memory.current": fmt.Sprintf("%d\n", fakeMemoryCurrent),
+		"memory.peak":    fmt.Sprintf("%d\n", fakeMemoryPeak),
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(cgroupPath, name), []byte(content), 0o644))
+	}
+
+	memoryPeakFile, err := os.OpenFile(filepath.Join(cgroupPath, "memory.peak"), os.O_RDWR, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = memoryPeakFile.Close() })
+
+	return cgroupPath, memoryPeakFile
+}
+
+func assertParsedStats(t *testing.T, stats *Stats) {
+	t.Helper()
+
+	require.NotNil(t, stats)
+	assert.Equal(t, fakeCPUUsageUsec, stats.CPUUsageUsec)
+	assert.Equal(t, fakeCPUUserUsec, stats.CPUUserUsec)
+	assert.Equal(t, fakeCPUSystemUsec, stats.CPUSystemUsec)
+	assert.Equal(t, fakeMemoryCurrent, stats.MemoryUsageBytes)
+	assert.Equal(t, fakeMemoryPeak, stats.MemoryPeakBytes, "the peak read must be reported regardless of reset support")
+}
+
+// Kernels older than 6.12 have no write handler for memory.peak and reject
+// every reset with EINVAL. The first failure must latch so the warning is
+// emitted once per process and the doomed write is never retried — instead of
+// once per sandbox per sample, forever.
+//
+//nolint:paralleltest // mutates the process-wide reset latch and the global logger
+func TestGetStatsPeakResetUnsupportedLatchesAfterOneWarning(t *testing.T) {
+	calls := stubPeakReset(t, peakWriteError(syscall.EINVAL))
+	logs := observeWarnings(t)
+
+	cgroupPath, memoryPeakFile := fakeCgroupDir(t)
+	mgr := &managerImpl{}
+
+	for range 3 {
+		stats, err := mgr.getStatsForPath(t.Context(), cgroupPath, memoryPeakFile)
+		require.NoError(t, err)
+		assertParsedStats(t, stats)
+	}
+
+	assert.True(t, memoryPeakResetUnsupported.Load(), "EINVAL must latch the reset as unsupported")
+	assert.Equal(t, int64(1), calls.Load(), "reset must be attempted once, then skipped entirely")
+
+	warnings := logs.FilterLevelExact(zapcore.WarnLevel).All()
+	require.Len(t, warnings, 1, "unsupported reset must be logged exactly once per process")
+	assert.Contains(t, warnings[0].Message, "kernel 6.12+")
+
+	// The latch is a property of the kernel, so it must hold for every other
+	// sandbox on this host too, not just the FD that discovered it.
+	otherPath, otherPeakFile := fakeCgroupDir(t)
+	stats, err := mgr.getStatsForPath(t.Context(), otherPath, otherPeakFile)
+	require.NoError(t, err)
+	assertParsedStats(t, stats)
+	assert.Equal(t, int64(1), calls.Load(), "latch must suppress the reset for every sandbox")
+	assert.Len(t, logs.FilterLevelExact(zapcore.WarnLevel).All(), 1)
+}
+
+//nolint:paralleltest // mutates the process-wide reset latch and the global logger
+func TestGetStatsPeakResetTransientErrorDoesNotLatch(t *testing.T) {
+	calls := stubPeakReset(t, peakWriteError(syscall.EIO))
+	logs := observeWarnings(t)
+
+	cgroupPath, memoryPeakFile := fakeCgroupDir(t)
+	mgr := &managerImpl{}
+
+	for range 3 {
+		stats, err := mgr.getStatsForPath(t.Context(), cgroupPath, memoryPeakFile)
+		require.NoError(t, err)
+		assertParsedStats(t, stats)
+	}
+
+	assert.False(t, memoryPeakResetUnsupported.Load(), "a transient error must not latch")
+	assert.Equal(t, int64(3), calls.Load(), "a transient error must be retried on every sample")
+
+	warnings := logs.FilterLevelExact(zapcore.WarnLevel).All()
+	require.Len(t, warnings, 3, "transient failures keep warning, as before")
+	assert.Contains(t, warnings[0].Message, "interval peak semantics degraded")
+}
+
+//nolint:paralleltest // mutates the process-wide reset latch and the global logger
+func TestGetStatsPeakResetSucceeds(t *testing.T) {
+	calls := stubPeakReset(t, nil)
+	logs := observeWarnings(t)
+
+	cgroupPath, memoryPeakFile := fakeCgroupDir(t)
+	mgr := &managerImpl{}
+
+	for range 3 {
+		stats, err := mgr.getStatsForPath(t.Context(), cgroupPath, memoryPeakFile)
+		require.NoError(t, err)
+		assertParsedStats(t, stats)
+	}
+
+	assert.False(t, memoryPeakResetUnsupported.Load())
+	assert.Equal(t, int64(3), calls.Load(), "a supported reset runs on every sample")
+	assert.Empty(t, logs.FilterLevelExact(zapcore.WarnLevel).All())
+}
+
+func TestPeakResetUnsupported(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+		},
+		{
+			name: "EINVAL",
+			err:  syscall.EINVAL,
+			want: true,
+		},
+		{
+			name: "EINVAL wrapped by os.File.WriteString",
+			err:  peakWriteError(syscall.EINVAL),
+			want: true,
+		},
+		{
+			name: "ENOTSUP",
+			err:  syscall.ENOTSUP,
+			want: true,
+		},
+		{
+			name: "EOPNOTSUPP",
+			err:  syscall.EOPNOTSUPP,
+			want: true,
+		},
+		{
+			name: "EIO",
+			err:  syscall.EIO,
+		},
+		{
+			name: "EBADF",
+			err:  syscall.EBADF,
+		},
+		{
+			name: "not a syscall error",
+			err:  errors.New("boom"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, peakResetUnsupported(tc.err))
+		})
+	}
+}


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-672/failed-to-reset-memorypeak

**Broken:** one WARN per sandbox per second for its whole life (`failed to reset memory.peak ... invalid argument`) — the host-stats collector samples at 1 Hz and zap sampling is disabled repo-wide, so 100 concurrent sandboxes ≈ 360k log lines/hour, plus a syscall per sandbox per second that can never succeed.

**Root cause:** resetting the peak by writing `memory.peak` is Linux 6.12+; the fleet node image (`ubuntu-2404-noble-*`) runs GA kernel 6.8 with no HWE upgrade in packer, so every write returns EINVAL. `Create`'s O_RDWR open can't detect it — the file is 0444 pre-6.12, but root's `CAP_DAC_OVERRIDE` lets the open succeed. Regression re-run: #1959 disabled this reset for exactly this reason; #2430 re-enabled it on the premise "we run on kernel 6.12+ (ubuntu24)" (which did not hold) and escalated the log Debug→Warn.

**Fix:** latch on the first EINVAL/ENOTSUP/EOPNOTSUPP — the write itself is the authoritative probe (uname parsing is brittle across vendor kernels/backports); kernel support is per-host, so one failure settles every sandbox: one warning per process instead of N per second. Other errors stay transient (retry + warn exactly as before). The read peak is still returned — the metric degrades to a lifetime peak; no ClickHouse schema change, no new `Stats` fields, `MemoryPeakBytes` still populated; the interval-semantics comments and the misleading `peak_reset_available` log field now say what they actually prove.

**Repro:** reproduced, not inferred — on kernel 6.8.0-64-generic (same GA kernel as the fleet) against a real cgroup v2 fs in a privileged container: open O_RDWR OK, write → EINVAL (errno 22), character-for-character the production error; confirms the predicate must match EINVAL, not EIO.

**Verification:** new `peak_reset_test.go`, 4 tests via an injectable write seam (a temp file accepts the write and O_RDONLY gives EBADF, so the failure genuinely can't be reproduced without one; no root/cgroupfs needed, unlike the existing root-gated tests that skip in CI). Reverting only the latch: 3 writes / 3 warnings / no latch fails while the 3 control cases pass — diagnostic, not accidental; a full revert is a compile error, so the isolated revert is the meaningful before-state. Full `./pkg/sandbox/cgroup/...` suite green incl. `-race` and in a privileged container on a real kernel-6.8 cgroupfs with zero skips; `go build`/`go vet`/`gofmt` clean on both touched modules; `golangci-lint` v2.11.4 reports 0 issues (confirmed it genuinely analyses the linux-tagged test file by removing a `//nolint` and seeing it fire). Verified on linux/arm64 (local Docker constraint); `syscall.EINVAL` is 22 on amd64 too.

**Flagging:** `TestCgroupHandlePeakReset` only asserts `peak >= current`, so it passes with lifetime semantics — that is why #2430 shipped green; strengthening it needs a ≥6.12 kernel in CI (out of scope). Someone should also confirm whether the HWE kernel upgrade #2430 assumed was planned and dropped — this PR stops the spam and tells the truth, but only a newer kernel restores real interval peaks.
