### PR TITLE
fix(orchestrator): explain why a COPY step could not find its source

### DIFF
--- a/packages/orchestrator/pkg/template/build/commands/copy.go
+++ b/packages/orchestrator/pkg/template/build/commands/copy.go
@@ -151,7 +151,8 @@ func (c *Copy) Execute(
 
 	// Run the move script as root so it can chown files to any user
 	// The script handles both ownership and permissions on the source before moving
-	err = sandboxtools.RunCommandWithLogger(
+	var moveStderr strings.Builder
+	err = sandboxtools.RunCommandWithLoggerAndOutput(
 		ctx,
 		proxy,
 		logger,
@@ -160,12 +161,38 @@ func (c *Copy) Execute(
 		sandboxID,
 		moveScript.String(),
 		cmdMetadata.WithUser("root"),
+		func(_, stderr string) {
+			moveStderr.WriteString(stderr)
+		},
 	)
 	if err != nil {
-		return metadata.Context{}, fmt.Errorf("failed to move files in sandbox: %w", err)
+		return metadata.Context{}, fmt.Errorf(
+			"failed to copy %q to %q in sandbox: %w",
+			args.SourcePath, args.TargetPath, withCommandDiagnostic(err, moveStderr.String()),
+		)
 	}
 
 	return cmdMetadata, nil
+}
+
+// maxCommandDiagnosticLen caps how much of a failing command's stderr is folded
+// into the returned error, so a runaway command cannot flood the build result.
+const maxCommandDiagnosticLen = 512
+
+// withCommandDiagnostic annotates err with what the command printed on stderr.
+// Without it a failing copy surfaces as a bare "exit status 1" with no hint of
+// which path could not be resolved.
+func withCommandDiagnostic(err error, stderr string) error {
+	diagnostic := strings.TrimSpace(stderr)
+	if diagnostic == "" {
+		return err
+	}
+
+	if len(diagnostic) > maxCommandDiagnosticLen {
+		diagnostic = diagnostic[:maxCommandDiagnosticLen] + "..."
+	}
+
+	return fmt.Errorf("%w: %s", err, diagnostic)
 }
 
 func ensureTrailingSlash(s string) string {

--- a/packages/orchestrator/pkg/template/build/commands/copy.go
+++ b/packages/orchestrator/pkg/template/build/commands/copy.go
@@ -175,13 +175,10 @@ func (c *Copy) Execute(
 	return cmdMetadata, nil
 }
 
-// maxCommandDiagnosticLen caps how much of a failing command's stderr is folded
-// into the returned error, so a runaway command cannot flood the build result.
+// maxCommandDiagnosticLen caps how much stderr is quoted into the returned error.
 const maxCommandDiagnosticLen = 512
 
 // withCommandDiagnostic annotates err with what the command printed on stderr.
-// Without it a failing copy surfaces as a bare "exit status 1" with no hint of
-// which path could not be resolved.
 func withCommandDiagnostic(err error, stderr string) error {
 	diagnostic := strings.TrimSpace(stderr)
 	if diagnostic == "" {

--- a/packages/orchestrator/pkg/template/build/commands/copy_script.sh
+++ b/packages/orchestrator/pkg/template/build/commands/copy_script.sh
@@ -15,7 +15,10 @@ if [ -z "${workdir}" ]; then
     # Use the user's home directory
     workdir=$(getent passwd "$user" | cut -d: -f6)
 fi
-cd "$workdir" || exit 1
+if ! cd "$workdir"; then
+    echo "Error: working directory does not exist: $workdir" >&2
+    exit 1
+fi
 
 # Get the parent folder of the source file/folder
 sourceFolder="$(dirname "$sourcePath")"
@@ -28,13 +31,19 @@ else
     targetPath="$(pwd)/$inputPath"
 fi
 
-cd "$sourceFolder" || exit 1
+# A missing parent folder means the source path was never part of the uploaded
+# build context - report it the same way as a missing entry instead of exiting
+# silently, which left the build with a bare "exit status 1".
+if ! cd "$sourceFolder"; then
+    echo "Error: source path does not exist: $sourcePath" >&2
+    exit 1
+fi
 
 # Get the entry (file, directory, or symlink) named by the source path
 entry="$(basename "$sourcePath")"
 
 if [ ! -e "$entry" ] && [ ! -L "$entry" ]; then
-    echo "Error: source path does not exist: $sourcePath"
+    echo "Error: source path does not exist: $sourcePath" >&2
     exit 1
 fi
 
@@ -87,6 +96,6 @@ elif [ -d "$entry" ]; then
     chmod -R u+rwx "$entry"
     rm -rf "$entry"
 else
-    echo "Error: entry is neither file, directory, nor symlink"
+    echo "Error: entry is neither file, directory, nor symlink: $sourcePath" >&2
     exit 1
 fi

--- a/packages/orchestrator/pkg/template/build/commands/copy_script.sh
+++ b/packages/orchestrator/pkg/template/build/commands/copy_script.sh
@@ -31,9 +31,7 @@ else
     targetPath="$(pwd)/$inputPath"
 fi
 
-# A missing parent folder means the source path was never part of the uploaded
-# build context - report it the same way as a missing entry instead of exiting
-# silently, which left the build with a bare "exit status 1".
+# A missing parent folder means the source path was never in the build context
 if ! cd "$sourceFolder"; then
     echo "Error: source path does not exist: $sourcePath" >&2
     exit 1

--- a/packages/orchestrator/pkg/template/build/commands/copy_test.go
+++ b/packages/orchestrator/pkg/template/build/commands/copy_test.go
@@ -871,9 +871,7 @@ func TestCopyScriptBehavior(t *testing.T) { //nolint:paralleltest // no idea why
 		},
 		{
 			// EN-819: an absolute host path is joined onto the unpack directory,
-			// so the synthesized parent folder never exists. The script used to
-			// "cd || exit 1" here without printing anything, leaving the build
-			// with a bare "exit status 1".
+			// so the parent folder itself is missing, not just the entry.
 			name:        "absolute_source_path_outside_context",
 			description: "An absolute source path that is not in the build context reports which path is missing",
 			files: map[string]string{

--- a/packages/orchestrator/pkg/template/build/commands/copy_test.go
+++ b/packages/orchestrator/pkg/template/build/commands/copy_test.go
@@ -870,6 +870,36 @@ func TestCopyScriptBehavior(t *testing.T) { //nolint:paralleltest // no idea why
 			},
 		},
 		{
+			// EN-819: an absolute host path is joined onto the unpack directory,
+			// so the synthesized parent folder never exists. The script used to
+			// "cd || exit 1" here without printing anything, leaving the build
+			// with a bare "exit status 1".
+			name:        "absolute_source_path_outside_context",
+			description: "An absolute source path that is not in the build context reports which path is missing",
+			files: map[string]string{
+				"file.txt": "file",
+			},
+			copyFrom:         "/Users/mish/Documents/Projects/E2B/pathwork/file.txt",
+			copyTo:           "file.txt",
+			shouldSucceed:    false,
+			expectedExitCode: 1,
+			expectedError:    "source path does not exist",
+			absentPaths:      []string{"file.txt"},
+		},
+		{
+			name:        "missing_source_entry_in_existing_folder",
+			description: "A missing entry inside an existing folder still reports the source path",
+			files: map[string]string{
+				"app/main.js": "file",
+			},
+			copyFrom:         "app/missing.js",
+			copyTo:           "out/missing.js",
+			shouldSucceed:    false,
+			expectedExitCode: 1,
+			expectedError:    "source path does not exist",
+			absentPaths:      []string{"out/missing.js"},
+		},
+		{
 			name:        "deeply_nested_folder",
 			description: "Deeply nested folder should be copied correctly",
 			files: map[string]string{
@@ -989,6 +1019,49 @@ func TestCopyScriptBehavior(t *testing.T) { //nolint:paralleltest // no idea why
 					}
 				}
 			}
+		})
+	}
+}
+
+func TestWithCommandDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	baseErr := errors.New("exit status 1")
+
+	tests := []struct {
+		name     string
+		stderr   string
+		expected string
+	}{
+		{
+			name:     "no output leaves the error untouched",
+			stderr:   "",
+			expected: "exit status 1",
+		},
+		{
+			name:     "whitespace only leaves the error untouched",
+			stderr:   "\n  \n",
+			expected: "exit status 1",
+		},
+		{
+			name:     "diagnostic is appended",
+			stderr:   "Error: source path does not exist: /tmp/hash/unpack/Users/mish/file.txt\n",
+			expected: "exit status 1: Error: source path does not exist: /tmp/hash/unpack/Users/mish/file.txt",
+		},
+		{
+			name:     "long output is truncated",
+			stderr:   strings.Repeat("x", maxCommandDiagnosticLen+50),
+			expected: "exit status 1: " + strings.Repeat("x", maxCommandDiagnosticLen) + "...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := withCommandDiagnostic(baseErr, tt.stderr)
+			assert.Equal(t, tt.expected, err.Error())
+			assert.ErrorIs(t, err, baseErr, "the original error must stay unwrappable")
 		})
 	}
 }

