### PR TITLE
fix(envd): re-forward a sandbox port that drops out of a single scan

### DIFF
--- a/packages/envd/internal/port/forward.go
+++ b/packages/envd/internal/port/forward.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 
 	"github.com/rs/zerolog"
+	gopsnet "github.com/shirou/gopsutil/v4/net"
 
 	"github.com/e2b-dev/infra/packages/envd/internal/services/cgroups"
 	"github.com/e2b-dev/infra/packages/envd/internal/services/spec/upgrade"
@@ -108,62 +109,84 @@ func (f *Forwarder) StartForwarding(ctx context.Context) {
 				return
 			}
 
-			// Serialize the whole refresh against a concurrent ExportForwards
-			// (live-upgrade). stop/startPortForwarding below are called with the
-			// lock held and must not take it themselves.
-			f.mu.Lock()
-
-			// Now we are going to refresh all ports that are being forwarded in the `ports` map. Maybe add new ones
-			// and maybe remove some.
-
-			// Go through the ports that are currently being forwarded and set all of them
-			// to the `DELETE` state. We don't know yet if they will be there after refresh.
-			for _, v := range f.ports {
-				v.state = PortStateDelete
-			}
-
-			// Let's refresh our map of currently forwarded ports and mark the currently opened ones with the "FORWARD" state.
-			// This will make sure we won't delete them later.
-			for _, p := range procs {
-				key := fmt.Sprintf("%d-%d", p.Pid, p.Laddr.Port)
-
-				// We check if the opened port is in our map of forwarded ports.
-				val, portOk := f.ports[key]
-				if portOk {
-					// Just mark the port as being forwarded so we don't delete it.
-					// The actual socat process that handles forwarding should be running from the last iteration.
-					val.state = PortStateForward
-				} else {
-					f.logger.Debug().
-						Str("ip", p.Laddr.IP).
-						Uint32("port", p.Laddr.Port).
-						Uint32("family", familyToIPVersion(p.Family)).
-						Str("state", p.Status).
-						Msg("Detected new opened port on localhost that is not forwarded")
-
-					// The opened port wasn't in the map so we create a new PortToForward and start forwarding.
-					ptf := &PortToForward{
-						pid:    p.Pid,
-						port:   p.Laddr.Port,
-						state:  PortStateForward,
-						family: familyToIPVersion(p.Family),
-					}
-					f.ports[key] = ptf
-					f.startPortForwarding(ctx, ptf)
-				}
-			}
-
-			// We go through the ports map one more time and stop forwarding all ports
-			// that stayed marked as "DELETE".
-			for _, v := range f.ports {
-				if v.state == PortStateDelete {
-					f.stopPortForwarding(v)
-				}
-			}
-
-			f.mu.Unlock()
+			f.refresh(ctx, procs)
 		}
 	}
