### PR TITLE
fix(orchestrator): retry a failed sandbox stop instead of caching the failure

### DIFF
--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -314,11 +314,9 @@ type Sandbox struct {
 
 	exit *utils.ErrorOnce
 
-	// stopMu serializes stop attempts; stopped latches once one of them
-	// succeeds. Deliberately not a sync.Once: sync.Once would memoize a failed
-	// stop and every later caller — the priority cleanup hook, the exit-watcher
-	// goroutine, stopSandboxAsync — would get the stale error back without the
-	// kill ever being re-attempted, orphaning the Firecracker process.
+	// stopMu serializes stop attempts; stopped latches only on success.
+	// Deliberately not a sync.Once: that would memoize a failed stop and the
+	// kill would never be re-attempted, orphaning the Firecracker process.
 	stopMu  sync.Mutex
 	stopped bool
 
@@ -1325,12 +1323,9 @@ func (s *Sandbox) Close(ctx context.Context) error {
 	return nil
 }
 
-// Stop kills the sandbox. It is safe to call multiple times and from multiple
-// goroutines: attempts are serialized, and once one succeeds the sandbox stays
-// stopped and later calls are a no-op. A *failed* stop is retried by the next
-// caller — a transient failure (a canceled context, an FC process that outlived
-// its SIGKILL grace, a cgroup that was still populated when the kill budget ran
-// out) must not leave the VM running with nothing left to kill it.
+// Stop kills the sandbox. Safe to call multiple times and from multiple
+// goroutines: attempts are serialized, a success latches so later calls are
+// no-ops, and a failed stop is retried by the next caller.
 func (s *Sandbox) Stop(ctx context.Context) error {
 	return s.latchStop(func() error {
 		return s.doStop(ctx)

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -314,7 +314,13 @@ type Sandbox struct {
 
 	exit *utils.ErrorOnce
 
-	stop utils.Lazy[error]
+	// stopMu serializes stop attempts; stopped latches once one of them
+	// succeeds. Deliberately not a sync.Once: sync.Once would memoize a failed
+	// stop and every later caller — the priority cleanup hook, the exit-watcher
+	// goroutine, stopSandboxAsync — would get the stale error back without the
+	// kill ever being re-attempted, orphaning the Firecracker process.
+	stopMu  sync.Mutex
+	stopped bool
 
 	// startupRecorded guards ALL first-WaitForEnvd recording — the envd-init
 	// duration + uffd.startup.* histograms, the envd-init call counter (in
@@ -1319,12 +1325,36 @@ func (s *Sandbox) Close(ctx context.Context) error {
 	return nil
 }
 
-// Stop kills the sandbox. It is safe to call multiple times; only the first
-// call will actually perform the stop operation.
+// Stop kills the sandbox. It is safe to call multiple times and from multiple
+// goroutines: attempts are serialized, and once one succeeds the sandbox stays
+// stopped and later calls are a no-op. A *failed* stop is retried by the next
+// caller — a transient failure (a canceled context, an FC process that outlived
+// its SIGKILL grace, a cgroup that was still populated when the kill budget ran
+// out) must not leave the VM running with nothing left to kill it.
 func (s *Sandbox) Stop(ctx context.Context) error {
-	return s.stop.GetOrInit(func() error {
+	return s.latchStop(func() error {
 		return s.doStop(ctx)
 	})
+}
+
+// latchStop serializes stop attempts and latches only on success, so a failed
+// stop stays retryable. doStop is idempotent, so re-running it after a partial
+// failure is safe.
+func (s *Sandbox) latchStop(stop func() error) error {
+	s.stopMu.Lock()
+	defer s.stopMu.Unlock()
+
+	if s.stopped {
+		return nil
+	}
+
+	if err := stop(); err != nil {
+		return err
+	}
+
+	s.stopped = true
+
+	return nil
 }
 
 // doStop performs the actual stop operation.

--- a/packages/orchestrator/pkg/sandbox/stop_test.go
+++ b/packages/orchestrator/pkg/sandbox/stop_test.go
@@ -1,0 +1,212 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errStopFailed stands in for the ordinary, transient failures doStop can
+// return: "fc process %d still exists after SIGKILL", "cgroup %s still has
+// processes after cgroup.kill", or a canceled context in the FC-exit wait.
+var errStopFailed = errors.New("stop failed")
+
+// TestSandboxStop_RetriesAfterFailure is a regression test for the orphaned
+// Firecracker leak.
+//
+// Stop used to memoize its result in a utils.Lazy[error], which is backed by
+// sync.Once and therefore caches the *failure* too. Every later caller — the
+// priority cleanup hook, the exit-watcher goroutine, and stopSandboxAsync —
+// then got the stale error back without the kill ever being re-attempted, so a
+// single transient failure permanently orphaned the VM (and, with it, its
+// netns/tap/iptables rules).
+//
+// The latch must close only on success.
+func TestSandboxStop_RetriesAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	sbx := &Sandbox{}
+
+	var calls atomic.Int32
+	stop := func() error {
+		if calls.Add(1) == 1 {
+			return errStopFailed
+		}
+
+		return nil
+	}
+
+	err := sbx.latchStop(stop)
+	require.ErrorIs(t, err, errStopFailed, "first attempt must surface the stop failure")
+	require.EqualValues(t, 1, calls.Load())
+
+	err = sbx.latchStop(stop)
+	require.NoError(t, err, "the retry succeeded, so Stop must report success")
+	require.EqualValues(t, 2, calls.Load(), "a failed stop must be retried, not served from a cached error")
+}
+
+// TestSandboxStop_RetriesEveryFailure checks that the latch stays open across
+// repeated failures and that each attempt returns its own error rather than the
+// first one.
+func TestSandboxStop_RetriesEveryFailure(t *testing.T) {
+	t.Parallel()
+
+	sbx := &Sandbox{}
+
+	var calls atomic.Int32
+	stop := func() error {
+		return fmt.Errorf("attempt %d: %w", calls.Add(1), errStopFailed)
+	}
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		err := sbx.latchStop(stop)
+		require.ErrorIs(t, err, errStopFailed)
+		assert.EqualValues(t, attempt, calls.Load())
+		assert.Contains(t, err.Error(), fmt.Sprintf("attempt %d", attempt), "each attempt must return its own error, not a cached one")
+	}
+}
+
+// TestSandboxStop_NoRetryAfterSuccess checks the other half of the contract:
+// once a stop succeeds the sandbox stays stopped, so repeated Stop calls (the
+// cleanup hook plus the exit watcher both fire on a normal teardown) must not
+// re-run the kill.
+func TestSandboxStop_NoRetryAfterSuccess(t *testing.T) {
+	t.Parallel()
+
+	sbx := &Sandbox{}
+
+	var calls atomic.Int32
+	stop := func() error {
+		calls.Add(1)
+
+		return nil
+	}
+
+	for range 3 {
+		require.NoError(t, sbx.latchStop(stop))
+	}
+
+	require.EqualValues(t, 1, calls.Load(), "a successful stop must latch")
+}
+
+// TestSandboxStop_RetryLatchesAfterSuccess combines both halves: a failure is
+// retried, and the successful retry latches.
+func TestSandboxStop_RetryLatchesAfterSuccess(t *testing.T) {
+	t.Parallel()
+
+	sbx := &Sandbox{}
+
+	var calls atomic.Int32
+	stop := func() error {
+		if calls.Add(1) == 1 {
+			return errStopFailed
+		}
+
+		return nil
+	}
+
+	require.ErrorIs(t, sbx.latchStop(stop), errStopFailed)
+	require.NoError(t, sbx.latchStop(stop))
+	require.NoError(t, sbx.latchStop(stop))
+	require.EqualValues(t, 2, calls.Load(), "the successful retry must latch")
+}
+
+// TestSandboxStop_ConcurrentCallersRunStopOnce checks that concurrent callers
+// are serialized and, on success, the work runs exactly once. Run under -race.
+func TestSandboxStop_ConcurrentCallersRunStopOnce(t *testing.T) {
+	t.Parallel()
+
+	sbx := &Sandbox{}
+
+	var (
+		calls    atomic.Int32
+		inFlight atomic.Int32
+	)
+	stop := func() error {
+		assert.EqualValues(t, 1, inFlight.Add(1), "stop attempts must not overlap")
+		defer inFlight.Add(-1)
+
+		calls.Add(1)
+
+		return nil
+	}
+
+	const callers = 16
+
+	var wg sync.WaitGroup
+
+	start := make(chan struct{})
+
+	for range callers {
+		wg.Go(func() {
+			<-start
+
+			assert.NoError(t, sbx.latchStop(stop))
+		})
+	}
+
+	close(start)
+	wg.Wait()
+
+	require.EqualValues(t, 1, calls.Load(), "concurrent callers must run the stop work once")
+}
+
+// TestSandboxStop_ConcurrentCallersRetryUntilSuccess checks that a failing stop
+// under concurrency is retried by the callers that follow, and stops being
+// retried once one of them succeeds.
+func TestSandboxStop_ConcurrentCallersRetryUntilSuccess(t *testing.T) {
+	t.Parallel()
+
+	sbx := &Sandbox{}
+
+	const failures = 4
+
+	var (
+		calls    atomic.Int32
+		inFlight atomic.Int32
+	)
+	stop := func() error {
+		assert.EqualValues(t, 1, inFlight.Add(1), "stop attempts must not overlap")
+		defer inFlight.Add(-1)
+
+		if calls.Add(1) <= failures {
+			return errStopFailed
+		}
+
+		return nil
+	}
+
+	const callers = 16
+
+	var (
+		wg        sync.WaitGroup
+		successes atomic.Int32
+	)
+
+	start := make(chan struct{})
+
+	for range callers {
+		wg.Go(func() {
+			<-start
+
+			if sbx.latchStop(stop) == nil {
+				successes.Add(1)
+			}
+		})
+	}
+
+	close(start)
+	wg.Wait()
+
+	// The first `failures` callers each retry; the next one succeeds and latches,
+	// so every remaining caller is a no-op that also reports success.
+	require.EqualValues(t, failures+1, calls.Load(), "the stop must be retried until it succeeds, then latch")
+	require.EqualValues(t, callers-failures, successes.Load())
+}

--- a/packages/orchestrator/pkg/sandbox/stop_test.go
+++ b/packages/orchestrator/pkg/sandbox/stop_test.go
@@ -13,22 +13,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// errStopFailed stands in for the ordinary, transient failures doStop can
-// return: "fc process %d still exists after SIGKILL", "cgroup %s still has
-// processes after cgroup.kill", or a canceled context in the FC-exit wait.
+// errStopFailed stands in for the transient failures doStop can return.
 var errStopFailed = errors.New("stop failed")
 
-// TestSandboxStop_RetriesAfterFailure is a regression test for the orphaned
-// Firecracker leak.
-//
-// Stop used to memoize its result in a utils.Lazy[error], which is backed by
-// sync.Once and therefore caches the *failure* too. Every later caller — the
-// priority cleanup hook, the exit-watcher goroutine, and stopSandboxAsync —
-// then got the stale error back without the kill ever being re-attempted, so a
-// single transient failure permanently orphaned the VM (and, with it, its
-// netns/tap/iptables rules).
-//
-// The latch must close only on success.
+// Regression test: Stop used to memoize its result in a utils.Lazy[error]
+// (sync.Once-backed), so a single transient failure was cached forever and the
+// Firecracker VM leaked. A failed stop must stay retryable.
 func TestSandboxStop_RetriesAfterFailure(t *testing.T) {
 	t.Parallel()
 
@@ -52,9 +42,6 @@ func TestSandboxStop_RetriesAfterFailure(t *testing.T) {
 	require.EqualValues(t, 2, calls.Load(), "a failed stop must be retried, not served from a cached error")
 }
 
-// TestSandboxStop_RetriesEveryFailure checks that the latch stays open across
-// repeated failures and that each attempt returns its own error rather than the
-// first one.
 func TestSandboxStop_RetriesEveryFailure(t *testing.T) {
 	t.Parallel()
 
@@ -73,10 +60,6 @@ func TestSandboxStop_RetriesEveryFailure(t *testing.T) {
 	}
 }
 
-// TestSandboxStop_NoRetryAfterSuccess checks the other half of the contract:
-// once a stop succeeds the sandbox stays stopped, so repeated Stop calls (the
-// cleanup hook plus the exit watcher both fire on a normal teardown) must not
-// re-run the kill.
 func TestSandboxStop_NoRetryAfterSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -96,8 +79,6 @@ func TestSandboxStop_NoRetryAfterSuccess(t *testing.T) {
 	require.EqualValues(t, 1, calls.Load(), "a successful stop must latch")
 }
 
-// TestSandboxStop_RetryLatchesAfterSuccess combines both halves: a failure is
-// retried, and the successful retry latches.
 func TestSandboxStop_RetryLatchesAfterSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -118,8 +99,6 @@ func TestSandboxStop_RetryLatchesAfterSuccess(t *testing.T) {
 	require.EqualValues(t, 2, calls.Load(), "the successful retry must latch")
 }
 
-// TestSandboxStop_ConcurrentCallersRunStopOnce checks that concurrent callers
-// are serialized and, on success, the work runs exactly once. Run under -race.
 func TestSandboxStop_ConcurrentCallersRunStopOnce(t *testing.T) {
 	t.Parallel()
 
@@ -158,9 +137,6 @@ func TestSandboxStop_ConcurrentCallersRunStopOnce(t *testing.T) {
 	require.EqualValues(t, 1, calls.Load(), "concurrent callers must run the stop work once")
 }
 
-// TestSandboxStop_ConcurrentCallersRetryUntilSuccess checks that a failing stop
-// under concurrency is retried by the callers that follow, and stops being
-// retried once one of them succeeds.
 func TestSandboxStop_ConcurrentCallersRetryUntilSuccess(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-643/orchestrator-many-orphaned-firecracker-instances-and-leftover

**Broken:** `Sandbox.Stop` memoized its result in `utils.Lazy` (backed by `sync.Once`), so a failure got cached too — every later caller (priority cleanup hook, exit-watcher, `stopSandboxAsync`) received the stale error and never re-attempted the kill. One transient failure permanently orphaned the VM plus its netns/tap/iptables rules. `doStop` has ordinary transient modes: "fc process still exists after SIGKILL", "cgroup still has processes" (2 s budget), canceled ctx in the FC-exit wait.

**Fix:** latch on success only — `sync.Mutex` + `stopped bool` serializes attempts, failure leaves the latch open for the next caller, success makes further calls a no-op. `utils.Lazy` untouched (latch-always is right for a memoized value, wrong for a kill).

**Retry safety, checked step by step:** `Checks.Stop` is mutex-guarded; `Process.Stop` re-checks `Exit.Done()` and tolerates `ErrProcessDone`/`ENOENT`; `CgroupHandle.Kill` is nil/noop/removed-guarded and documented safe twice; memory `Stop` is a `sync.OnceValue` pipe write. No caller retries in a loop — all six are one-shot goroutines or `sync.Once`-guarded `Cleanup.Run`, so no unbounded-retry risk.

**Verification:** six new tests in `pkg/sandbox/stop_test.go` (retry-after-failure, per-attempt error propagation, no-retry-after-success, retry-then-latch, two `-race` overlap tests); four fail against the old latch, all six pass now. `gofmt`, `go vet`, `go build`, `go test -race`, golangci-lint v2.11.4 clean.

**Scope caveats:** this fixes one contributing path — not proven to account for the ~44 strays observed. Left for the reconcile-sweep feature the ticket discusses: (1) `Process.Stop` SIGTERMs only the `unshare` leader while `firecracker` is a non-exec'd descendant, and `createCgroup` degrades to `NoCgroupFD` with only a warning (`Setsid` is set but never used as a `kill(-pgid)` fallback); (2) `Pool.recycle` reissues a network slot without confirming the previous VM exited, so an orphan can still hold the netns/tap/IP; (3) `startupreclaim` sweeps only at orchestrator startup, never periodically.

Note: `utils.Lazy` now has no callers repo-wide — left in place rather than deleted in a bugfix; happy to remove it if preferred.
