### PR TITLE
fix(api): keep template builds alive through transient status-poll errors

### DIFF
--- a/packages/api/internal/template-manager/template_status.go
+++ b/packages/api/internal/template-manager/template_status.go
@@ -9,6 +9,8 @@ import (
 	"github.com/flowchartsman/retry"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/e2b-dev/infra/packages/db/pkg/types"
 	"github.com/e2b-dev/infra/packages/db/queries"
@@ -19,7 +21,17 @@ import (
 var (
 	buildTimeout             = time.Hour
 	syncWaitingStateDeadline = time.Minute * 40
+
+	// transientErrorGracePeriod is how long the poller keeps asking the builder
+	// for a build status that only answers with transient errors. The build
+	// itself keeps running on the builder while we retry, so failing it on the
+	// first hiccup would throw away work that is still perfectly fine.
+	transientErrorGracePeriod = 5 * time.Minute
 )
+
+// errTransientStatus marks a status error that is worth retrying instead of
+// failing the build over.
+var errTransientStatus = errors.New("transient error")
 
 func (tm *TemplateManager) BuildStatusSync(ctx context.Context, buildID uuid.UUID, templateID string, clusterID uuid.UUID, nodeID *string) error {
 	if tm.createInProcessingQueue(buildID, templateID) {
@@ -99,6 +111,10 @@ type PollBuildStatus struct {
 	nodeID    string
 
 	status *templatemanagergrpc.TemplateBuildStatusResponse
+
+	// transientErrorsSince is when the current run of transient status errors
+	// started. Zero while the builder is answering.
+	transientErrorsSince time.Time
 }
 
 func (c *PollBuildStatus) poll(ctx context.Context) {
@@ -121,10 +137,17 @@ func (c *PollBuildStatus) poll(ctx context.Context) {
 		case <-ticker.C:
 			buildCompleted, err := c.checkBuildStatus(ctx)
 			if err != nil {
-				c.logger.Error(ctx, "Build status polling received unrecoverable error", zap.Error(err))
+				failure := c.buildFailure(err)
+				if failure == nil {
+					c.logger.Warn(ctx, "Build status polling received a transient error, keeping the build alive", zap.Error(err))
+
+					continue
+				}
+
+				c.logger.Error(ctx, "Build status polling failed", zap.Error(failure))
 
 				statusErr := c.client.SetStatus(ctx, c.buildID, types.BuildStatusGroupFailed, &templatemanagergrpc.TemplateBuildStatusReason{
-					Message: fmt.Sprintf("polling received unrecoverable error: %s", err),
+					Message: failure.Error(),
 				})
 				if statusErr != nil {
 					c.logger.Error(ctx, "error when setting build status", zap.Error(statusErr))
@@ -133,12 +156,56 @@ func (c *PollBuildStatus) poll(ctx context.Context) {
 				return
 			}
 
+			c.transientErrorsSince = time.Time{}
+
 			// build status can return empty error when build is still in progress
 			// this will cause fast return to avoid pooling when build is already finished
 			if buildCompleted {
 				return
 			}
 		}
+	}
+}
+
+// buildFailure turns a polling error into the reason the build should be failed
+// with, or nil when the error is transient and the poller should just try again.
+func (c *PollBuildStatus) buildFailure(err error) error {
+	if !errors.Is(err, errTransientStatus) {
+		return fmt.Errorf("polling received unrecoverable error: %w", err)
+	}
+
+	if c.transientErrorsSince.IsZero() {
+		c.transientErrorsSince = time.Now()
+	}
+
+	// Give up once the builder has been unreachable for long enough that the
+	// build is very unlikely to still be alive on the other end.
+	if time.Since(c.transientErrorsSince) >= transientErrorGracePeriod {
+		return fmt.Errorf("polling kept failing for %s: %w", transientErrorGracePeriod, err)
+	}
+
+	return nil
+}
+
+// isTransientStatusError reports whether a status RPC failed for a reason that
+// says nothing about the build itself: the call timed out, or the builder was
+// briefly unreachable or overloaded. gRPC status errors do not unwrap to
+// context.DeadlineExceeded, so the status code has to be inspected explicitly.
+func isTransientStatusError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	st, ok := grpcstatus.FromError(err)
+	if !ok {
+		return false
+	}
+
+	switch st.Code() {
+	case codes.DeadlineExceeded, codes.Unavailable, codes.ResourceExhausted:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -160,9 +227,9 @@ func newTerminalError(err error) error {
 
 func (c *PollBuildStatus) setStatus(ctx context.Context) error {
 	status, err := c.client.GetStatus(ctx, c.buildID, c.templateID, c.clusterID, c.nodeID)
-	if err != nil && errors.Is(err, context.DeadlineExceeded) {
-		return fmt.Errorf("context deadline exceeded: %w", err)
-	} else if err != nil { // retry only on context deadline exceeded
+	if err != nil && isTransientStatusError(err) {
+		return fmt.Errorf("%w when polling build status: %w", errTransientStatus, err)
+	} else if err != nil { // retry only on transient errors
 		c.logger.Error(ctx, "terminal error when polling build status", zap.Error(err))
 
 		return newTerminalError(err)
@@ -229,10 +296,9 @@ func (c *PollBuildStatus) checkBuildStatus(ctx context.Context) (bool, error) {
 		time.Second,
 	)
 
+	// The caller logs the error with the level matching how it handles it.
 	err := retrier.RunContext(ctx, c.setStatus)
 	if err != nil {
-		c.logger.Error(ctx, "error when calling setStatus", zap.Error(err))
-
 		return false, err
 	}
 

--- a/packages/api/internal/template-manager/template_status.go
+++ b/packages/api/internal/template-manager/template_status.go
@@ -22,15 +22,12 @@ var (
 	buildTimeout             = time.Hour
 	syncWaitingStateDeadline = time.Minute * 40
 
-	// transientErrorGracePeriod is how long the poller keeps asking the builder
-	// for a build status that only answers with transient errors. The build
-	// itself keeps running on the builder while we retry, so failing it on the
-	// first hiccup would throw away work that is still perfectly fine.
+	// transientErrorGracePeriod bounds how long the poller tolerates transient
+	// status errors — the build keeps running on the builder while we retry.
 	transientErrorGracePeriod = 5 * time.Minute
 )
 
-// errTransientStatus marks a status error that is worth retrying instead of
-// failing the build over.
+// errTransientStatus marks a status error worth retrying instead of failing the build.
 var errTransientStatus = errors.New("transient error")
 
 func (tm *TemplateManager) BuildStatusSync(ctx context.Context, buildID uuid.UUID, templateID string, clusterID uuid.UUID, nodeID *string) error {
@@ -178,8 +175,6 @@ func (c *PollBuildStatus) buildFailure(err error) error {
 		c.transientErrorsSince = time.Now()
 	}
 
-	// Give up once the builder has been unreachable for long enough that the
-	// build is very unlikely to still be alive on the other end.
 	if time.Since(c.transientErrorsSince) >= transientErrorGracePeriod {
 		return fmt.Errorf("polling kept failing for %s: %w", transientErrorGracePeriod, err)
 	}
@@ -188,8 +183,7 @@ func (c *PollBuildStatus) buildFailure(err error) error {
 }
 
 // isTransientStatusError reports whether a status RPC failed for a reason that
-// says nothing about the build itself: the call timed out, or the builder was
-// briefly unreachable or overloaded. gRPC status errors do not unwrap to
+// says nothing about the build itself. gRPC status errors do not unwrap to
 // context.DeadlineExceeded, so the status code has to be inspected explicitly.
 func isTransientStatusError(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
@@ -296,7 +290,6 @@ func (c *PollBuildStatus) checkBuildStatus(ctx context.Context) (bool, error) {
 		time.Second,
 	)
 
-	// The caller logs the error with the level matching how it handles it.
 	err := retrier.RunContext(ctx, c.setStatus)
 	if err != nil {
 		return false, err

--- a/packages/api/internal/template-manager/template_status_test.go
+++ b/packages/api/internal/template-manager/template_status_test.go
@@ -1,0 +1,228 @@
+package template_manager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	"github.com/e2b-dev/infra/packages/db/pkg/types"
+	templatemanagergrpc "github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+)
+
+// grpcDeadlineExceeded is the error the API sees when the status RPC to the
+// template builder times out, e.g. "rpc error: code = DeadlineExceeded desc =
+// context deadline exceeded".
+func grpcDeadlineExceeded() error {
+	return grpcstatus.Error(codes.DeadlineExceeded, "context deadline exceeded")
+}
+
+type getStatusResult struct {
+	resp *templatemanagergrpc.TemplateBuildStatusResponse
+	err  error
+}
+
+// scriptedClient replays a canned sequence of GetStatus outcomes (the last one
+// repeats forever) and records what the poller persisted for the build.
+type scriptedClient struct {
+	mu sync.Mutex
+
+	script []getStatusResult
+	calls  int
+
+	failedReasons []string
+	finished      bool
+}
+
+func (s *scriptedClient) GetStatus(context.Context, uuid.UUID, string, uuid.UUID, string) (*templatemanagergrpc.TemplateBuildStatusResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := s.script[min(s.calls, len(s.script)-1)]
+	s.calls++
+
+	return result.resp, result.err
+}
+
+func (s *scriptedClient) SetStatus(_ context.Context, _ uuid.UUID, statusGroup types.BuildStatusGroup, reason *templatemanagergrpc.TemplateBuildStatusReason) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if statusGroup == types.BuildStatusGroupFailed {
+		s.failedReasons = append(s.failedReasons, reason.GetMessage())
+	}
+
+	return nil
+}
+
+func (s *scriptedClient) SetFinished(context.Context, uuid.UUID, int64, string, string, string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.finished = true
+
+	return nil
+}
+
+func (s *scriptedClient) snapshot() ([]string, bool, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]string(nil), s.failedReasons...), s.finished, s.calls
+}
+
+func completedStatus() *templatemanagergrpc.TemplateBuildStatusResponse {
+	return &templatemanagergrpc.TemplateBuildStatusResponse{
+		Status: templatemanagergrpc.TemplateBuildState_Completed,
+		Metadata: &templatemanagergrpc.TemplateBuildMetadata{
+			RootfsSizeKey:  100,
+			EnvdVersionKey: "1.0.0",
+		},
+	}
+}
+
+// TestPollBuildStatus_transientRPCErrorKeepsBuildAlive covers EN-828: a status
+// RPC that times out is a backend hiccup, not a build failure, and must not
+// terminate an otherwise healthy build.
+func TestPollBuildStatus_transientRPCErrorKeepsBuildAlive(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		script := make([]getStatusResult, 0, 61)
+		for range 60 {
+			script = append(script, getStatusResult{err: grpcDeadlineExceeded()})
+		}
+		script = append(script, getStatusResult{resp: completedStatus()})
+
+		client := &scriptedClient{script: script}
+		c := &PollBuildStatus{
+			client:  client,
+			logger:  logger.NewNopLogger(),
+			buildID: uuid.New(),
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), buildTimeout)
+		defer cancel()
+
+		c.poll(ctx)
+
+		failedReasons, finished, calls := client.snapshot()
+		if len(failedReasons) > 0 {
+			t.Fatalf("build was failed after %d status calls, reasons: %q", calls, failedReasons)
+		}
+		if !finished {
+			t.Fatalf("build was not finished after %d status calls", calls)
+		}
+	})
+}
+
+// TestPollBuildStatus_transientRPCErrorEventuallyFailsBuild makes sure the
+// tolerance above stays bounded: a builder that never answers again still fails
+// the build, it just takes the grace period instead of a single hiccup.
+func TestPollBuildStatus_transientRPCErrorEventuallyFailsBuild(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		client := &scriptedClient{script: []getStatusResult{{err: grpcDeadlineExceeded()}}}
+		c := &PollBuildStatus{
+			client:  client,
+			logger:  logger.NewNopLogger(),
+			buildID: uuid.New(),
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), buildTimeout)
+		defer cancel()
+
+		start := time.Now()
+		c.poll(ctx)
+		elapsed := time.Since(start)
+
+		failedReasons, _, _ := client.snapshot()
+		if len(failedReasons) != 1 {
+			t.Fatalf("expected exactly one failure, got %q", failedReasons)
+		}
+		if !strings.Contains(failedReasons[0], "DeadlineExceeded") {
+			t.Errorf("failure reason should keep the underlying error, got %q", failedReasons[0])
+		}
+		if elapsed < transientErrorGracePeriod {
+			t.Errorf("build failed after %s, expected the poller to retry for at least %s", elapsed, transientErrorGracePeriod)
+		}
+		if elapsed >= buildTimeout {
+			t.Errorf("build failed only once the build timed out, after %s", elapsed)
+		}
+	})
+}
+
+// TestPollBuildStatus_terminalRPCErrorFailsBuild keeps the existing behaviour
+// for errors that will not fix themselves.
+func TestPollBuildStatus_terminalRPCErrorFailsBuild(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		client := &scriptedClient{script: []getStatusResult{
+			{err: errors.New("error while getting build info, maybe already expired")},
+		}}
+		c := &PollBuildStatus{
+			client:  client,
+			logger:  logger.NewNopLogger(),
+			buildID: uuid.New(),
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), buildTimeout)
+		defer cancel()
+
+		start := time.Now()
+		c.poll(ctx)
+		elapsed := time.Since(start)
+
+		failedReasons, _, _ := client.snapshot()
+		if len(failedReasons) != 1 {
+			t.Fatalf("expected exactly one failure, got %q", failedReasons)
+		}
+		if !strings.Contains(failedReasons[0], "polling received unrecoverable error") {
+			t.Errorf("unexpected failure reason %q", failedReasons[0])
+		}
+		if elapsed >= transientErrorGracePeriod {
+			t.Errorf("terminal error took %s to fail the build", elapsed)
+		}
+	})
+}
+
+func TestIsTransientStatusError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "grpc deadline exceeded", err: grpcDeadlineExceeded(), want: true},
+		{name: "wrapped grpc deadline exceeded", err: fmt.Errorf("polling: %w", grpcDeadlineExceeded()), want: true},
+		{name: "grpc unavailable", err: grpcstatus.Error(codes.Unavailable, "connection refused"), want: true},
+		{name: "grpc resource exhausted", err: grpcstatus.Error(codes.ResourceExhausted, "too many builds"), want: true},
+		{name: "bare context deadline exceeded", err: context.DeadlineExceeded, want: true},
+		{name: "wrapped context deadline exceeded", err: fmt.Errorf("polling: %w", context.DeadlineExceeded), want: true},
+		{name: "grpc not found", err: grpcstatus.Error(codes.NotFound, "no such build"), want: false},
+		{name: "grpc internal", err: grpcstatus.Error(codes.Internal, "boom"), want: false},
+		{name: "plain error", err: errors.New("build info expired"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isTransientStatusError(tt.err); got != tt.want {
+				t.Errorf("isTransientStatusError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/packages/api/internal/template-manager/template_status_test.go
+++ b/packages/api/internal/template-manager/template_status_test.go
@@ -19,9 +19,8 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
-// grpcDeadlineExceeded is the error the API sees when the status RPC to the
-// template builder times out, e.g. "rpc error: code = DeadlineExceeded desc =
-// context deadline exceeded".
+// grpcDeadlineExceeded is a status-RPC timeout as the API sees it: a gRPC
+// status error, not context.DeadlineExceeded.
 func grpcDeadlineExceeded() error {
 	return grpcstatus.Error(codes.DeadlineExceeded, "context deadline exceeded")
 }
@@ -162,8 +161,8 @@ func TestPollBuildStatus_transientRPCErrorEventuallyFailsBuild(t *testing.T) {
 	})
 }
 
-// TestPollBuildStatus_terminalRPCErrorFailsBuild keeps the existing behaviour
-// for errors that will not fix themselves.
+// TestPollBuildStatus_terminalRPCErrorFailsBuild: errors that will not fix
+// themselves fail the build immediately, with no grace period.
 func TestPollBuildStatus_terminalRPCErrorFailsBuild(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-828/when-polling-build-logs-handle-timeoutbackend-errors-gracefully-with

**Broken:** one timed-out status RPC to the template builder throws away a healthy, still-running build — the API's build-status poller marks it failed with `polling received unrecoverable error: rpc error: code = DeadlineExceeded ...` (that string is API-written, not SDK-produced), which killed a CI template build.

**Root cause:** `PollBuildStatus.poll` treats every `checkBuildStatus` error as unrecoverable. The intended transient/terminal split never worked: it retried only on `errors.Is(err, context.DeadlineExceeded)`, but gRPC status errors don't unwrap to that (`errors.Is(status.Error(codes.DeadlineExceeded, ...), context.DeadlineExceeded)` is false), and the inner retrier only buys ~10 quick attempts.

**Fix:** `isTransientStatusError` classifies by gRPC code (`DeadlineExceeded`, `Unavailable`, `ResourceExhausted`) plus `context.DeadlineExceeded`; the poller rides out transient errors for a 5-minute grace period (reset on any successful poll). Terminal errors still fail immediately with the unchanged reason string; a builder that never recovers fails after the grace period rather than hanging until the 1 h build timeout.

**Verification:** new `template_status_test.go` tests drive the real `poll` loop (real 1 s ticker, retry backoff, 5 min grace) under `testing/synctest`. On origin/main the transient-error test fails ("build was failed after 10 status calls" with the exact production reason); after the fix all pass incl. `-race -count=3`. `gofmt`, `go vet`, golangci-lint 2.11.4 clean on the package.
