### PR TITLE
fix(iac): raise neighbour table thresholds on worker nodes

### DIFF
--- a/iac/provider-aws/modules/nodepool-client/scripts/start-client.sh
+++ b/iac/provider-aws/modules/nodepool-client/scripts/start-client.sh
@@ -52,6 +52,15 @@ net.core.netdev_max_backlog = 65535
 # Increase maximum number of TCP sockets
 net.ipv4.tcp_max_syn_backlog = 65535
 
+# Raise the ARP/NDP neighbour table limits. Each sandbox adds a host-side veth
+# neighbour entry, and the kernel defaults (128/512/1024) overflow on a full node.
+net.ipv4.neigh.default.gc_thresh1 = 4096
+net.ipv4.neigh.default.gc_thresh2 = 8192
+net.ipv4.neigh.default.gc_thresh3 = 16384
+net.ipv6.neigh.default.gc_thresh1 = 4096
+net.ipv6.neigh.default.gc_thresh2 = 8192
+net.ipv6.neigh.default.gc_thresh3 = 16384
+
 # Increase the maximum number of memory map areas
 vm.max_map_count=1048576
 

--- a/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
@@ -124,6 +124,15 @@ net.core.netdev_max_backlog = 65535
 # Increase maximum number of TCP sockets
 net.ipv4.tcp_max_syn_backlog = 65535
 
+# Raise the ARP/NDP neighbour table limits. Each sandbox adds a host-side veth
+# neighbour entry, and the kernel defaults (128/512/1024) overflow on a full node.
+net.ipv4.neigh.default.gc_thresh1 = 4096
+net.ipv4.neigh.default.gc_thresh2 = 8192
+net.ipv4.neigh.default.gc_thresh3 = 16384
+net.ipv6.neigh.default.gc_thresh1 = 4096
+net.ipv6.neigh.default.gc_thresh2 = 8192
+net.ipv6.neigh.default.gc_thresh3 = 16384
+
 # Increase the maximum number of memory map areas
 vm.max_map_count=1048576
 


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-966/neighbor-arp-cache-neighbor-table-overflow

**Broken:** worker nodes log `neighbour: arp_cache: neighbor table overflow!` and neighbour inserts fail with ENOBUFS.

**Root cause:** no ARP/neigh sysctl set anywhere in the repo, so hosts run kernel defaults 128/512/1024. Each sandbox slot costs one ARP + one IPv6 ND entry in the host root netns (`CreateNetwork` veth + /31 + /32 route); 200 `max-sandboxes-per-node` (LaunchDarkly-raisable in prod with no code change) + 131 pre-warmed pool slots ≈ 330 steady-state entries before infra peers and stale entries — past `gc_thresh2=512` under churn, reaching `gc_thresh3=1024`.

**Repro (Linux 6.8, privileged container):** at defaults, fresh NUD_STALE adds fail at 1017–1019 with `RTNETLINK answers: No buffer space available` and the exact ticket line in dmesg; IPv6 (`ndisc_cache`) fails identically at 1024. Forced GC can't reclaim entries younger than `gc_interval` (30 s), so a creation burst overflows. Two flags: the counter is global, not per-netns (filling from a child netns broke root-netns adds — one `arp_tbl`/`nd_tbl` per kernel), and `neigh/default` only exists in the init netns, so the root-netns setting is the only lever and governs every namespace. IPv6 included because nothing sets `disable_ipv6` and every veth gets a link-local address.

**Fix:** raise thresholds to 4096/8192/16384 on both GCP and AWS (the comparable `vm.dirty_*` change bb920f4f3c only landed on GCP). Sizing: ~330 steady state needs real headroom since the cap is runtime-raisable; `gc_thresh1=4096` keeps GC off the hot path; 16384 ≈ 50x steady state, ~6 MB per table worst case — consistent with existing generous limits (`somaxconn 65535`, `nf_conntrack_max 2097152`).

**Verification:** appending the exact block to `/etc/sysctl.conf` + `sysctl -p` (what the scripts do) returns 0, applies all six keys, and the previously failing 3000-entry IPv4 and IPv6 fills pass with no overflow logged.

**Rollout:** bootstrap sysctl-only — only reaches nodes created after this lands. #2786 (NUD_PERMANENT entries in `Slot.CreateNetwork`) was closed unmerged after smoke-test failures; this is the orthogonal, lower-risk fix the ticket itself suggests.