--- a/packages/orchestrator/pkg/template/build/sandboxtools/command.go
+++ b/packages/orchestrator/pkg/template/build/sandboxtools/command.go
@@ -93,6 +93,39 @@ func RunCommandWithLogger(
 	)
 }
 
+// RunCommandWithLoggerAndOutput streams the command output to the build logger
+// exactly like RunCommandWithLogger, and additionally hands every chunk to
+// processOutput so the caller can quote the command's own diagnostics in the
+// error it returns. Build logs are emitted at lvl, which is usually too verbose
+// to be shown to the user, so a failing command has no other way to explain
+// itself.
+func RunCommandWithLoggerAndOutput(
+	ctx context.Context,
+	proxy *proxy.SandboxProxy,
+	logger logger.Logger,
+	lvl zapcore.Level,
+	id string,
+	sandboxID string,
+	command string,
+	metadata metadata.Context,
+	processOutput func(stdout, stderr string),
+) error {
+	return runCommandWithAllOptions(
+		ctx,
+		proxy,
+		sandboxID,
+		command,
+		metadata,
+		// No confirmation needed for this command
+		make(chan struct{}),
+		func(stdout, stderr string) {
+			logStream(ctx, logger, lvl, id, "stdout", stdout)
+			logStream(ctx, logger, lvl, id, "stderr", stderr)
+			processOutput(stdout, stderr)
+		},
+	)
+}
+
 func RunCommandWithConfirmation(
 	ctx context.Context,
 	proxy *proxy.SandboxProxy,

--- a/packages/orchestrator/pkg/template/build/sandboxtools/command.go
+++ b/packages/orchestrator/pkg/template/build/sandboxtools/command.go
@@ -93,12 +93,8 @@ func RunCommandWithLogger(
 	)
 }
 
