### PR TITLE
fix(orchestrator): bound Consul KV slot operations with a context and timeout

### DIFF
--- a/packages/orchestrator/pkg/sandbox/network/pool.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool.go
@@ -28,6 +28,20 @@ const (
 	// ReturnDelay is how long we wait before returning a slot to the reused pool,
 	// to let inflight requests on the previous sandbox drain and reduce reuse churn.
 	ReturnDelay = 3 * time.Second
+
+	// poolCloseTimeout bounds the whole shutdown drain. Close detaches the
+	// drain from its caller's context (see Close) so slots are still released
+	// under FORCE_STOP, which cancels that context up front; this timeout is
+	// what keeps the detached drain from running unbounded.
+	//
+	// Sizing: against a healthy Consul agent on localhost the drain is two
+	// round trips per slot and finishes well inside a second, so this only
+	// bites when the backend is unresponsive. The forced-stop path runs with
+	// Nomad's kill_timeout of 1m shared across every closer, and the network
+	// pool is one of ~26, so it must not take the whole budget. 15s leaves 45s
+	// for the rest while still being long enough for at least one full release
+	// to complete when the backend is slow rather than dead.
+	poolCloseTimeout = 15 * time.Second
 )
 
 var (
@@ -148,7 +162,11 @@ func (p *Pool) createNetworkSlot(ctx context.Context) (*Slot, error) {
 
 	err = ips.CreateNetwork(ctx)
 	if err != nil {
-		releaseErr := p.slotStorage.Release(ips)
+		// Detach from ctx: CreateNetwork commonly fails *because* ctx ended, and
+		// skipping the release would leak the slot's KV key, marking that slot
+		// index permanently taken for this node. The storage bounds every call
+		// with its own timeout, so detaching cannot hang.
+		releaseErr := p.slotStorage.Release(context.WithoutCancel(ctx), ips)
 		err = errors.Join(err, releaseErr)
 
 		return nil, fmt.Errorf("failed to create network: %w", err)
@@ -247,7 +265,11 @@ func (p *Pool) returnSlot(ctx context.Context, slot *Slot, releasedFn ReleaseNot
 	// still fall through and clean up the slot to avoid leaking it.
 	select {
 	case <-ctx.Done():
-		return p.cleanupWith(ctx, slot, ctx.Err())
+		// Detach the cleanup from the dead ctx so the slot's storage entry is
+		// still released — otherwise its KV key leaks and the slot index stays
+		// marked as taken for this node forever. The storage bounds every call
+		// with its own timeout, so detaching cannot hang.
+		return p.cleanupWith(context.WithoutCancel(ctx), slot, ctx.Err())
 	case <-p.done:
 		return p.cleanupWith(ctx, slot, ErrClosed)
 	case <-time.After(returnDelay):
@@ -360,7 +382,7 @@ func (p *Pool) cleanup(ctx context.Context, slot *Slot) error {
 		errs = append(errs, fmt.Errorf("cannot remove network when releasing slot '%d': %w", slot.Idx, err))
 	}
 
-	err = p.slotStorage.Release(slot)
+	err = p.slotStorage.Release(ctx, slot)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to release slot '%d': %w", slot.Idx, err))
 	}
@@ -385,12 +407,20 @@ func (p *Pool) Close(ctx context.Context) error {
 	// up itself or has already pushed it into reusedSlots, drained below.
 	p.returnsWG.Wait()
 
+	// Slot releases must outlive a forced shutdown's already-cancelled context:
+	// the storage key is node-scoped and nothing ever reclaims it, so skipping
+	// the release would permanently burn that slot index on this node. Detach
+	// from cancellation, but bound the whole drain so an unresponsive backend
+	// still cannot stall shutdown.
+	drainCtx, cancelDrain := context.WithTimeout(context.WithoutCancel(ctx), poolCloseTimeout)
+	defer cancelDrain()
+
 	var errs []error
 
 	for slot := range p.newSlots {
 		newSlotsAvailableCounter.Add(ctx, -1)
 
-		err := p.cleanup(ctx, slot)
+		err := p.cleanup(drainCtx, slot)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to cleanup slot '%d': %w", slot.Idx, err))
 		}
@@ -402,7 +432,7 @@ drain:
 		case slot := <-p.reusedSlots:
 			reusableSlotsAvailableCounter.Add(ctx, -1)
 
-			err := p.cleanup(ctx, slot)
+			err := p.cleanup(drainCtx, slot)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to cleanup slot '%d': %w", slot.Idx, err))
 			}

--- a/packages/orchestrator/pkg/sandbox/network/pool.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool.go
@@ -29,18 +29,11 @@ const (
 	// to let inflight requests on the previous sandbox drain and reduce reuse churn.
 	ReturnDelay = 3 * time.Second
 
-	// poolCloseTimeout bounds the whole shutdown drain. Close detaches the
-	// drain from its caller's context (see Close) so slots are still released
-	// under FORCE_STOP, which cancels that context up front; this timeout is
-	// what keeps the detached drain from running unbounded.
-	//
-	// Sizing: against a healthy Consul agent on localhost the drain is two
-	// round trips per slot and finishes well inside a second, so this only
-	// bites when the backend is unresponsive. The forced-stop path runs with
-	// Nomad's kill_timeout of 1m shared across every closer, and the network
-	// pool is one of ~26, so it must not take the whole budget. 15s leaves 45s
-	// for the rest while still being long enough for at least one full release
-	// to complete when the backend is slow rather than dead.
+	// poolCloseTimeout bounds the shutdown drain, which Close detaches from
+	// its caller's context so slots are still released under FORCE_STOP. A
+	// healthy drain finishes well under a second, so this only bites when the
+	// backend is unresponsive; 15s stays a fraction of Nomad's 1m kill_timeout
+	// shared across ~26 closers while fitting a slow-but-alive release.
 	poolCloseTimeout = 15 * time.Second
 )
 
@@ -162,10 +155,9 @@ func (p *Pool) createNetworkSlot(ctx context.Context) (*Slot, error) {
 
 	err = ips.CreateNetwork(ctx)
 	if err != nil {
-		// Detach from ctx: CreateNetwork commonly fails *because* ctx ended, and
-		// skipping the release would leak the slot's KV key, marking that slot
-		// index permanently taken for this node. The storage bounds every call
-		// with its own timeout, so detaching cannot hang.
+		// Release even on a dead ctx — CreateNetwork commonly fails *because*
+		// ctx ended, and a skipped release leaks the slot's node-scoped KV key.
+		// The storage bounds its own calls, so detaching cannot hang.
 		releaseErr := p.slotStorage.Release(context.WithoutCancel(ctx), ips)
 		err = errors.Join(err, releaseErr)
 
@@ -265,10 +257,8 @@ func (p *Pool) returnSlot(ctx context.Context, slot *Slot, releasedFn ReleaseNot
 	// still fall through and clean up the slot to avoid leaking it.
 	select {
 	case <-ctx.Done():
-		// Detach the cleanup from the dead ctx so the slot's storage entry is
-		// still released — otherwise its KV key leaks and the slot index stays
-		// marked as taken for this node forever. The storage bounds every call
-		// with its own timeout, so detaching cannot hang.
+		// Detach so the release still happens — a skipped release leaks the
+		// slot's node-scoped KV key. The storage bounds its own calls.
 		return p.cleanupWith(context.WithoutCancel(ctx), slot, ctx.Err())
 	case <-p.done:
 		return p.cleanupWith(ctx, slot, ErrClosed)
@@ -407,11 +397,9 @@ func (p *Pool) Close(ctx context.Context) error {
 	// up itself or has already pushed it into reusedSlots, drained below.
 	p.returnsWG.Wait()
 
-	// Slot releases must outlive a forced shutdown's already-cancelled context:
-	// the storage key is node-scoped and nothing ever reclaims it, so skipping
-	// the release would permanently burn that slot index on this node. Detach
-	// from cancellation, but bound the whole drain so an unresponsive backend
-	// still cannot stall shutdown.
+	// Releases must outlive a forced shutdown's already-cancelled context —
+	// nothing ever reclaims the node-scoped storage keys. Detach, but bound
+	// the drain so an unresponsive backend cannot stall shutdown.
 	drainCtx, cancelDrain := context.WithTimeout(context.WithoutCancel(ctx), poolCloseTimeout)
 	defer cancelDrain()
 

--- a/packages/orchestrator/pkg/sandbox/network/pool_test.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool_test.go
@@ -17,19 +17,37 @@ import (
 type fakeStorage struct {
 	released  atomic.Int64
 	releaseFn func(*Slot) error
+
+	// ctxErrMu guards releaseCtxErrs, which records ctx.Err() as seen at the
+	// start of each Release call. A non-nil entry means the caller handed the
+	// storage a dead context, which a real backend would refuse to act on.
+	ctxErrMu       sync.Mutex
+	releaseCtxErrs []error
 }
 
 func (f *fakeStorage) Acquire(_ context.Context) (*Slot, error) {
 	return nil, context.Canceled
 }
 
-func (f *fakeStorage) Release(s *Slot) error {
+func (f *fakeStorage) Release(ctx context.Context, s *Slot) error {
 	f.released.Add(1)
+
+	f.ctxErrMu.Lock()
+	f.releaseCtxErrs = append(f.releaseCtxErrs, ctx.Err())
+	f.ctxErrMu.Unlock()
+
 	if f.releaseFn != nil {
 		return f.releaseFn(s)
 	}
 
 	return nil
+}
+
+func (f *fakeStorage) releaseCtxErrors() []error {
+	f.ctxErrMu.Lock()
+	defer f.ctxErrMu.Unlock()
+
+	return append([]error(nil), f.releaseCtxErrs...)
 }
 
 // testSlotIdxOffset keeps test slot indices outside the range any real
@@ -176,6 +194,39 @@ func TestReturnAsync_AfterCloseCleansUpSynchronously(t *testing.T) {
 	err := pool.ReturnAsync(t.Context(), newTestSlot(1), noopRelease, time.Hour)
 	require.ErrorIs(t, err, ErrClosed)
 	assert.Equal(t, int64(1), storage.released.Load(), "ReturnAsync after Close must release the slot before returning")
+}
+
+// TestClose_ReleasesPooledSlotsWithCanceledContext guards the shutdown path
+// the template-manager actually runs: it sets FORCE_STOP, which cancels the
+// close context before any closer runs. Close must still hand Storage.Release
+// a live context — the storage key is node-scoped and nothing reclaims it, so
+// releases skipped here leak those slot indices for the lifetime of the node.
+func TestClose_ReleasesPooledSlotsWithCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	const slots = 4
+
+	storage := &fakeStorage{}
+	pool := NewPool(2, slots, storage, Config{})
+	close(pool.newSlots)
+
+	for i := range slots {
+		pool.reusedSlots <- newTestSlot(i + 1)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	// Close error ignored: cleanup()'s netlink teardown may fail in the test
+	// environment; the release accounting is the leak signal.
+	_ = pool.Close(ctx)
+
+	require.Equal(t, int64(slots), storage.released.Load(),
+		"Close must release every pooled slot even when its context is already canceled")
+
+	for i, err := range storage.releaseCtxErrors() {
+		assert.NoErrorf(t, err, "Release call %d received a dead context, so the slot's storage key would leak", i)
+	}
 }
 
 func TestReturn_AfterClose_CleanupFailure_PreservesErrClosed(t *testing.T) {

--- a/packages/orchestrator/pkg/sandbox/network/pool_test.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool_test.go
@@ -18,9 +18,8 @@ type fakeStorage struct {
 	released  atomic.Int64
 	releaseFn func(*Slot) error
 
-	// ctxErrMu guards releaseCtxErrs, which records ctx.Err() as seen at the
-	// start of each Release call. A non-nil entry means the caller handed the
-	// storage a dead context, which a real backend would refuse to act on.
+	// releaseCtxErrs records ctx.Err() at the start of each Release; non-nil
+	// means the caller handed the storage a dead context.
 	ctxErrMu       sync.Mutex
 	releaseCtxErrs []error
 }
@@ -196,11 +195,9 @@ func TestReturnAsync_AfterCloseCleansUpSynchronously(t *testing.T) {
 	assert.Equal(t, int64(1), storage.released.Load(), "ReturnAsync after Close must release the slot before returning")
 }
 
-// TestClose_ReleasesPooledSlotsWithCanceledContext guards the shutdown path
-// the template-manager actually runs: it sets FORCE_STOP, which cancels the
-// close context before any closer runs. Close must still hand Storage.Release
-// a live context — the storage key is node-scoped and nothing reclaims it, so
-// releases skipped here leak those slot indices for the lifetime of the node.
+// TestClose_ReleasesPooledSlotsWithCanceledContext guards the FORCE_STOP
+// shutdown path: the close context is cancelled before any closer runs, yet
+// Release must get a live context or the node-scoped slot keys leak forever.
 func TestClose_ReleasesPooledSlotsWithCanceledContext(t *testing.T) {
 	t.Parallel()
 
@@ -217,8 +214,8 @@ func TestClose_ReleasesPooledSlotsWithCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	// Close error ignored: cleanup()'s netlink teardown may fail in the test
-	// environment; the release accounting is the leak signal.
+	// cleanup()'s netlink teardown may fail in the test environment; the
+	// release accounting is the leak signal.
 	_ = pool.Close(ctx)
 
 	require.Equal(t, int64(slots), storage.released.Load(),

--- a/packages/orchestrator/pkg/sandbox/network/storage.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage.go
@@ -8,8 +8,7 @@ import (
 
 type Storage interface {
 	Acquire(ctx context.Context) (*Slot, error)
-	// Release frees the slot. Implementations backed by a remote store must
-	// honor ctx so a shutdown can cut the call short instead of blocking on an
-	// unresponsive backend.
+	// Release frees the slot. Remote-backed implementations must honor ctx so
+	// shutdown can cut a call to an unresponsive backend short.
 	Release(ctx context.Context, s *Slot) error
 }

--- a/packages/orchestrator/pkg/sandbox/network/storage.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage.go
@@ -8,5 +8,8 @@ import (
 
 type Storage interface {
 	Acquire(ctx context.Context) (*Slot, error)
-	Release(s *Slot) error
+	// Release frees the slot. Implementations backed by a remote store must
+	// honor ctx so a shutdown can cut the call short instead of blocking on an
+	// unresponsive backend.
+	Release(ctx context.Context, s *Slot) error
 }

--- a/packages/orchestrator/pkg/sandbox/network/storage_kv.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_kv.go
@@ -8,11 +8,19 @@ import (
 	"fmt"
 	"math/rand"
 	"slices"
+	"time"
 
 	consulApi "github.com/hashicorp/consul/api"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
+
+// consulRequestTimeout bounds a single Consul KV round trip. The Consul API
+// client builds its http.Client without a Timeout and without a
+// ResponseHeaderTimeout, so an agent that accepts the connection but never
+// answers would otherwise block the caller forever — stalling orchestrator
+// shutdown, which releases every pooled slot through this storage.
+const consulRequestTimeout = 5 * time.Second
 
 type StorageKV struct {
 	config       Config
@@ -20,6 +28,8 @@ type StorageKV struct {
 	consulClient *consulApi.Client
 	nodeID       string
 	egressProxy  EgressProxy
+	// requestTimeout bounds each individual Consul round trip. Tests shrink it.
+	requestTimeout time.Duration
 }
 
 func (s *StorageKV) getKVKey(slotIdx int) string {
@@ -35,17 +45,48 @@ func NewStorageKV(nodeID string, config Config, egressProxy EgressProxy) (*Stora
 	}
 
 	return &StorageKV{
-		config:       config,
-		slotsSize:    vrtSlotsSize,
-		consulClient: consulClient,
-		nodeID:       nodeID,
-		egressProxy:  egressProxy,
+		config:         config,
+		slotsSize:      vrtSlotsSize,
+		consulClient:   consulClient,
+		nodeID:         nodeID,
+		egressProxy:    egressProxy,
+		requestTimeout: consulRequestTimeout,
 	}, nil
 }
 
-func newConsulClient(token string) (*consulApi.Client, error) {
+// opContext bounds a single Consul round trip so no individual call can hang,
+// even when the caller's context carries no deadline. The caller must cancel.
+func (s *StorageKV) opContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, s.requestTimeout)
+}
+
+// newConsulConfig builds the Consul client configuration with an explicit
+// overall HTTP timeout, which consulApi.DefaultConfig() does not set.
+func newConsulConfig(token string) (*consulApi.Config, error) {
 	config := consulApi.DefaultConfig()
 	config.Token = token
+
+	// Build the same client consulApi.NewClient would have built, but with an
+	// explicit Timeout. Every call site below already bounds itself with a
+	// per-operation context; this is the backstop so a call added later without
+	// one cannot go unbounded. Note NewClient replaces this client for
+	// "unix://" addresses, which we never configure.
+	httpClient, err := consulApi.NewHttpClient(config.Transport, config.TLSConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Consul HTTP client: %w", err)
+	}
+
+	httpClient.Timeout = consulRequestTimeout
+	config.HttpClient = httpClient
+
+	return config, nil
+}
+
+func newConsulClient(token string) (*consulApi.Client, error) {
+	config, err := newConsulConfig(token)
+	if err != nil {
+		return nil, err
+	}
 
 	consulClient, err := consulApi.NewClient(config)
 	if err != nil {
@@ -55,16 +96,19 @@ func newConsulClient(token string) (*consulApi.Client, error) {
 	return consulClient, nil
 }
 
-func (s *StorageKV) Acquire(_ context.Context) (*Slot, error) {
+func (s *StorageKV) Acquire(ctx context.Context) (*Slot, error) {
 	kv := s.consulClient.KV()
 
 	var slot *Slot
 
 	trySlot := func(slotIdx int, key string) (*Slot, error) {
+		opCtx, cancel := s.opContext(ctx)
+		defer cancel()
+
 		status, _, err := kv.CAS(&consulApi.KVPair{
 			Key:         key,
 			ModifyIndex: 0,
-		}, nil)
+		}, (&consulApi.WriteOptions{}).WithContext(opCtx))
 		if err != nil {
 			return nil, fmt.Errorf("failed to write to Consul KV: %w", err)
 		}
@@ -77,6 +121,12 @@ func (s *StorageKV) Acquire(_ context.Context) (*Slot, error) {
 	}
 
 	for randomTry := 1; randomTry <= 10; randomTry++ {
+		// Stop retrying as soon as the caller gives up instead of spending the
+		// remaining attempts on doomed round trips.
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("failed to acquire IP slot: %w", err)
+		}
+
 		slotIdx := rand.Intn(s.slotsSize)
 		key := s.getKVKey(slotIdx)
 
@@ -96,12 +146,16 @@ func (s *StorageKV) Acquire(_ context.Context) (*Slot, error) {
 		// This is a fallback for the case when all slots are taken.
 		// There is no Consul lock so it's possible that multiple sandboxes will try to acquire the same slot.
 		// In this case, only one of them will succeed and other will try with different slots.
-		reservedKeys, _, keysErr := kv.Keys(s.nodeID+"/", "", nil)
+		reservedKeys, keysErr := s.reservedKeys(ctx, kv)
 		if keysErr != nil {
 			return nil, fmt.Errorf("failed to read Consul KV: %w", keysErr)
 		}
 
 		for slotIdx := range s.slotsSize {
+			if err := ctx.Err(); err != nil {
+				return nil, fmt.Errorf("failed to acquire IP slot: %w", err)
+			}
+
 			key := s.getKVKey(slotIdx)
 
 			if slices.Contains(reservedKeys, key) {
@@ -128,10 +182,22 @@ func (s *StorageKV) Acquire(_ context.Context) (*Slot, error) {
 	return slot, nil
 }
 
-func (s *StorageKV) Release(ips *Slot) error {
+// reservedKeys lists the slot keys already taken on this node. It lives in its
+// own function so the per-request context is cancelled as soon as the call
+// returns.
+func (s *StorageKV) reservedKeys(ctx context.Context, kv *consulApi.KV) ([]string, error) {
+	opCtx, cancel := s.opContext(ctx)
+	defer cancel()
+
+	keys, _, err := kv.Keys(s.nodeID+"/", "", (&consulApi.QueryOptions{}).WithContext(opCtx))
+
+	return keys, err
+}
+
+func (s *StorageKV) Release(ctx context.Context, ips *Slot) error {
 	kv := s.consulClient.KV()
 
-	pair, _, err := kv.Get(ips.Key, nil)
+	pair, err := s.slotPair(ctx, kv, ips.Key)
 	if err != nil {
 		return fmt.Errorf("failed to release IPSlot: Failed to read Consul KV: %w", err)
 	}
@@ -140,10 +206,13 @@ func (s *StorageKV) Release(ips *Slot) error {
 		return fmt.Errorf("IP slot %d was already released", ips.Idx)
 	}
 
+	deleteCtx, cancel := s.opContext(ctx)
+	defer cancel()
+
 	status, _, err := kv.DeleteCAS(&consulApi.KVPair{
 		Key:         ips.Key,
 		ModifyIndex: pair.ModifyIndex,
-	}, nil)
+	}, (&consulApi.WriteOptions{}).WithContext(deleteCtx))
 	if err != nil {
 		return fmt.Errorf("failed to release IPSlot: Failed to delete slot from Consul KV: %w", err)
 	}
@@ -153,4 +222,15 @@ func (s *StorageKV) Release(ips *Slot) error {
 	}
 
 	return nil
+}
+
+// slotPair reads the slot's KV entry. Separate function so the per-request
+// context is cancelled before the follow-up delete starts.
+func (s *StorageKV) slotPair(ctx context.Context, kv *consulApi.KV, key string) (*consulApi.KVPair, error) {
+	opCtx, cancel := s.opContext(ctx)
+	defer cancel()
+
+	pair, _, err := kv.Get(key, (&consulApi.QueryOptions{}).WithContext(opCtx))
+
+	return pair, err
 }

--- a/packages/orchestrator/pkg/sandbox/network/storage_kv.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_kv.go
@@ -16,10 +16,9 @@ import (
 )
 
 // consulRequestTimeout bounds a single Consul KV round trip. The Consul API
-// client builds its http.Client without a Timeout and without a
-// ResponseHeaderTimeout, so an agent that accepts the connection but never
-// answers would otherwise block the caller forever — stalling orchestrator
-// shutdown, which releases every pooled slot through this storage.
+// client's http.Client has no timeout of its own, so an agent that accepts
+// the connection but never answers would block callers — including
+// shutdown's slot releases — forever.
 const consulRequestTimeout = 5 * time.Second
 
 type StorageKV struct {
@@ -28,7 +27,7 @@ type StorageKV struct {
 	consulClient *consulApi.Client
 	nodeID       string
 	egressProxy  EgressProxy
-	// requestTimeout bounds each individual Consul round trip. Tests shrink it.
+	// requestTimeout bounds each Consul round trip; tests shrink it.
 	requestTimeout time.Duration
 }
 
@@ -54,23 +53,18 @@ func NewStorageKV(nodeID string, config Config, egressProxy EgressProxy) (*Stora
 	}, nil
 }
 
-// opContext bounds a single Consul round trip so no individual call can hang,
-// even when the caller's context carries no deadline. The caller must cancel.
 func (s *StorageKV) opContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, s.requestTimeout)
 }
 
-// newConsulConfig builds the Consul client configuration with an explicit
-// overall HTTP timeout, which consulApi.DefaultConfig() does not set.
 func newConsulConfig(token string) (*consulApi.Config, error) {
 	config := consulApi.DefaultConfig()
 	config.Token = token
 
-	// Build the same client consulApi.NewClient would have built, but with an
-	// explicit Timeout. Every call site below already bounds itself with a
-	// per-operation context; this is the backstop so a call added later without
-	// one cannot go unbounded. Note NewClient replaces this client for
-	// "unix://" addresses, which we never configure.
+	// The client NewClient would build, plus a Timeout DefaultConfig never
+	// sets — the backstop for any future call that skips a per-operation
+	// context. NewClient replaces this client for "unix://" addresses, which
+	// we never configure.
 	httpClient, err := consulApi.NewHttpClient(config.Transport, config.TLSConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Consul HTTP client: %w", err)
@@ -121,8 +115,6 @@ func (s *StorageKV) Acquire(ctx context.Context) (*Slot, error) {
 	}
 
 	for randomTry := 1; randomTry <= 10; randomTry++ {
-		// Stop retrying as soon as the caller gives up instead of spending the
-		// remaining attempts on doomed round trips.
 		if err := ctx.Err(); err != nil {
 			return nil, fmt.Errorf("failed to acquire IP slot: %w", err)
 		}
@@ -182,9 +174,8 @@ func (s *StorageKV) Acquire(ctx context.Context) (*Slot, error) {
 	return slot, nil
 }
 
-// reservedKeys lists the slot keys already taken on this node. It lives in its
-// own function so the per-request context is cancelled as soon as the call
-// returns.
+// reservedKeys lists the slot keys already taken on this node. Separate
+// function so its per-request context is cancelled on return.
 func (s *StorageKV) reservedKeys(ctx context.Context, kv *consulApi.KV) ([]string, error) {
 	opCtx, cancel := s.opContext(ctx)
 	defer cancel()
@@ -224,8 +215,8 @@ func (s *StorageKV) Release(ctx context.Context, ips *Slot) error {
 	return nil
 }
 
-// slotPair reads the slot's KV entry. Separate function so the per-request
-// context is cancelled before the follow-up delete starts.
+// slotPair reads the slot's KV entry. Separate function so its per-request
+// context is cancelled before the follow-up delete.
 func (s *StorageKV) slotPair(ctx context.Context, kv *consulApi.KV, key string) (*consulApi.KVPair, error) {
 	opCtx, cancel := s.opContext(ctx)
 	defer cancel()

--- a/packages/orchestrator/pkg/sandbox/network/storage_kv_test.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_kv_test.go
@@ -1,0 +1,286 @@
+//go:build linux
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	consulApi "github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hangWatchdog is deliberately far larger than any timeout these tests
+// configure. It makes the tests hang detectors rather than stopwatches: a
+// correct implementation returns in milliseconds, a regression blocks forever.
+const hangWatchdog = 10 * time.Second
+
+// blockingRequestTimeout is the per-request timeout used by tests that must
+// prove the *caller's* context aborted the call. It is longer than
+// hangWatchdog, so if the context were ignored the watchdog would fire first.
+const blockingRequestTimeout = time.Minute
+
+// newBlackHoleConsul starts a server that accepts requests and never answers,
+// standing in for a wedged Consul agent.
+func newBlackHoleConsul(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+
+	// Unblock the handlers before Close, which waits for outstanding requests.
+	t.Cleanup(func() {
+		close(release)
+		srv.Close()
+	})
+
+	return srv
+}
+
+// newTestStorageKV builds a StorageKV talking to addr. The client is
+// constructed directly instead of through NewStorageKV so the tests need no
+// environment variables and stay parallel-safe.
+func newTestStorageKV(t *testing.T, addr string, requestTimeout time.Duration) *StorageKV {
+	t.Helper()
+
+	cfg := consulApi.DefaultConfig()
+	cfg.Address = addr
+
+	client, err := consulApi.NewClient(cfg)
+	require.NoError(t, err)
+
+	return &StorageKV{
+		config:         Config{},
+		slotsSize:      8,
+		consulClient:   client,
+		nodeID:         "node-test",
+		egressProxy:    NoopEgressProxy{},
+		requestTimeout: requestTimeout,
+	}
+}
+
+// runWithin runs fn and fails the test if it does not return before the
+// watchdog fires, which is what an unbounded Consul call looks like.
+func runWithin(t *testing.T, what string, fn func() error) error {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(hangWatchdog):
+		t.Fatalf("%s did not return within %s: it is blocked on the unresponsive Consul agent", what, hangWatchdog)
+
+		return nil
+	}
+}
+
+func TestStorageKV_ReleaseHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	srv := newBlackHoleConsul(t)
+	storage := newTestStorageKV(t, srv.Listener.Addr().String(), blockingRequestTimeout)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := runWithin(t, "Release", func() error {
+		return storage.Release(ctx, &Slot{Key: "node-test/1", Idx: 1})
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestStorageKV_AcquireHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	srv := newBlackHoleConsul(t)
+	storage := newTestStorageKV(t, srv.Listener.Addr().String(), blockingRequestTimeout)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := runWithin(t, "Acquire", func() error {
+		_, acquireErr := storage.Acquire(ctx)
+
+		return acquireErr
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestStorageKV_ReleaseBoundsRequestWithoutDeadline covers the case the
+// shutdown path actually hits: a live context with no deadline of its own. The
+// per-request timeout must still cut the call off.
+func TestStorageKV_ReleaseBoundsRequestWithoutDeadline(t *testing.T) {
+	t.Parallel()
+
+	srv := newBlackHoleConsul(t)
+	storage := newTestStorageKV(t, srv.Listener.Addr().String(), 50*time.Millisecond)
+
+	err := runWithin(t, "Release", func() error {
+		return storage.Release(t.Context(), &Slot{Key: "node-test/1", Idx: 1})
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestStorageKV_AcquireBoundsRequestWithoutDeadline(t *testing.T) {
+	t.Parallel()
+
+	srv := newBlackHoleConsul(t)
+	storage := newTestStorageKV(t, srv.Listener.Addr().String(), 50*time.Millisecond)
+
+	err := runWithin(t, "Acquire", func() error {
+		_, acquireErr := storage.Acquire(t.Context())
+
+		return acquireErr
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// fakeConsul is a minimal Consul KV endpoint: it answers the handful of
+// requests StorageKV makes and records what it saw.
+type fakeConsul struct {
+	mu sync.Mutex
+	// modifyIndex is the index reported for every existing key.
+	modifyIndex uint64
+	// deleted records the cas parameter of every DELETE, keyed by KV key.
+	deleted map[string]string
+	// casPut records the keys a CAS PUT succeeded on.
+	casPut []string
+}
+
+func (f *fakeConsul) deletedCAS(key string) (string, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	cas, ok := f.deleted[key]
+
+	return cas, ok
+}
+
+func (f *fakeConsul) putKeys() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return append([]string(nil), f.casPut...)
+}
+
+func (f *fakeConsul) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	key := r.URL.Path[len("/v1/kv/"):]
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	w.Header().Set("X-Consul-Index", "1")
+	w.Header().Set("X-Consul-LastContact", "0")
+	w.Header().Set("X-Consul-KnownLeader", "true")
+
+	switch r.Method {
+	case http.MethodGet:
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `[{"Key":%q,"CreateIndex":1,"ModifyIndex":%d,"Value":null}]`, key, f.modifyIndex)
+	case http.MethodDelete:
+		f.deleted[key] = r.URL.Query().Get("cas")
+		fmt.Fprint(w, "true")
+	case http.MethodPut:
+		// Slot 0 is not a valid slot index, so refuse it and let Acquire retry.
+		// Ten consecutive draws of the same index are not realistic.
+		if key == "node-test/0" {
+			fmt.Fprint(w, "false")
+
+			return
+		}
+
+		f.casPut = append(f.casPut, key)
+		fmt.Fprint(w, "true")
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func newFakeConsul(t *testing.T, modifyIndex uint64) (*fakeConsul, *httptest.Server) {
+	t.Helper()
+
+	fake := &fakeConsul{modifyIndex: modifyIndex, deleted: make(map[string]string)}
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+
+	return fake, srv
+}
+
+// TestNewConsulConfig_SetsHTTPClientTimeout guards the backstop. Every call
+// site bounds itself with a per-operation context today; the client-level
+// timeout is what keeps a Consul call added later from being unbounded,
+// because consulApi.DefaultConfig() sets neither Timeout nor
+// ResponseHeaderTimeout.
+func TestNewConsulConfig_SetsHTTPClientTimeout(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := newConsulConfig("test-token")
+	require.NoError(t, err)
+	require.NotNil(t, cfg.HttpClient)
+
+	assert.Equal(t, consulRequestTimeout, cfg.HttpClient.Timeout)
+	assert.Equal(t, "test-token", cfg.Token)
+}
+
+// TestStorageKV_ReleaseAgainstRespondingConsul guards the normal path: the
+// context plumbing must not break a release that should succeed, and the
+// DeleteCAS must carry the ModifyIndex read by the preceding Get.
+func TestStorageKV_ReleaseAgainstRespondingConsul(t *testing.T) {
+	t.Parallel()
+
+	fake, srv := newFakeConsul(t, 42)
+	storage := newTestStorageKV(t, srv.Listener.Addr().String(), blockingRequestTimeout)
+
+	err := runWithin(t, "Release", func() error {
+		return storage.Release(t.Context(), &Slot{Key: "node-test/1", Idx: 1})
+	})
+	require.NoError(t, err)
+
+	cas, ok := fake.deletedCAS("node-test/1")
+	require.True(t, ok, "Release must delete the slot key from Consul KV")
+	assert.Equal(t, "42", cas, "DeleteCAS must use the ModifyIndex returned by the preceding Get")
+}
+
+// TestStorageKV_AcquireAgainstRespondingConsul is the Acquire counterpart: the
+// WriteOptions context must not break a CAS that should succeed.
+func TestStorageKV_AcquireAgainstRespondingConsul(t *testing.T) {
+	t.Parallel()
+
+	fake, srv := newFakeConsul(t, 0)
+	storage := newTestStorageKV(t, srv.Listener.Addr().String(), blockingRequestTimeout)
+
+	var slot *Slot
+	err := runWithin(t, "Acquire", func() error {
+		var acquireErr error
+		slot, acquireErr = storage.Acquire(t.Context())
+
+		return acquireErr
+	})
+	require.NoError(t, err)
+	require.NotNil(t, slot)
+
+	assert.Contains(t, fake.putKeys(), slot.Key, "Acquire must CAS the key it hands back")
+	assert.Equal(t, fmt.Sprintf("node-test/%d", slot.Idx), slot.Key)
+}

--- a/packages/orchestrator/pkg/sandbox/network/storage_kv_test.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_kv_test.go
@@ -48,9 +48,8 @@ func newBlackHoleConsul(t *testing.T) *httptest.Server {
 	return srv
 }
 
-// newTestStorageKV builds a StorageKV talking to addr. The client is
-// constructed directly instead of through NewStorageKV so the tests need no
-// environment variables and stay parallel-safe.
+// newTestStorageKV builds a StorageKV talking to addr, bypassing NewStorageKV
+// so the tests need no environment variables and stay parallel-safe.
 func newTestStorageKV(t *testing.T, addr string, requestTimeout time.Duration) *StorageKV {
 	t.Helper()
 
@@ -228,11 +227,8 @@ func newFakeConsul(t *testing.T, modifyIndex uint64) (*fakeConsul, *httptest.Ser
 	return fake, srv
 }
 
-// TestNewConsulConfig_SetsHTTPClientTimeout guards the backstop. Every call
-// site bounds itself with a per-operation context today; the client-level
-// timeout is what keeps a Consul call added later from being unbounded,
-// because consulApi.DefaultConfig() sets neither Timeout nor
-// ResponseHeaderTimeout.
+// TestNewConsulConfig_SetsHTTPClientTimeout guards the client-level backstop
+// for any future Consul call that skips a per-operation context.
 func TestNewConsulConfig_SetsHTTPClientTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -245,8 +241,7 @@ func TestNewConsulConfig_SetsHTTPClientTimeout(t *testing.T) {
 }
 
 // TestStorageKV_ReleaseAgainstRespondingConsul guards the normal path: the
-// context plumbing must not break a release that should succeed, and the
-// DeleteCAS must carry the ModifyIndex read by the preceding Get.
+// context plumbing must not break a release that should succeed.
 func TestStorageKV_ReleaseAgainstRespondingConsul(t *testing.T) {
 	t.Parallel()
 
@@ -263,8 +258,6 @@ func TestStorageKV_ReleaseAgainstRespondingConsul(t *testing.T) {
 	assert.Equal(t, "42", cas, "DeleteCAS must use the ModifyIndex returned by the preceding Get")
 }
 
-// TestStorageKV_AcquireAgainstRespondingConsul is the Acquire counterpart: the
-// WriteOptions context must not break a CAS that should succeed.
 func TestStorageKV_AcquireAgainstRespondingConsul(t *testing.T) {
 	t.Parallel()
 

--- a/packages/orchestrator/pkg/sandbox/network/storage_local.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_local.go
@@ -109,7 +109,7 @@ func (s *StorageLocal) Acquire(ctx context.Context) (*Slot, error) {
 	}
 }
 
-func (s *StorageLocal) Release(ips *Slot) error {
+func (s *StorageLocal) Release(_ context.Context, ips *Slot) error {
 	s.acquiredNsMu.Lock()
 	defer s.acquiredNsMu.Unlock()
 

--- a/packages/orchestrator/pkg/sandbox/network/storage_memory.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_memory.go
@@ -45,7 +45,7 @@ func (s *StorageMemory) Acquire(_ context.Context) (*Slot, error) {
 	return nil, errors.New("failed to acquire IP slot: no empty slots found")
 }
 
-func (s *StorageMemory) Release(ips *Slot) error {
+func (s *StorageMemory) Release(_ context.Context, ips *Slot) error {
 	s.freeSlotsMu.Lock()
 	defer s.freeSlotsMu.Unlock()
 


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-981/networkstoragekvrelease-makes-unbounded-consul-calls-without-context

**Broken:** a wedged Consul agent (accepts TCP, never answers) stalls orchestrator shutdown indefinitely — `Pool.Close` drains every pooled slot through `Storage.Release`, and since `FORCE_STOP` cancels the shutdown context up-front, even a forced stop couldn't cut the calls short.

**Root cause:** `Storage.Release` took no context, `StorageKV.Acquire` named its context `_`, all four Consul KV calls passed nil options, and `consul/api` builds its `http.Client` with no `Timeout` or `ResponseHeaderTimeout` — nothing bounded the round trip.

**Repro:** against a black-hole HTTP server on unmodified main: `Release` still blocked after 5 s, `Release` with an already-cancelled context still blocked, `Acquire(cancelledCtx)` still blocked.

**Fix:** `Release` takes a context, both methods plumb it through Consul `Query`/`WriteOptions`, every round trip gets a 5 s per-request timeout, the client gets an `http.Client.Timeout` backstop for future call sites, and `Acquire` checks cancellation between retries. `Pool.Close` detaches its drain from the caller's context and caps it at 15 s instead of passing a possibly-cancelled context through — the template-manager is the orchestrator binary with `FORCE_STOP=true` and a Consul-backed pool, so passing the cancelled context would skip releasing up to 131 node-scoped keys per deploy that nothing reclaims (`ReclaimLeakedSlots` only handles netns entries). 15 s sits inside the shared 1 m `kill_timeout` (~26 closers, leaves 45 s); a healthy drain finishes well under a second, so the cap only bites when Consul is unresponsive.

**Alternative considered:** #3515 fixes the same ticket without changing the `Storage` interface (`context.Background()` + 10 s inside `Release`, plus the same client timeout) — avoids the key leak but leaves the drain stall: `Release` is uncancellable and the drain is serial, so a wedged agent costs up to 131 x 10 s (~22 min), far past the 1 m `kill_timeout` — the exact symptom EN-981 reports. This PR threads the context and bounds the whole drain once, getting both properties.

**Verification:** new `storage_kv_test.go` covers cancelled-context, per-request timeout, client backstop, and happy paths against a fake Consul (it doesn't compile against main — the missing context parameter is the bug). `TestClose_ReleasesPooledSlotsWithCanceledContext` asserts `Storage.Release` gets a live context during forced shutdown and fails against the interface-only version. `go build`, `go vet`, `go test -race`, golangci-lint v2.11.4 all clean.
