### PR TITLE
fix(orchestrator): bound the Consul calls behind network slot acquire and release

### DIFF
--- a/packages/orchestrator/pkg/sandbox/network/storage_kv.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_kv.go
@@ -8,10 +8,25 @@ import (
 	"fmt"
 	"math/rand"
 	"slices"
+	"time"
 
 	consulApi "github.com/hashicorp/consul/api"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
+)
+
+const (
+	// consulRequestTimeout bounds a single Consul HTTP request.
+	// consulApi.DefaultConfig() builds an http.Client with no Timeout, so an
+	// agent that accepts the connection and then goes silent blocks the caller
+	// forever.
+	consulRequestTimeout = 5 * time.Second
+
+	// consulReleaseTimeout bounds a whole slot release (Get + DeleteCAS). It has
+	// to stay under 2*consulRequestTimeout to bite before the per-request
+	// timeouts do. Pool.Close drains slots serially, so this is the per-slot
+	// cost of an unreachable agent during shutdown - keep it small.
+	consulReleaseTimeout = 10 * time.Second
 )
 
 type StorageKV struct {
@@ -20,6 +35,10 @@ type StorageKV struct {
 	consulClient *consulApi.Client
 	nodeID       string
 	egressProxy  EgressProxy
+
+	// releaseTimeout is the per-release deadline, consulReleaseTimeout outside
+	// of tests.
+	releaseTimeout time.Duration
 }
 
 func (s *StorageKV) getKVKey(slotIdx int) string {
@@ -35,17 +54,40 @@ func NewStorageKV(nodeID string, config Config, egressProxy EgressProxy) (*Stora
 	}
 
 	return &StorageKV{
-		config:       config,
-		slotsSize:    vrtSlotsSize,
-		consulClient: consulClient,
-		nodeID:       nodeID,
-		egressProxy:  egressProxy,
+		config:         config,
+		slotsSize:      vrtSlotsSize,
+		consulClient:   consulClient,
+		nodeID:         nodeID,
+		egressProxy:    egressProxy,
+		releaseTimeout: consulReleaseTimeout,
 	}, nil
 }
 
-func newConsulClient(token string) (*consulApi.Client, error) {
+// newConsulConfig builds the Consul client configuration with an explicit
+// overall HTTP timeout, which consulApi.DefaultConfig() does not set.
+func newConsulConfig(token string) (*consulApi.Config, error) {
 	config := consulApi.DefaultConfig()
 	config.Token = token
+
+	// Build the same client consulApi.NewClient would have built for us, but
+	// with a timeout on it. Note that NewClient replaces this client for
+	// "unix://" addresses; we never configure one.
+	httpClient, err := consulApi.NewHttpClient(config.Transport, config.TLSConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Consul HTTP client: %w", err)
+	}
+
+	httpClient.Timeout = consulRequestTimeout
+	config.HttpClient = httpClient
+
+	return config, nil
+}
+
+func newConsulClient(token string) (*consulApi.Client, error) {
+	config, err := newConsulConfig(token)
+	if err != nil {
+		return nil, err
+	}
 
 	consulClient, err := consulApi.NewClient(config)
 	if err != nil {
@@ -55,7 +97,7 @@ func newConsulClient(token string) (*consulApi.Client, error) {
 	return consulClient, nil
 }
 
-func (s *StorageKV) Acquire(_ context.Context) (*Slot, error) {
+func (s *StorageKV) Acquire(ctx context.Context) (*Slot, error) {
 	kv := s.consulClient.KV()
 
 	var slot *Slot
@@ -64,7 +106,7 @@ func (s *StorageKV) Acquire(_ context.Context) (*Slot, error) {
 		status, _, err := kv.CAS(&consulApi.KVPair{
 			Key:         key,
 			ModifyIndex: 0,
-		}, nil)
+		}, (&consulApi.WriteOptions{}).WithContext(ctx))
 		if err != nil {
 			return nil, fmt.Errorf("failed to write to Consul KV: %w", err)
 		}
@@ -96,12 +138,19 @@ func (s *StorageKV) Acquire(_ context.Context) (*Slot, error) {
 		// This is a fallback for the case when all slots are taken.
 		// There is no Consul lock so it's possible that multiple sandboxes will try to acquire the same slot.
 		// In this case, only one of them will succeed and other will try with different slots.
-		reservedKeys, _, keysErr := kv.Keys(s.nodeID+"/", "", nil)
+		reservedKeys, _, keysErr := kv.Keys(s.nodeID+"/", "", (&consulApi.QueryOptions{}).WithContext(ctx))
 		if keysErr != nil {
 			return nil, fmt.Errorf("failed to read Consul KV: %w", keysErr)
 		}
 
 		for slotIdx := range s.slotsSize {
+			// Slots already in reservedKeys are skipped without a round trip, so
+			// without this check a cancelled context still walks all
+			// vrtSlotsSize entries before it can hit a cancellable CAS.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, fmt.Errorf("failed to acquire IP slot: %w", ctxErr)
+			}
+
 			key := s.getKVKey(slotIdx)
 
 			if slices.Contains(reservedKeys, key) {
@@ -128,10 +177,19 @@ func (s *StorageKV) Acquire(_ context.Context) (*Slot, error) {
 	return slot, nil
 }
 
+// Release deliberately takes no context: it frees a reservation the caller has
+// already finished with, and the callers' contexts are torn down teardown
+// contexts (Pool.Close's drain, and returns that the sandbox cleanup has
+// already run through context.WithoutCancel). Honouring cancellation here would
+// mean skipping the delete and leaking the node-scoped Consul key, which
+// nothing reclaims. Instead the release is unconditional but bounded.
 func (s *StorageKV) Release(ips *Slot) error {
+	releaseCtx, releaseCancel := context.WithTimeout(context.Background(), s.releaseTimeout)
+	defer releaseCancel()
+
 	kv := s.consulClient.KV()
 
-	pair, _, err := kv.Get(ips.Key, nil)
+	pair, _, err := kv.Get(ips.Key, (&consulApi.QueryOptions{}).WithContext(releaseCtx))
 	if err != nil {
 		return fmt.Errorf("failed to release IPSlot: Failed to read Consul KV: %w", err)
 	}
@@ -143,7 +201,7 @@ func (s *StorageKV) Release(ips *Slot) error {
 	status, _, err := kv.DeleteCAS(&consulApi.KVPair{
 		Key:         ips.Key,
 		ModifyIndex: pair.ModifyIndex,
-	}, nil)
+	}, (&consulApi.WriteOptions{}).WithContext(releaseCtx))
 	if err != nil {
 		return fmt.Errorf("failed to release IPSlot: Failed to delete slot from Consul KV: %w", err)
 	}

--- a/packages/orchestrator/pkg/sandbox/network/storage_kv.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_kv.go
@@ -16,16 +16,13 @@ import (
 )
 
 const (
-	// consulRequestTimeout bounds a single Consul HTTP request.
-	// consulApi.DefaultConfig() builds an http.Client with no Timeout, so an
-	// agent that accepts the connection and then goes silent blocks the caller
-	// forever.
+	// consulRequestTimeout bounds a single Consul HTTP request, so an agent
+	// that accepts the connection and then goes silent cannot block forever.
 	consulRequestTimeout = 5 * time.Second
 
-	// consulReleaseTimeout bounds a whole slot release (Get + DeleteCAS). It has
-	// to stay under 2*consulRequestTimeout to bite before the per-request
-	// timeouts do. Pool.Close drains slots serially, so this is the per-slot
-	// cost of an unreachable agent during shutdown - keep it small.
+	// consulReleaseTimeout bounds a whole slot release (Get + DeleteCAS); keep
+	// it <= 2*consulRequestTimeout. Pool.Close drains slots serially, so this
+	// is the per-slot cost of an unreachable agent during shutdown.
 	consulReleaseTimeout = 10 * time.Second
 )
 
@@ -36,8 +33,7 @@ type StorageKV struct {
 	nodeID       string
 	egressProxy  EgressProxy
 
-	// releaseTimeout is the per-release deadline, consulReleaseTimeout outside
-	// of tests.
+	// releaseTimeout is the per-release deadline; consulReleaseTimeout outside tests.
 	releaseTimeout time.Duration
 }
 
@@ -69,9 +65,7 @@ func newConsulConfig(token string) (*consulApi.Config, error) {
 	config := consulApi.DefaultConfig()
 	config.Token = token
 
-	// Build the same client consulApi.NewClient would have built for us, but
-	// with a timeout on it. Note that NewClient replaces this client for
-	// "unix://" addresses; we never configure one.
+	// NewClient replaces HttpClient for "unix://" addresses; we never configure one.
 	httpClient, err := consulApi.NewHttpClient(config.Transport, config.TLSConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Consul HTTP client: %w", err)
@@ -144,9 +138,8 @@ func (s *StorageKV) Acquire(ctx context.Context) (*Slot, error) {
 		}
 
 		for slotIdx := range s.slotsSize {
-			// Slots already in reservedKeys are skipped without a round trip, so
-			// without this check a cancelled context still walks all
-			// vrtSlotsSize entries before it can hit a cancellable CAS.
+			// Reserved slots skip the CAS below, so without this check a
+			// cancelled context still walks every remaining slot.
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return nil, fmt.Errorf("failed to acquire IP slot: %w", ctxErr)
 			}
@@ -177,12 +170,9 @@ func (s *StorageKV) Acquire(ctx context.Context) (*Slot, error) {
 	return slot, nil
 }
 
-// Release deliberately takes no context: it frees a reservation the caller has
-// already finished with, and the callers' contexts are torn down teardown
-// contexts (Pool.Close's drain, and returns that the sandbox cleanup has
-// already run through context.WithoutCancel). Honouring cancellation here would
-// mean skipping the delete and leaking the node-scoped Consul key, which
-// nothing reclaims. Instead the release is unconditional but bounded.
+// Release deliberately takes no context: honouring a caller's cancellation
+// would skip the delete and leak the node-scoped Consul key, which nothing
+// reclaims. The release is unconditional but bounded by releaseTimeout.
 func (s *StorageKV) Release(ips *Slot) error {
 	releaseCtx, releaseCancel := context.WithTimeout(context.Background(), s.releaseTimeout)
 	defer releaseCancel()

--- a/packages/orchestrator/pkg/sandbox/network/storage_kv_test.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_kv_test.go
@@ -1,0 +1,122 @@
+//go:build linux
+
+package network
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	consulApi "github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newWedgedConsul returns a StorageKV talking to a fake agent that accepts
+// requests and never answers them - what a wedged Consul agent looks like on
+// the wire. The returned channel is closed once the agent has seen a request.
+func newWedgedConsul(t *testing.T, releaseTimeout time.Duration) (*StorageKV, <-chan struct{}) {
+	t.Helper()
+
+	gotRequest := make(chan struct{})
+	unblock := make(chan struct{})
+
+	var once sync.Once
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		once.Do(func() { close(gotRequest) })
+
+		select {
+		case <-unblock:
+		case <-r.Context().Done():
+		}
+	}))
+
+	// Let every in-flight handler go before Close, which waits on them.
+	t.Cleanup(func() {
+		close(unblock)
+		srv.Close()
+	})
+
+	config, err := newConsulConfig("test-token")
+	require.NoError(t, err)
+
+	config.Address = srv.Listener.Addr().String()
+
+	client, err := consulApi.NewClient(config)
+	require.NoError(t, err)
+
+	return &StorageKV{
+		slotsSize:      4,
+		consulClient:   client,
+		nodeID:         "test-node",
+		releaseTimeout: releaseTimeout,
+	}, gotRequest
+}
+
+// consulApi.DefaultConfig() hands back an http.Client with no Timeout, so
+// reverting to it would put every Consul call back on an unbounded wait.
+func TestNewConsulConfig_SetsHTTPRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	config, err := newConsulConfig("test-token")
+	require.NoError(t, err)
+	require.NotNil(t, config.HttpClient)
+
+	assert.Positive(t, config.HttpClient.Timeout, "Consul HTTP client must have an overall request timeout")
+	assert.Equal(t, consulRequestTimeout, config.HttpClient.Timeout)
+	assert.Equal(t, "test-token", config.Token)
+}
+
+// Release takes no context by design, so its own deadline is the only thing
+// standing between a wedged agent and a slot return that never completes -
+// which Pool.Close waits on. It must fail, not block.
+func TestStorageKV_ReleaseIsBounded(t *testing.T) {
+	t.Parallel()
+
+	const releaseTimeout = 100 * time.Millisecond
+
+	storage, _ := newWedgedConsul(t, releaseTimeout)
+
+	started := time.Now()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- storage.Release(&Slot{Key: "test-node/1", Idx: 1}) }()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.WithinDuration(t, started.Add(releaseTimeout), time.Now(), time.Second,
+			"Release should give up at about its own deadline")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Release stayed blocked on the wedged agent instead of hitting its own deadline")
+	}
+}
+
+func TestStorageKV_AcquireHonoursContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	storage, gotRequest := newWedgedConsul(t, consulReleaseTimeout)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := storage.Acquire(ctx)
+		errCh <- err
+	}()
+
+	<-gotRequest
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Acquire ignored its context and stayed blocked on the wedged agent")
+	}
+}

--- a/packages/orchestrator/pkg/sandbox/network/storage_kv_test.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_kv_test.go
@@ -15,9 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newWedgedConsul returns a StorageKV talking to a fake agent that accepts
-// requests and never answers them - what a wedged Consul agent looks like on
-// the wire. The returned channel is closed once the agent has seen a request.
+// newWedgedConsul returns a StorageKV backed by a fake Consul agent that
+// accepts requests and never answers. The channel closes on the first request.
 func newWedgedConsul(t *testing.T, releaseTimeout time.Duration) (*StorageKV, <-chan struct{}) {
 	t.Helper()
 
@@ -57,8 +56,6 @@ func newWedgedConsul(t *testing.T, releaseTimeout time.Duration) (*StorageKV, <-
 	}, gotRequest
 }
 
-// consulApi.DefaultConfig() hands back an http.Client with no Timeout, so
-// reverting to it would put every Consul call back on an unbounded wait.
 func TestNewConsulConfig_SetsHTTPRequestTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -71,9 +68,6 @@ func TestNewConsulConfig_SetsHTTPRequestTimeout(t *testing.T) {
 	assert.Equal(t, "test-token", config.Token)
 }
 
-// Release takes no context by design, so its own deadline is the only thing
-// standing between a wedged agent and a slot return that never completes -
-// which Pool.Close waits on. It must fail, not block.
 func TestStorageKV_ReleaseIsBounded(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-981/networkstoragekvrelease-makes-unbounded-consul-calls-without-context

**Broken:** the Consul client behind network-slot allocation comes from `consulApi.DefaultConfig()`, whose `http.Client` has no `Timeout` — an agent that accepts TCP then goes silent blocks forever (dial/TLS timeouts don't help post-connect). `Release` does two such round trips on every slot teardown and `Pool.Close` waits on in-flight returns, so a wedged agent hangs slot returns and stalls the shutdown drain; `Acquire` had the same exposure (up to 10 `kv.CAS` + a `kv.Keys` scan + a 32766-slot fallback loop) while discarding the context it was given.

**Fix (no interface change):** explicit `http.Client.Timeout` on the Consul client — the load-bearing part, capping every call including teardowns that deliberately run on non-cancellable contexts; `Release` gets its own deadline covering both round trips; `Acquire` honours its context (`WithContext` on every query/write plus a `ctx.Err()` bail-out inside the fallback scan, which otherwise walks all 32766 entries without a round trip). Timeouts are modest (5 s per request, 10 s per release) because `Close` drains serially — the release bound is the per-slot cost of an unreachable agent, previously unbounded.

**Deliberate: `Release` still takes no context.** Built the interface-threading version first and backed it out — a cancellable `Release` under `ForceStop` (where `closeCtx` is already cancelled) would fail every drained slot instantly and skip the Consul delete, leaking up to 132 node-scoped KV keys per force-stop that nothing reclaims (`ReclaimLeakedSlots` only scans `/var/run/netns`); on a stable `nodeID` they persist across restarts and eat the slot space. The `createNetworkSlot` rollback would skip its compensating delete for the same reason, and `context.WithoutCancel` strips deadlines too, so threading-but-ignoring is pointless. Happy to flip if you'd rather fast-abort-on-force-stop than key retention.

**Verification:** new `storage_kv_test.go` drives a real `consulApi.Client` against an `httptest` wedged agent (accepts, never answers); three pure unit tests, all pass in a `golang:1.26` linux container. Mutation-proven: reverting the release deadline → `TestStorageKV_ReleaseIsBounded` fails (blocked 5 s); removing the client timeout → config test fails (expected 5s, actual 0s). `gofmt` clean; `GOOS=linux go vet` clean; repo-pinned `golangci-lint` v2.11.4 (`GOOS=linux GOARCH=amd64`) 0 issues.

**Not run locally:** the full `./pkg/sandbox/network/...` suite — two tests need `CAP_SYS_ADMIN` + iptables and the local Docker VM ran out of capacity; the diff is confined to `storage_kv.go` (no other test touches it, interface unchanged) and CI runs the orchestrator shard with sudo. Nothing was verified against a real Consul agent — all Consul-facing tests use the hermetic fake.

**Follow-ups, not done here:** `Pool.Close`'s bare `p.returnsWG.Wait()` means `Close` is now bounded but not interruptible; both drain loops are serial, so worst-case shutdown scales linearly with pooled slots; `NewClient` replaces the HTTP client for `unix://` addresses, which would silently drop the timeout — no `CONSUL_HTTP_ADDR` is configured anywhere in this repo (noted in a comment).
