### PR TITLE
fix(aws): stop s3fs caching missing FC/kernel/envd objects

### DIFF
--- a/iac/provider-aws/modules/nodepool-client/scripts/start-client.sh
+++ b/iac/provider-aws/modules/nodepool-client/scripts/start-client.sh
@@ -75,24 +75,32 @@ modprobe nbd nbds_max=4096
 mkdir -p /fc-vm
 
 # Mount envd buckets
+#
+# disable_noobj_cache: s3fs caches "this object does not exist" answers for
+# stat_cache_expire (900s by default). These buckets are written out-of-band -
+# a new Firecracker/kernel/envd version is uploaded after a host has already
+# looked for it - so a cached miss makes the freshly uploaded object invisible
+# on that host until the entry expires or the mount is recreated.
+# Note that "enable_noobj_cache" is the s3fs default, so passing it was a no-op;
+# "disable_noobj_cache" is the option that actually turns the negative cache off.
 envd_dir="/fc-envd"
 mkdir -p $envd_dir
-s3fs "${FC_ENV_PIPELINE_BUCKET_NAME}" "$envd_dir" -o allow_other -o umask=000 -o nonempty -o iam_role -o enable_noobj_cache
+s3fs "${FC_ENV_PIPELINE_BUCKET_NAME}" "$envd_dir" -o allow_other -o umask=000 -o nonempty -o iam_role -o disable_noobj_cache
 
 # Mount kernels
 kernels_dir="/fc-kernels"
 mkdir -p $kernels_dir
-s3fs "${FC_KERNELS_BUCKET_NAME}" "$kernels_dir" -o allow_other -o umask=000 -o nonempty -o iam_role -o enable_noobj_cache
+s3fs "${FC_KERNELS_BUCKET_NAME}" "$kernels_dir" -o allow_other -o umask=000 -o nonempty -o iam_role -o disable_noobj_cache
 
 # Mount FC versions
 fc_versions_dir="/fc-versions"
 mkdir -p $fc_versions_dir
-s3fs "${FC_VERSIONS_BUCKET_NAME}" "$fc_versions_dir" -o allow_other -o umask=000 -o nonempty -o iam_role -o enable_noobj_cache
+s3fs "${FC_VERSIONS_BUCKET_NAME}" "$fc_versions_dir" -o allow_other -o umask=000 -o nonempty -o iam_role -o disable_noobj_cache
 
 # Mount busybox
 busybox_dir="/fc-busybox"
 mkdir -p $busybox_dir
-s3fs "${FC_BUSYBOX_BUCKET_NAME}" "$busybox_dir" -o allow_other -o umask=000 -o nonempty -o iam_role -o enable_noobj_cache
+s3fs "${FC_BUSYBOX_BUCKET_NAME}" "$busybox_dir" -o allow_other -o umask=000 -o nonempty -o iam_role -o disable_noobj_cache
 
 # These variables are passed in via Terraform template interpolation
 aws s3 cp "s3://${SCRIPTS_BUCKET}/run-consul-${RUN_CONSUL_FILE_HASH}.sh" /opt/consul/bin/run-consul.sh

--- a/iac/provider-aws/modules/nodepool-client/scripts/start-client.sh
+++ b/iac/provider-aws/modules/nodepool-client/scripts/start-client.sh
@@ -75,14 +75,8 @@ modprobe nbd nbds_max=4096
 mkdir -p /fc-vm
 
 # Mount envd buckets
-#
-# disable_noobj_cache: s3fs caches "this object does not exist" answers for
-# stat_cache_expire (900s by default). These buckets are written out-of-band -
-# a new Firecracker/kernel/envd version is uploaded after a host has already
-# looked for it - so a cached miss makes the freshly uploaded object invisible
-# on that host until the entry expires or the mount is recreated.
-# Note that "enable_noobj_cache" is the s3fs default, so passing it was a no-op;
-# "disable_noobj_cache" is the option that actually turns the negative cache off.
+# disable_noobj_cache: s3fs caches negative lookups for stat_cache_expire (900s
+# default), hiding freshly uploaded envd/kernel/FC versions until the entry expires.
 envd_dir="/fc-envd"
 mkdir -p $envd_dir
 s3fs "${FC_ENV_PIPELINE_BUCKET_NAME}" "$envd_dir" -o allow_other -o umask=000 -o nonempty -o iam_role -o disable_noobj_cache


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-386

**Broken:** on AWS BYOC hosts, an FC version (or kernel/envd build) uploaded to S3 after a host had already tried to read it stayed invisible on that host — sandboxes kept failing; only known workaround was unmount → clean dir → remount.

**Root cause:** all four s3fs mounts in `start-client.sh` pass `-o enable_noobj_cache`, which is a no-op — negative ("does not exist") caching is the s3fs default and the real toggle is `-o disable_noobj_cache`. Every missed lookup is remembered for `stat_cache_expire` (default 900 s), and these buckets are written out-of-band, so a cached miss outlives the upload by up to 15 minutes.

**Fix:** replace (not append — later flag wins) `enable_noobj_cache` with `disable_noobj_cache` on the four mounts.

**Repro (MinIO + s3fs 1.93, the Ubuntu 24.04 base-AMI version, exact production flags):** miss → upload → read: production flags not found for >100 s; flag removed, identical (confirms the no-op); `stat_cache_expire=20` visible after ~40 s (confirms the expiry is the bound); `disable_noobj_cache` visible after ~1 s. With no prior lookup the object is always visible immediately, isolating the negative cache as the cause.

**Verification:** the `disable_noobj_cache` run above is the passing case. `shellcheck -S warning` reports only the pre-existing SC2155 on line 43.
