### PR TITLE
fix(orchestrator): wait for detached snapshot uploads before finishing the drain

### DIFF
--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -56,6 +56,18 @@ job "orchestrator-${latest_orchestrator_job_id}" {
     task "start" {
       driver = "raw_exec"
 
+      # The orchestrator drains on SIGTERM: it marks itself draining, waits for
+      # its sandboxes to exit and then for the detached snapshot uploads of the
+      # sandboxes that were paused on the way out. Without an explicit
+      # kill_timeout Nomad SIGKILLs after 5s, which is shorter than the drain's
+      # own 15s status-propagation wait, so the drain never got to run and a
+      # snapshot still uploading was lost. The clients allow up to 24h
+      # (max_kill_timeout in run-nomad.sh); FORCE_STOP=true is the escape hatch
+      # for an immediate stop.
+      # https://developer.hashicorp.com/nomad/docs/configuration/client#max_kill_timeout
+      kill_timeout = "24h"
+      kill_signal  = "SIGTERM"
+
       restart {
         attempts = 0
       }

--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -56,15 +56,11 @@ job "orchestrator-${latest_orchestrator_job_id}" {
     task "start" {
       driver = "raw_exec"
 
-      # The orchestrator drains on SIGTERM: it marks itself draining, waits for
-      # its sandboxes to exit and then for the detached snapshot uploads of the
-      # sandboxes that were paused on the way out. Without an explicit
-      # kill_timeout Nomad SIGKILLs after 5s, which is shorter than the drain's
-      # own 15s status-propagation wait, so the drain never got to run and a
-      # snapshot still uploading was lost. The clients allow up to 24h
-      # (max_kill_timeout in run-nomad.sh); FORCE_STOP=true is the escape hatch
-      # for an immediate stop.
-      # https://developer.hashicorp.com/nomad/docs/configuration/client#max_kill_timeout
+      # SIGTERM starts a drain that waits for sandboxes to exit and for their
+      # detached snapshot uploads to finish; Nomad's default 5s kill_timeout
+      # SIGKILLs mid-drain and loses in-flight snapshots. 24h matches the
+      # clients' max_kill_timeout (run-nomad.sh); FORCE_STOP=true is the
+      # escape hatch for an immediate stop.
       kill_timeout = "24h"
       kill_signal  = "SIGTERM"
 

--- a/packages/orchestrator/pkg/server/drain_test.go
+++ b/packages/orchestrator/pkg/server/drain_test.go
@@ -76,10 +76,8 @@ func TestDrainSandboxesCompletesAfterSandboxLeaves(t *testing.T) {
 	}
 }
 
-// Pausing a sandbox marks it stopping before the snapshot is taken and ends its
-// lifecycle before the upload finishes, so the node looks empty while the last
-// snapshot is still on its way to storage. The drain must not report completion
-// until those detached uploads land.
+// Pause ends a sandbox's lifecycle before its snapshot upload finishes; the
+// drain must not report an empty node until those detached uploads land.
 func TestDrainSandboxesWaitsForInFlightSnapshotUploads(t *testing.T) {
 	t.Parallel()
 
@@ -119,8 +117,7 @@ func TestDrainSandboxesWaitsForUploadStartedByTheLastSandbox(t *testing.T) {
 		done <- s.DrainSandboxes(t.Context())
 	}()
 
-	// Pause of the last sandbox: it leaves the live map and its lifecycle ends,
-	// but the snapshot upload is registered and still running.
+	// Simulate Pause of the last sandbox: lifecycle ends, upload still in flight.
 	s.uploadsInFlight.Add(1)
 	require.True(t, s.sandboxFactory.Sandboxes.MarkStopping(t.Context(), sbx.Runtime.SandboxID, sbx.LifecycleID))
 	s.sandboxFactory.Sandboxes.MarkStopped(t.Context(), sbx)
@@ -146,7 +143,6 @@ func drainTestServer() *Server {
 		sandboxFactory: &sandbox.Factory{
 			Sandboxes: sandbox.NewSandboxesMap(),
 		},
-		// Keep the drain responsive; production polls every 5s.
 		drainPoll: 10 * time.Millisecond,
 	}
 }

--- a/packages/orchestrator/pkg/server/drain_test.go
+++ b/packages/orchestrator/pkg/server/drain_test.go
@@ -76,11 +76,78 @@ func TestDrainSandboxesCompletesAfterSandboxLeaves(t *testing.T) {
 	}
 }
 
+// Pausing a sandbox marks it stopping before the snapshot is taken and ends its
+// lifecycle before the upload finishes, so the node looks empty while the last
+// snapshot is still on its way to storage. The drain must not report completion
+// until those detached uploads land.
+func TestDrainSandboxesWaitsForInFlightSnapshotUploads(t *testing.T) {
+	t.Parallel()
+
+	s := drainTestServer()
+	s.uploadsInFlight.Add(1)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.DrainSandboxes(t.Context())
+	}()
+
+	select {
+	case err := <-done:
+		require.Failf(t, "DrainSandboxes returned while a snapshot upload was in flight", "err: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	s.uploadsInFlight.Add(-1)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("DrainSandboxes did not complete after the snapshot upload finished")
+	}
+}
+
+func TestDrainSandboxesWaitsForUploadStartedByTheLastSandbox(t *testing.T) {
+	t.Parallel()
+
+	s := drainTestServer()
+	sbx := drainTestSandbox(t, "lifecycle-1")
+	s.sandboxFactory.Sandboxes.MarkRunning(t.Context(), sbx)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.DrainSandboxes(t.Context())
+	}()
+
+	// Pause of the last sandbox: it leaves the live map and its lifecycle ends,
+	// but the snapshot upload is registered and still running.
+	s.uploadsInFlight.Add(1)
+	require.True(t, s.sandboxFactory.Sandboxes.MarkStopping(t.Context(), sbx.Runtime.SandboxID, sbx.LifecycleID))
+	s.sandboxFactory.Sandboxes.MarkStopped(t.Context(), sbx)
+
+	select {
+	case err := <-done:
+		require.Failf(t, "DrainSandboxes returned while the last snapshot was uploading", "err: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	s.uploadsInFlight.Add(-1)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("DrainSandboxes did not complete after the snapshot upload finished")
+	}
+}
+
 func drainTestServer() *Server {
 	return &Server{
 		sandboxFactory: &sandbox.Factory{
 			Sandboxes: sandbox.NewSandboxesMap(),
 		},
+		// Keep the drain responsive; production polls every 5s.
+		drainPoll: 10 * time.Millisecond,
 	}
 }
 

--- a/packages/orchestrator/pkg/server/main.go
+++ b/packages/orchestrator/pkg/server/main.go
@@ -93,6 +93,9 @@ type Server struct {
 	uploadsWG       sync.WaitGroup
 	uploadsInFlight atomic.Int64
 
+	// drainPoll overrides sandboxDrainPollInterval. Only set in tests.
+	drainPoll time.Duration
+
 	done      chan struct{}
 	closeOnce sync.Once
 }
@@ -321,24 +324,51 @@ func (s *Server) drainUploads(ctx context.Context, uploadsDone <-chan struct{}) 
 }
 
 // DrainSandboxes waits for the live sandboxes on this node to exit on their own
-// during a graceful shutdown, then waits for their lifecycle cleanup to finish.
-// It does not reject new sandbox starts; that admission gating is layered in
-// separately. It returns ctx.Err() if ctx is cancelled before the node empties.
+// during a graceful shutdown, then waits for their lifecycle cleanup and for any
+// detached snapshot upload to finish. It does not reject new sandbox starts;
+// that admission gating is layered in separately. It returns ctx.Err() if ctx is
+// cancelled before the node empties.
 func (s *Server) DrainSandboxes(ctx context.Context) error {
 	live := s.sandboxFactory.Sandboxes.Count()
 	logger.L().Info(ctx, "starting graceful sandbox drain", zap.Int("live_sandboxes", live))
 
-	ticker := time.NewTicker(sandboxDrainPollInterval)
+	pollInterval := s.drainPoll
+	if pollInterval <= 0 {
+		pollInterval = sandboxDrainPollInterval
+	}
+
+	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 	startedAt := time.Now()
 	lastLoggedAt := startedAt
+	awaitingUploads := false
 
 	for {
 		remaining := s.sandboxFactory.Sandboxes.Count()
 		if remaining == 0 {
-			logger.L().Info(ctx, "graceful sandbox drain complete", zap.Int("live_sandboxes", remaining))
+			if err := s.waitSandboxLifecycles(ctx); err != nil {
+				return err
+			}
 
-			return s.waitSandboxLifecycles(ctx)
+			// Pause detaches the snapshot upload from the sandbox lifecycle: the
+			// sandbox is marked stopping when Pause starts and its lifecycle ends
+			// well before the memfile and rootfs reach storage. Reporting the node
+			// as drained here lets the supervisor terminate the orchestrator while
+			// the last paused sandbox is still uploading, which loses the snapshot.
+			uploads := s.uploadsInFlight.Load()
+			if uploads == 0 {
+				logger.L().Info(ctx, "graceful sandbox drain complete", zap.Int("live_sandboxes", remaining))
+
+				return nil
+			}
+
+			if !awaitingUploads {
+				awaitingUploads = true
+
+				logger.L().Info(ctx, "sandboxes drained, waiting for in-flight snapshot uploads",
+					zap.Int64("uploads", uploads),
+				)
+			}
 		}
 
 		select {

--- a/packages/orchestrator/pkg/server/main.go
+++ b/packages/orchestrator/pkg/server/main.go
@@ -350,11 +350,9 @@ func (s *Server) DrainSandboxes(ctx context.Context) error {
 				return err
 			}
 
-			// Pause detaches the snapshot upload from the sandbox lifecycle: the
-			// sandbox is marked stopping when Pause starts and its lifecycle ends
-			// well before the memfile and rootfs reach storage. Reporting the node
-			// as drained here lets the supervisor terminate the orchestrator while
-			// the last paused sandbox is still uploading, which loses the snapshot.
+			// Pause detaches the snapshot upload from the sandbox lifecycle: the node
+			// looks empty while memfile and rootfs are still uploading. Reporting
+			// drained then lets the supervisor kill the orchestrator mid-upload.
 			uploads := s.uploadsInFlight.Load()
 			if uploads == 0 {
 				logger.L().Info(ctx, "graceful sandbox drain complete", zap.Int("live_sandboxes", remaining))


### PR DESCRIPTION
Linear: https://linear.app/e2b/issue/EN-679

**Broken:** pausing the last sandbox on a draining orchestrator can lose the snapshot — the node declares itself drained and is terminated while the memfile/rootfs are still uploading.

**Root cause, two halves:** (1) the drain check is blind to uploads — `Pause` calls `MarkStopping` at its start and the sandbox lifecycle ends via `Sandbox.Close` during `Pause` itself, while the actual upload is detached into `uploadsWG` (retry budget up to 2 h); `DrainSandboxes` returned once `Sandboxes.Count() == 0` and the lifecycles map emptied — both true while bytes are still in flight — and `uploadsInFlight` was only consulted later in `Server.Close`, after the drain had already reported an empty node. (2) `orchestrator.hcl` set no `kill_timeout`, so Nomad's 5 s default applied — shorter than the drain's own 15 s status-propagation sleep, so the graceful drain added in #3069 never got to run. Every sibling job sets one (client-proxy 24h, ingress 24h, template-manager 70m, api 150s); clients already allow `max_kill_timeout = 24h`.

**Fix:** `DrainSandboxes` keeps polling until live count, lifecycles, and `uploadsInFlight` are all zero (logging the transition once); the orchestrator task gets `kill_timeout = "24h"` / `kill_signal = "SIGTERM"`; `FORCE_STOP=true` remains the immediate-stop escape hatch.

**Verification:** new `TestDrainSandboxesWaitsForInFlightSnapshotUploads` and `TestDrainSandboxesWaitsForUploadStartedByTheLastSandbox` (the latter replays the EN-679 sequence: last sandbox → `MarkStopping` → `MarkStopped` with an upload registered). Both fail with `main.go` reverted ("DrainSandboxes returned while a snapshot upload was in flight"); after, the package passes with `-race`. `gofmt`, `go vet`, `golangci-lint` v2.11.4 (0 issues) clean.

**Reviewer input wanted on the HCL half:** the Go change is unit-verified, but `kill_timeout = "24h"` is a cluster behaviour change I could not exercise — 24h matches client-proxy/ingress, which also wait on user workloads; say the word if you want it bounded nearer the 2 h upload budget.