+}
+
+// refresh reconciles the forwarded ports with the listening sockets reported by
+// the latest scan.
+func (f *Forwarder) refresh(ctx context.Context, procs []gopsnet.ConnectionStat) {
+	// Serialize the whole refresh against a concurrent ExportForwards
+	// (live-upgrade). stop/startPortForwarding below are called with the
+	// lock held and must not take it themselves.
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Now we are going to refresh all ports that are being forwarded in the `ports` map. Maybe add new ones
+	// and maybe remove some.
+
+	// Go through the ports that are currently being forwarded and set all of them
+	// to the `DELETE` state. We don't know yet if they will be there after refresh.
+	for _, v := range f.ports {
+		v.state = PortStateDelete
+	}
+
+	// Let's refresh our map of currently forwarded ports and mark the currently opened ones with the "FORWARD" state.
+	// This will make sure we won't delete them later.
+	// The actual socat process that handles forwarding is running from the last iteration.
+	for _, p := range procs {
+		if val, portOk := f.ports[forwardKey(p)]; portOk {
+			val.state = PortStateForward
+		}
+	}
+
+	// Stop forwarding all ports that stayed marked as "DELETE" and forget them.
+	// Forgetting is what makes the forwarding recoverable: a retained entry would
+	// be marked "FORWARD" again as soon as the same listener shows up in a later
+	// scan, and because it is already in the map no socat would ever be started
+	// for it again — leaving the port permanently unreachable from outside the
+	// sandbox. Listeners do drop out of individual scans: an app can close and
+	// reopen its socket, and the scanner reports a socket with no pid when it
+	// cannot map the socket's inode to a process.
+	//
+	// This also has to happen before the new forwards are started below, so a
+	// fresh socat never has to contend for a bind address that a socat being
+	// torn down still holds.
+	for key, v := range f.ports {
+		if v.state == PortStateDelete {
+			f.stopPortForwarding(v)
+			delete(f.ports, key)
+		}
+	}
+
+	// Start forwarding the ports that are newly opened.
+	for _, p := range procs {
+		key := forwardKey(p)
+		if _, portOk := f.ports[key]; portOk {
+			continue
+		}
+
+		f.logger.Debug().
+			Str("ip", p.Laddr.IP).
+			Uint32("port", p.Laddr.Port).
+			Uint32("family", familyToIPVersion(p.Family)).
+			Str("state", p.Status).
+			Msg("Detected new opened port on localhost that is not forwarded")
+
+		ptf := &PortToForward{
+			pid:    p.Pid,
+			port:   p.Laddr.Port,
+			state:  PortStateForward,
+			family: familyToIPVersion(p.Family),
+		}
+		f.ports[key] = ptf
+		f.startPortForwarding(ctx, ptf)
+	}
+}
+
+func forwardKey(p gopsnet.ConnectionStat) string {
+	return fmt.Sprintf("%d-%d", p.Pid, p.Laddr.Port)
 }
 
 func (f *Forwarder) startPortForwarding(ctx context.Context, p *PortToForward) {

--- a/packages/envd/internal/port/forward.go
+++ b/packages/envd/internal/port/forward.go
@@ -114,8 +114,7 @@ func (f *Forwarder) StartForwarding(ctx context.Context) {
 	}
 }
 
-// refresh reconciles the forwarded ports with the listening sockets reported by
-// the latest scan.
+// refresh reconciles the forwarded ports with the latest scan's listening sockets.
 func (f *Forwarder) refresh(ctx context.Context, procs []gopsnet.ConnectionStat) {
 	// Serialize the whole refresh against a concurrent ExportForwards
 	// (live-upgrade). stop/startPortForwarding below are called with the
@@ -141,18 +140,12 @@ func (f *Forwarder) refresh(ctx context.Context, procs []gopsnet.ConnectionStat)
 		}
 	}
 
-	// Stop forwarding all ports that stayed marked as "DELETE" and forget them.
-	// Forgetting is what makes the forwarding recoverable: a retained entry would
-	// be marked "FORWARD" again as soon as the same listener shows up in a later
-	// scan, and because it is already in the map no socat would ever be started
-	// for it again — leaving the port permanently unreachable from outside the
-	// sandbox. Listeners do drop out of individual scans: an app can close and
-	// reopen its socket, and the scanner reports a socket with no pid when it
-	// cannot map the socket's inode to a process.
-	//
-	// This also has to happen before the new forwards are started below, so a
-	// fresh socat never has to contend for a bind address that a socat being
-	// torn down still holds.
+	// Torn-down forwards must also leave the map: a retained entry would be
+	// re-marked "FORWARD" by a later scan with no new socat ever started,
+	// leaving the port permanently unreachable. Listeners do drop out of
+	// single scans — a socket closed and reopened, or an inode the scanner
+	// cannot map to a pid. Tearing down before starting new forwards keeps a
+	// fresh socat from contending for a bind address a dying one still holds.
 	for key, v := range f.ports {
 		if v.state == PortStateDelete {
 			f.stopPortForwarding(v)
@@ -160,7 +153,6 @@ func (f *Forwarder) refresh(ctx context.Context, procs []gopsnet.ConnectionStat)
 		}
 	}
 
