### PR TITLE
fix(orchestrator): restore dpkg-owned dirs under /etc/ssl/certs before cert bundle

### DIFF
--- a/packages/orchestrator/pkg/template/build/core/rootfs/files/seed-certs.sh.tpl
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/files/seed-certs.sh.tpl
@@ -18,9 +18,13 @@
 if ! mountpoint -q /etc/ssl/certs; then
     mkdir -p /run/e2b/certs
     if [ -f /usr/local/share/e2b/ssl-certs.tar ]; then
+        # Seed the underlying rootfs directory first so package-owned subdirectories
+        # (e.g. /etc/ssl/certs/java/ from ca-certificates-java) that exist on the
+        # rootfs but are absent from the tar survive the fresh-VM boot. The tar
+        # overlay then takes precedence for any file present in both sources.
+        cp -aL /etc/ssl/certs/. /run/e2b/certs/ 2>/dev/null || true
         if ! tar -C /run/e2b/certs -xf /usr/local/share/e2b/ssl-certs.tar; then
-            echo "e2b-seed-certs: ssl-certs.tar extraction failed; seeding from the live cert dir instead" >&2
-            cp -aL /etc/ssl/certs/. /run/e2b/certs/
+            echo "e2b-seed-certs: ssl-certs.tar extraction failed; running with rootfs-only certs" >&2
         fi
     else
         # Only expected during the base-layer boot, before finalize packs the tar.

--- a/packages/orchestrator/pkg/template/build/phases/finalize/configure.go
+++ b/packages/orchestrator/pkg/template/build/phases/finalize/configure.go
@@ -43,8 +43,42 @@ var ConfigureScriptTemplate = tt.Must(tt.New("provisioning-finish-script").Parse
 // already refreshes the store per family; this step only has to merge CAs that
 // later build layers dropped in, which is a Debian/Alpine convention anyway.
 const packCertBundleCmd = `set -e
+# Restore any package-owned directories under /etc/ssl/certs that exist in
+# dpkg's file database but are absent in this VM's tmpfs. They were originally
+# created by dpkg into a prior build-layer's tmpfs; finalize boots a fresh VM
+# and e2b-seed-certs re-seeds /etc/ssl/certs from ssl-certs.tar, which never
+# contained those subdirectories, so they silently vanish before this step.
+# The canonical case: ca-certificates-java ships /etc/ssl/certs/java/ and its
+# postinst writes cacerts there — if the directory is missing the trigger fails
+# with FileNotFoundException, update-ca-certificates swallows the error, and
+# the package is baked into the snapshot in half-configured (iF) state.
+if command -v dpkg-query >/dev/null 2>&1; then
+	dpkg-query -W -f='${db:Status-Abbrev} ${Package}\n' 2>/dev/null \\
+		| awk '/^.i /{print $2}' \\
+		| while IFS= read -r pkg; do dpkg -L "$pkg" 2>/dev/null; done \\
+		| grep '^/etc/ssl/certs/' \\
+		| sort -u \\
+		| while IFS= read -r path; do
+			[ -e "$path" ] || mkdir -p "$path"
+		  done
+fi
+# Resolve any dpkg triggers still pending now that their required paths exist.
+if command -v dpkg >/dev/null 2>&1; then
+	dpkg --configure -a
+fi
 if command -v update-ca-certificates >/dev/null 2>&1; then
 	update-ca-certificates
+fi
+# Fail the build explicitly if any package is still half-configured (iF).
+# update-ca-certificates swallows hook failures, so without this check a
+# broken dpkg state would be silently baked into the snapshot and every
+# subsequent apt-get inside the sandbox would exit 100.
+if command -v dpkg >/dev/null 2>&1; then
+	broken=$(dpkg -l 2>/dev/null | awk '/^iF /{print $2}' | tr '\n' ' ')
+	if [ -n "$broken" ]; then
+		printf 'e2b cert bundle: broken dpkg packages after configure: %s\n' "$broken" >&2
+		exit 1
+	fi
 fi
 mkdir -p /usr/local/share/e2b
 tar -C /etc/ssl/certs -chf /usr/local/share/e2b/ssl-certs.tar .


### PR DESCRIPTION
Fixes #3518

## What was broken

Any template that installs a JRE (directly or transitively) ships a snapshot where:

-  is missing at sandbox runtime
-  is in **half-configured** () state in the dpkg database

causing every subsequent  inside those sandboxes to exit with code 100.

## Root cause

Three mechanisms interact (full analysis in #3518):

1.  is a tmpfs bind-mount inside the guest — dpkg writes from build layers go there and never reach the NBD-backed rootfs.
2. The finalize phase boots a **fresh VM**;  re-seeds the tmpfs from , which never contained , so the directory silently vanishes.
3.  then runs , which activates 's dpkg trigger. The trigger's  fails with  because  is missing.  **swallows the hook failure** and exits 0 — the build reports success and the  state is baked into the snapshot.

## Fix

** — ** (primary fix):

Before :
1. Walk dpkg's file database and recreate any missing directories under 
2. Run  to resolve pending triggers now that their required paths exist

After :
3. Check for remaining  packages and **fail the build explicitly** — preventing silent broken snapshots going forward

**** (defense in depth):

Seed the tmpfs additively: copy the underlying rootfs directory first, then overlay the tar on top. The tar remains authoritative for cert files; the rootfs copy ensures subdirectories present on the rootfs but absent from an older tar survive the fresh-VM boot.

## Testing

Reproduced the issue (template with ) and confirmed:
- Before:  → ;  → exit 100
- After:  → ;  → exit 0

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi @tomassrnka Looking forward to your code review.