### PR TITLE
fix(azure): add copy-public-builds support for PROVIDER=azure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,19 @@ ifeq ($(PROVIDER),aws)
 	rm -rf ./.kernels
 	rm -rf ./.firecrackers
 	rm -rf ./.busybox
+else ifeq ($(PROVIDER),azure)
+	mkdir -p ./.kernels
+	mkdir -p ./.firecrackers
+	mkdir -p ./.busybox
+	gcloud storage cp -r "gs://e2b-prod-public-builds/kernels/*" ./.kernels/
+	gcloud storage cp -r "gs://e2b-prod-public-builds/firecrackers/*" ./.firecrackers/
+	gcloud storage cp -r "gs://e2b-prod-public-builds/busybox/*" ./.busybox/
+	az storage blob upload-batch --auth-mode login --account-name $(AZURE_STORAGE_ACCOUNT_NAME) --destination fc-kernels --source ./.kernels
+	az storage blob upload-batch --auth-mode login --account-name $(AZURE_STORAGE_ACCOUNT_NAME) --destination fc-versions --source ./.firecrackers
+	az storage blob upload-batch --auth-mode login --account-name $(AZURE_STORAGE_ACCOUNT_NAME) --destination fc-busybox --source ./.busybox
+	rm -rf ./.kernels
+	rm -rf ./.firecrackers
+	rm -rf ./.busybox
 else
 	gsutil cp -r gs://e2b-prod-public-builds/kernels/* gs://$(GCP_BUCKET_PREFIX)fc-kernels/
 	gsutil cp -r gs://e2b-prod-public-builds/firecrackers/* gs://$(GCP_BUCKET_PREFIX)fc-versions/


### PR DESCRIPTION
`make copy-public-builds` only handled `PROVIDER=aws`/gcp; `azure` fell through to the gcp else-branch and built a malformed `gs://-fc-kernels/` path from the unset `GCP_BUCKET_PREFIX`.

Adds the azure arm: download from the same public GCS bucket (`gcloud storage cp` — avoids `gsutil`'s Python version gate), upload via `az storage blob upload-batch --auth-mode login` into the `fc-kernels`/`fc-versions`/`fc-busybox` containers addressed by `AZURE_STORAGE_ACCOUNT_NAME`. Containers are unprefixed, unlike AWS/GCP's per-purpose-prefixed buckets — the BYOC Azure storage account already carries the unique prefix in its own name. The `--auth-mode login` data-plane call works because the BYOC terraform grants the apply runner `Storage Blob Data Contributor` on that account for exactly this flow.

Extracted unchanged from the `2026-06-Azure-PoC` branch, where it has run end-to-end against live Azure BYOC environments. Consumed by e2b-dev/byoc via its submodule pin (companion byoc PR bumps it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)