-	// Start forwarding the ports that are newly opened.
 	for _, p := range procs {
 		key := forwardKey(p)
 		if _, portOk := f.ports[key]; portOk {

--- a/packages/envd/internal/port/forward_refresh_test.go
+++ b/packages/envd/internal/port/forward_refresh_test.go
@@ -22,10 +22,9 @@ import (
 
 const fakeSocatEnv = "ENVD_PORT_FAKE_SOCAT"
 
-// TestFakeSocatHelperProcess is not a test. The forwarder tests put a `socat`
-// shim on PATH that re-executes this test binary, so the spawned "socat" is a
-// process that really binds the listen address and really holds it until it is
-// killed. That is what makes the forwarding observable end to end.
+// TestFakeSocatHelperProcess is not a test: the socat shim on PATH re-executes
+// this test binary, so the spawned "socat" really binds the listen address and
+// holds it until killed.
 //
 //nolint:paralleltest // helper process, must not run alongside anything
 func TestFakeSocatHelperProcess(t *testing.T) {
@@ -41,8 +40,7 @@ func TestFakeSocatHelperProcess(t *testing.T) {
 	var lc net.ListenConfig
 	l, err := lc.Listen(context.Background(), "tcp", addr)
 	if err != nil {
-		// Address already in use, exactly what a second socat bound to the
-		// same address would do.
+		// Exit nonzero, like a real socat whose address is already in use.
 		os.Exit(1)
 	}
 	defer l.Close()
@@ -156,11 +154,9 @@ func requireForwarded(t *testing.T, port uint32, want bool) {
 	}, 10*time.Second, 25*time.Millisecond, "port %d forwarded=%v, want %v", port, last, want)
 }
 
-// TestForwarderReForwardsPortAfterScanMiss covers a listening socket that drops
-// out of a single scan and comes back under the same pid: an app closing and
-// reopening its socket, or a scan that cannot map the socket's inode to a pid.
-// The forward has to come back, otherwise the app stays unreachable through the
-// proxy for the rest of the sandbox's life even though it is listening.
+// TestForwarderReForwardsPortAfterScanMiss covers a listener that drops out of
+// a single scan and comes back under the same pid: a socket closed and
+// reopened, or a scan that could not map the socket's inode to a pid.
 //
 //nolint:paralleltest // newRefreshTestForwarder uses t.Setenv
 func TestForwarderReForwardsPortAfterScanMiss(t *testing.T) {
@@ -170,19 +166,17 @@ func TestForwarderReForwardsPortAfterScanMiss(t *testing.T) {
 	f.refresh(t.Context(), []gopsnet.ConnectionStat{listening(100, port)})
 	requireForwarded(t, port, true)
 
-	// The listener drops out of one scan and the forward is torn down.
+	// The listener drops out of one scan.
 	f.refresh(t.Context(), nil)
 	requireForwarded(t, port, false)
 	assert.Empty(t, f.ports, "a torn down forward must not stay in the ports map")
 
-	// The next scan reports it again.
 	f.refresh(t.Context(), []gopsnet.ConnectionStat{listening(100, port)})
 	requireForwarded(t, port, true)
 }
 
 // TestForwarderReplacesForwardWhenListenerPidChanges covers an app restarting
-// inside the sandbox: same port, new pid. The port has to keep being forwarded
-// and the previous listener must not be left behind in the ports map.
+// inside the sandbox: same port, new pid.
 //
 //nolint:paralleltest // newRefreshTestForwarder uses t.Setenv
 func TestForwarderReplacesForwardWhenListenerPidChanges(t *testing.T) {

--- a/packages/envd/internal/port/forward_refresh_test.go
+++ b/packages/envd/internal/port/forward_refresh_test.go
@@ -1,0 +1,203 @@
+package port
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	gopsnet "github.com/shirou/gopsutil/v4/net"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/envd/internal/services/cgroups"
+)
+
+const fakeSocatEnv = "ENVD_PORT_FAKE_SOCAT"
+
+// TestFakeSocatHelperProcess is not a test. The forwarder tests put a `socat`
+// shim on PATH that re-executes this test binary, so the spawned "socat" is a
+// process that really binds the listen address and really holds it until it is
+// killed. That is what makes the forwarding observable end to end.
+//
+//nolint:paralleltest // helper process, must not run alongside anything
+func TestFakeSocatHelperProcess(t *testing.T) {
+	if os.Getenv(fakeSocatEnv) != "1" {
+		t.Skip("helper process, only runs through the socat shim")
+	}
+
+	addr, ok := parseFakeSocatListen(os.Args)
+	if !ok {
+		os.Exit(2)
+	}
+
+	var lc net.ListenConfig
+	l, err := lc.Listen(context.Background(), "tcp", addr)
+	if err != nil {
+		// Address already in use, exactly what a second socat bound to the
+		// same address would do.
+		os.Exit(1)
+	}
+	defer l.Close()
+
+	// Hold the address until the forwarder kills us.
+	time.Sleep(time.Hour)
+}
+
+// parseFakeSocatListen extracts host:port out of a socat listen spec such as
+// "TCP4-LISTEN:4000,bind=127.0.0.1,reuseaddr,fork".
+func parseFakeSocatListen(args []string) (string, bool) {
+	for _, a := range args {
+		spec, found := strings.CutPrefix(a, "TCP4-LISTEN:")
+		if !found {
+			continue
+		}
+
+		parts := strings.Split(spec, ",")
+
+		var host string
+		for _, opt := range parts[1:] {
+			if bind, isBind := strings.CutPrefix(opt, "bind="); isBind {
+				host = bind
+			}
+		}
+
+		return net.JoinHostPort(host, parts[0]), true
+	}
+
+	return "", false
+}
+
+// newRefreshTestForwarder builds a forwarder whose socat is the shim above and
+// whose forwarded address is loopback, so the shim can bind it for real.
+func newRefreshTestForwarder(t *testing.T) *Forwarder {
+	t.Helper()
+
+	self, err := os.Executable()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	shim := fmt.Sprintf("#!/bin/sh\nexec %q -test.run='^TestFakeSocatHelperProcess$' -- \"$@\"\n", self)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "socat"), []byte(shim), 0o755))
+
+	t.Setenv(fakeSocatEnv, "1")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	l := zerolog.Nop()
+	f := &Forwarder{
+		logger:        &l,
+		ports:         make(map[string]*PortToForward),
+		cgroupManager: cgroups.NewNoopManager(),
+		sourceIP:      net.IPv4(127, 0, 0, 1),
+	}
+
+	t.Cleanup(func() {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+
+		for _, p := range f.ports {
+			if pid := p.socatPID(); pid > 0 {
+				_ = syscall.Kill(-pid, syscall.SIGKILL)
+			}
+		}
+	})
+
+	return f
+}
+
+// freePort returns a port that is unused at the time of the call.
+func freePort(t *testing.T) uint32 {
+	t.Helper()
+
+	var lc net.ListenConfig
+	l, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+
+	return uint32(port)
+}
+
+func listening(pid int32, port uint32) gopsnet.ConnectionStat {
+	return gopsnet.ConnectionStat{
+		Family: syscall.AF_INET,
+		Status: "LISTEN",
+		Laddr:  gopsnet.Addr{IP: "127.0.0.1", Port: port},
+		Pid:    pid,
+	}
+}
+
+// requireForwarded waits until the forwarded address is (or is no longer)
+// accepting connections. Spawning the shim is asynchronous, so this polls.
+func requireForwarded(t *testing.T, port uint32, want bool) {
+	t.Helper()
+
+	addr := net.JoinHostPort("127.0.0.1", strconv.FormatUint(uint64(port), 10))
+
+	dialer := net.Dialer{Timeout: 200 * time.Millisecond}
+
+	var last bool
+	require.Eventually(t, func() bool {
+		c, err := dialer.DialContext(t.Context(), "tcp", addr)
+		if c != nil {
+			c.Close()
+		}
+		last = err == nil
+
+		return last == want
+	}, 10*time.Second, 25*time.Millisecond, "port %d forwarded=%v, want %v", port, last, want)
+}
+
+// TestForwarderReForwardsPortAfterScanMiss covers a listening socket that drops
+// out of a single scan and comes back under the same pid: an app closing and
+// reopening its socket, or a scan that cannot map the socket's inode to a pid.
+// The forward has to come back, otherwise the app stays unreachable through the
+// proxy for the rest of the sandbox's life even though it is listening.
+//
+//nolint:paralleltest // newRefreshTestForwarder uses t.Setenv
+func TestForwarderReForwardsPortAfterScanMiss(t *testing.T) {
+	f := newRefreshTestForwarder(t)
+	port := freePort(t)
+
+	f.refresh(t.Context(), []gopsnet.ConnectionStat{listening(100, port)})
+	requireForwarded(t, port, true)
+
+	// The listener drops out of one scan and the forward is torn down.
+	f.refresh(t.Context(), nil)
+	requireForwarded(t, port, false)
+	assert.Empty(t, f.ports, "a torn down forward must not stay in the ports map")
+
+	// The next scan reports it again.
+	f.refresh(t.Context(), []gopsnet.ConnectionStat{listening(100, port)})
+	requireForwarded(t, port, true)
+}
+
+// TestForwarderReplacesForwardWhenListenerPidChanges covers an app restarting
+// inside the sandbox: same port, new pid. The port has to keep being forwarded
+// and the previous listener must not be left behind in the ports map.
+//
+//nolint:paralleltest // newRefreshTestForwarder uses t.Setenv
+func TestForwarderReplacesForwardWhenListenerPidChanges(t *testing.T) {
+	f := newRefreshTestForwarder(t)
+	port := freePort(t)
+
+	f.refresh(t.Context(), []gopsnet.ConnectionStat{listening(100, port)})
+	requireForwarded(t, port, true)
+
+	f.refresh(t.Context(), []gopsnet.ConnectionStat{listening(200, port)})
+	requireForwarded(t, port, true)
+
+	// Steady state after the restart.
+	f.refresh(t.Context(), []gopsnet.ConnectionStat{listening(200, port)})
+	requireForwarded(t, port, true)
+
+	assert.Len(t, f.ports, 1, "a single listener must not leave stale entries behind")
+}


### PR DESCRIPTION
Found while investigating https://linear.app/e2b/issue/EN-1127/e2b-client-proxy-is-unstable-for-websockets-and-long-running-requests

**Broken:** a sandbox app listening on a port can become permanently unreachable through the E2B app proxy for the rest of the sandbox's life — the proxy serves the "port closed" page even though the app never stopped listening.

**Root cause:** `Forwarder.StartForwarding` reconciles a `ports` map against each 1 s socket scan; entries missing from a scan get their socat process group killed but are never removed from the map. When the listener reappears, the surviving entry is flipped back to `FORWARD` without ever calling `startPortForwarding` again — the port is dead from then on. The map also grows unbounded (one entry per socket ever observed). Listeners genuinely drop out of single scans: apps close/reopen sockets, and `gopsutil` `net.Connections` reports pid 0 when it can't map a socket's inode to a process, changing the `pid-port` key.

**Fix:** delete stopped entries from the map, and run the stop pass before starting new forwards so a fresh socat never contends for a bind address a dying socat still holds. Reconciliation moved into `Forwarder.refresh` so tests can drive it directly.

**Verification:** `forward_refresh_test.go` drives `refresh` with synthetic scans and a `socat` shim on PATH that really binds the forwarded address, so "is this port forwarded" is a real TCP dial. Before: `port 54544 forwarded=false, want true` after the port reappears, plus the stale map entry left behind; after: both tests pass. `gofmt`, `go vet`, `go test` (+`-race`), golangci-lint 2.11.4 clean on the package.