-// RunCommandWithLoggerAndOutput streams the command output to the build logger
-// exactly like RunCommandWithLogger, and additionally hands every chunk to
-// processOutput so the caller can quote the command's own diagnostics in the
-// error it returns. Build logs are emitted at lvl, which is usually too verbose
-// to be shown to the user, so a failing command has no other way to explain
-// itself.
+// RunCommandWithLoggerAndOutput streams output to the build logger like
+// RunCommandWithLogger and additionally hands each chunk to processOutput.
 func RunCommandWithLoggerAndOutput(
 	ctx context.Context,
 	proxy *proxy.SandboxProxy,


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-819

**Broken:** `Template().copy("/Users/mish/.../file.txt", "file.txt")` fails the build with only `failed to move files in sandbox: exit status 1` — no indication of which path was wrong or why.

**Root cause:** the COPY step does `filepath.Join(sbxUnpackPath, args.SourcePath)`, which doesn't special-case an absolute second element, so an absolute host path becomes `/tmp/<hash>/unpack/Users/...` — a folder never in the uploaded tar (the SDK tars relative to the build context). `copy_script.sh` then hits `cd "$sourceFolder" || exit 1`, which exits silently — the friendly "source path does not exist" message lives after that `cd`, unreachable in exactly the case that needs it. Even when the script did print, messages went to stdout and the whole unpack stream logs at Debug, never reaching the build result.

**Fix:** the script reports the missing source when the parent folder is absent, routes errors to stderr, and names the path in the "neither file, directory, nor symlink" case; `RunCommandWithLoggerAndOutput` logs as before and also hands output to the caller; `copy.go` names source/target in the error and appends the script's stderr (capped at 512 chars). Result: `failed to copy "/Users/mish/.../file.txt" to "file.txt" in sandbox: exit status 1: Error: source path does not exist: /tmp/<hash>/unpack/Users/...`.

**Verification:** new `TestCopyScriptBehavior` cases (`absolute_source_path_outside_context`, `missing_source_entry_in_existing_folder`) plus `TestWithCommandDiagnostic`. With the script reverted to main both fail, showing the silent `cd` exit; after, the package passes. `gofmt`, `go vet`, `go build ./...`, `golangci-lint` v2.11.4 (0 issues) clean.

Note: making an absolute source actually work belongs in the SDK, which now rejects non-relative copy sources client-side — this PR makes the server-side failure diagnosable.
