### PR TITLE
fix(envd): mount sandbox volumes with nolock so file locks don't hang

### DIFF
--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -359,13 +359,8 @@ var nfsOptions = strings.Join([]string{
 	"nfsvers=3",      // nfs proxy is nfs version 3
 	"noacl",          // no reason for acl in the sandbox
 
-	// Handle file locks locally instead of over NLM. The nfs proxy serves no
-	// nlockmgr (program 100021) — the portmapper only advertises nfs (100003)
-	// and mountd (100005), so a GETPORT for nlockmgr answers 0. Without this
-	// the kernel default (local_lock=none) sends every flock/fcntl to NLM,
-	// and "hard" makes it retry that bind forever, so any lock on a volume
-	// wedges in D state. Locks are therefore process-local to one sandbox,
-	// matching volume semantics: there is no cross-sandbox lock coordination.
+	// The nfs proxy serves no nlockmgr, so NLM lock calls wedge forever (D state)
+	// under "hard". Locks are sandbox-local: no cross-sandbox lock coordination.
 	"nolock",
 
 	// disable caching so that pause/resume works correctly

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -359,6 +359,15 @@ var nfsOptions = strings.Join([]string{
 	"nfsvers=3",      // nfs proxy is nfs version 3
 	"noacl",          // no reason for acl in the sandbox
 
+	// Handle file locks locally instead of over NLM. The nfs proxy serves no
+	// nlockmgr (program 100021) — the portmapper only advertises nfs (100003)
+	// and mountd (100005), so a GETPORT for nlockmgr answers 0. Without this
+	// the kernel default (local_lock=none) sends every flock/fcntl to NLM,
+	// and "hard" makes it retry that bind forever, so any lock on a volume
+	// wedges in D state. Locks are therefore process-local to one sandbox,
+	// matching volume semantics: there is no cross-sandbox lock coordination.
+	"nolock",
+
 	// disable caching so that pause/resume works correctly
 	"noac",
 	"lookupcache=none",

--- a/packages/envd/internal/api/init_test.go
+++ b/packages/envd/internal/api/init_test.go
@@ -754,3 +754,29 @@ func TestPostInit_UnauthorizedDoesNotUnfreeze(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	assert.Empty(t, mgr.unfreezeAttempts, "unauthorized /init must not attempt unfreeze")
 }
+
+// The nfs proxy serves no NLM (nlockmgr) program, so volume mounts must resolve
+// locks locally. Without "nolock" the kernel default is local_lock=none, every
+// flock/fcntl is forwarded to NLM, and "hard" makes the client retry the
+// (always failing) nlockmgr port lookup forever — wedging the caller in D state.
+func TestNFSOptionsResolveLocksLocally(t *testing.T) {
+	t.Parallel()
+
+	opts := make(map[string]string, 16)
+	for opt := range strings.SplitSeq(nfsOptions, ",") {
+		name, value, _ := strings.Cut(opt, "=")
+		opts[name] = value
+	}
+
+	_, hasNolock := opts["nolock"]
+	assert.True(t, hasNolock, "nfsOptions must contain nolock, got %q", nfsOptions)
+
+	_, hasLock := opts["lock"]
+	assert.False(t, hasLock, "nfsOptions must not contain lock, got %q", nfsOptions)
+
+	// local_lock is only meaningful when it keeps locks off the wire; "none"
+	// and "posix" both still forward flock or fcntl to NLM.
+	if localLock, ok := opts["local_lock"]; ok {
+		assert.Equal(t, "all", localLock, "local_lock must not re-enable NLM, got %q", nfsOptions)
+	}
+}

--- a/packages/envd/internal/api/init_test.go
+++ b/packages/envd/internal/api/init_test.go
@@ -755,10 +755,8 @@ func TestPostInit_UnauthorizedDoesNotUnfreeze(t *testing.T) {
 	assert.Empty(t, mgr.unfreezeAttempts, "unauthorized /init must not attempt unfreeze")
 }
 
-// The nfs proxy serves no NLM (nlockmgr) program, so volume mounts must resolve
-// locks locally. Without "nolock" the kernel default is local_lock=none, every
-// flock/fcntl is forwarded to NLM, and "hard" makes the client retry the
-// (always failing) nlockmgr port lookup forever — wedging the caller in D state.
+// The nfs proxy serves no NLM, so nfsOptions must keep locks local —
+// otherwise "hard" retries the lock RPCs forever, wedging callers in D state.
 func TestNFSOptionsResolveLocksLocally(t *testing.T) {
 	t.Parallel()
 
@@ -774,8 +772,7 @@ func TestNFSOptionsResolveLocksLocally(t *testing.T) {
 	_, hasLock := opts["lock"]
 	assert.False(t, hasLock, "nfsOptions must not contain lock, got %q", nfsOptions)
 
-	// local_lock is only meaningful when it keeps locks off the wire; "none"
-	// and "posix" both still forward flock or fcntl to NLM.
+	// Only local_lock=all keeps locks off the wire; "none" and "posix" still forward flock or fcntl to NLM.
 	if localLock, ok := opts["local_lock"]; ok {
 		assert.Equal(t, "all", localLock, "local_lock must not re-enable NLM, got %q", nfsOptions)
 	}

--- a/packages/orchestrator/pkg/portmap/server_test.go
+++ b/packages/orchestrator/pkg/portmap/server_test.go
@@ -57,9 +57,8 @@ func TestPortMapServer(t *testing.T) {
 // nlockmgrProg is the RPC program number of the NFSv3 lock manager (NLM).
 const nlockmgrProg = 100021
 
-// The proxy implements no NLM service, so the portmapper has no port to hand
-// out for it and answers 0. envd depends on this: it mounts sandbox volumes
-// with "nolock" precisely because a lock RPC here could never be answered.
+// envd mounts sandbox volumes with "nolock" because this proxy serves no NLM;
+// the portmapper must keep answering 0 for nlockmgr.
 func TestPortMapDoesNotAdvertiseNLM(t *testing.T) {
 	t.Parallel()
 

--- a/packages/orchestrator/pkg/portmap/server_test.go
+++ b/packages/orchestrator/pkg/portmap/server_test.go
@@ -53,3 +53,62 @@ func TestPortMapServer(t *testing.T) {
 	// verify results
 	assert.Equal(t, uint32(fakeNfsPort), uint32(output))
 }
+
+// nlockmgrProg is the RPC program number of the NFSv3 lock manager (NLM).
+const nlockmgrProg = 100021
+
+// The proxy implements no NLM service, so the portmapper has no port to hand
+// out for it and answers 0. envd depends on this: it mounts sandbox volumes
+// with "nolock" precisely because a lock RPC here could never be answered.
+func TestPortMapDoesNotAdvertiseNLM(t *testing.T) {
+	t.Parallel()
+
+	const fakeNfsPort = 19393
+
+	listenConfig := net.ListenConfig{}
+	lis, err := listenConfig.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := lis.Close()
+		assert.NoError(t, err)
+	})
+
+	s := NewPortMap(t.Context())
+	s.RegisterPort(t.Context(), fakeNfsPort)
+	go func() {
+		err := s.Serve(t.Context(), lis)
+		assert.NoError(t, err)
+	}()
+
+	a, err := net.ResolveTCPAddr("tcp", lis.Addr().String())
+	require.NoError(t, err)
+	conn, err := net.DialTCP("tcp", nil, a)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := conn.Close()
+		assert.NoError(t, err)
+	})
+	client := portmap.MakeClient(conn, portmap.PMAP_PROG, portmap.PMAP_VERS)
+
+	cred := portmap.Opaque_auth{Flavor: portmap.AUTH_NONE}
+	vfer := portmap.Opaque_auth{Flavor: portmap.AUTH_NONE}
+
+	getPort := func(t *testing.T, prog, vers uint32) uint32 {
+		t.Helper()
+
+		input := portmap.Mapping{Prog: prog, Vers: vers, Prot: portmap.IPPROTO_TCP}
+
+		var output portmap.Uint32
+		require.NoError(t, client.Call(portmap.PMAPPROC_GETPORT, cred, vfer, &input, &output))
+
+		return uint32(output)
+	}
+
+	// Control: nfs itself is advertised.
+	assert.Equal(t, uint32(fakeNfsPort), getPort(t, nfs.Nfs3Prog, nfs.Nfs3Vers))
+
+	for _, vers := range []uint32{1, 3, 4} {
+		assert.Zero(t, getPort(t, nlockmgrProg, vers),
+			"nlockmgr v%d must not be advertised", vers)
+	}
+}


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-1109/volume-file-locking-hangs-forever-nfsv3-nlm-never-answered

**Broken:** every file lock (`flock`, `fcntl`/`lockf`) on a Volume-backed path hung forever — blocking and non-blocking variants alike. Reads/writes/renames were fine, so `go build`, `cargo`, SQLite and zsh `compinit` silently wedged. Reported by a Volumes private-beta customer.

**Root cause:** volumes come from the orchestrator's userspace NFSv3 proxy, which serves no NLM — the portmapper answers `0` for nlockmgr (100021). The mount string set neither `nolock` nor `local_lock=`, so the kernel default `local_lock=none` forwarded every lock to NLM, and `hard` retried the bind forever.

**Repro:** real Linux NFSv3 client against the real proxy + portmapper (two containers). Before: `flock`/`fcntl`/`lockf`/`sqlite3` all exit 124 (timed out), task in state D at `rpc_wait_bit_killable` via `nfs_flock → nlmclnt_lock → rpc_call_sync`. Same mount + `nolock` (`local_lock=all`): every op exits 0 in ~2 ms, sqlite3 OK.

**Semantics trade-off (please agree explicitly):** `nolock` makes locks process-local to a single sandbox — two sandboxes mounting the same volume lose cross-sandbox `flock`/`fcntl` mutual exclusion. Today that case hangs (loud); after this it silently doesn't coordinate. The ticket accepts this ("acceptable per the existing volumes semantics"), but it is a real behaviour change. Within-sandbox locking still works — verified on the fixed mount: with a lock held, `flock -n` from a second process exits 1 and `flock -x` blocks 2.5 s until release.

**Rollout:** ships with an envd release; no runtime toggle (envd has no config surface), so already-running sandboxes keep the old behaviour until they get the new envd.

**Optional follow-ups (not done here):** make the portmapper return an error for 100021 instead of silently `0` (a recurrence would fail fast, not hang); the go-nfs fork returns `PROC_UNAVAIL` rather than `PROG_UNAVAIL` for unknown programs.
