### PR TITLE
orchestrator/nfsproxy: clean up .nfs* orphan files on sandbox teardown

### DIFF
--- a/packages/orchestrator/pkg/nfsproxy/chroot/nfs.go
+++ b/packages/orchestrator/pkg/nfsproxy/chroot/nfs.go
@@ -7,7 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/go-git/go-billy/v5"
@@ -101,6 +104,8 @@ func (h *NFSHandler) OnNetworkRelease(ctx context.Context, sbx *sandbox.Sandbox)
 	h.mu.Unlock()
 
 	for _, chroot := range chroots {
+		h.removeNFSOrphans(ctx, sbx.Runtime.SandboxID, chroot.Root())
+
 		err := chroot.Close()
 		if err != nil {
 			logger.L().Warn(ctx, "failed to close chroot",
@@ -111,6 +116,46 @@ func (h *NFSHandler) OnNetworkRelease(ctx context.Context, sbx *sandbox.Sandbox)
 			)
 		}
 		h.chrootUnmountsCounter.Add(ctx, 1)
+	}
+}
+
+// removeNFSOrphans removes .nfs* files left by the NFS silly-rename mechanism.
+// When an NFS client deletes a file that still has open fds, it renames the file
+// to .nfsXXXX instead of removing it, and sends a REMOVE only after the last fd
+// is closed. If the client VM is killed before closing its fds, the .nfs* file
+// remains on the server permanently. This function cleans them up at sandbox teardown.
+func (h *NFSHandler) removeNFSOrphans(ctx context.Context, sandboxID, dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logger.L().Warn(ctx, "failed to read volume dir for NFS orphan cleanup",
+				logger.WithSandboxID(sandboxID),
+				zap.String("dir", dir),
+				zap.Error(err),
+			)
+		}
+
+		return
+	}
+
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), ".nfs") {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			logger.L().Warn(ctx, "failed to remove NFS orphan file",
+				logger.WithSandboxID(sandboxID),
+				zap.String("path", path),
+				zap.Error(err),
+			)
+		} else {
+			logger.L().Info(ctx, "removed NFS orphan file",
+				logger.WithSandboxID(sandboxID),
+				zap.String("path", path),
+			)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #3532.

## Problem

When a sandbox VM is forcibly killed while holding open file descriptors on files
inside a persistent volume, the NFS silly-rename mechanism leaves `.nfs*` files
on the NFS server that are never cleaned up, leaking storage indefinitely.

Observed on production: a 5 GiB workspace image from Jul 29 remained as
`.nfs000000019000ee9800000001` — confirmed orphan (no process holds it, confirmed
via `/proc/*/fd`), yet persisted because the final NFS `REMOVE` RPC was never sent.

## Root Cause

NFS silly-rename: when an NFS client deletes a file that is still open locally,
the client kernel sends `RENAME ws_<id>.img → .nfsXXXX` to the server instead of
`REMOVE`, deferring the delete until the last fd is closed. If the VM is killed
before that point, the `REMOVE` never arrives and the `.nfsXXXX` file persists
permanently on the server (same size as the original file, typically several GiB).

`OnNetworkRelease` previously only closed the orchestrator-side chroot with no
cleanup of leftover `.nfs*` files in the volume directory.

## Fix

Add `removeNFSOrphans` called from `OnNetworkRelease` before closing each chroot.
It scans `chroot.Root()` (the actual host-side volume directory) for `.nfs*` files
and removes them. By the time `OnNetworkRelease` fires the sandbox VM is already
dead — all its fds are gone — so orphan files are safe to remove.

## Files Changed

- `packages/orchestrator/pkg/nfsproxy/chroot/nfs.go`


/cc @kalyazin @jakubno @dobrac @ValentaTomas @arkamar @tvi @tomassrnka Looking forward to your code review.