### PR TITLE
fix(envd): require sha256 for upgrade body

### DIFF
--- a/packages/envd/internal/services/process/upgrade_deliver.go
+++ b/packages/envd/internal/services/process/upgrade_deliver.go
@@ -1,0 +1,77 @@
+package process
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+)
+
+// UpgradeSha256Header carries the lowercase hex SHA-256 digest of a non-empty
+// POST /upgrade request body. envd refuses to materialize the body on disk
+// unless this header is present, well-formed, and matches the bytes — a
+// content-integrity check complementary to the authenticated trigger and the
+// fixed-path allowlist on DefaultUpgradeBinPath.
+const UpgradeSha256Header = "X-Envd-Upgrade-Sha256"
+
+var (
+	ErrUpgradeSHA256Missing   = errors.New("missing X-Envd-Upgrade-Sha256 header")
+	ErrUpgradeSHA256Malformed = errors.New("malformed X-Envd-Upgrade-Sha256 header")
+	ErrUpgradeSHA256Mismatch  = errors.New("upgrade body SHA-256 mismatch")
+)
+
+func parseUpgradeSHA256Header(h string) ([]byte, error) {
+	if h == "" {
+		return nil, ErrUpgradeSHA256Missing
+	}
+	if len(h) != hex.EncodedLen(sha256.Size) {
+		return nil, ErrUpgradeSHA256Malformed
+	}
+	for i := 0; i < len(h); i++ {
+		c := h[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return nil, ErrUpgradeSHA256Malformed
+		}
+	}
+	sum, err := hex.DecodeString(h)
+	if err != nil {
+		return nil, ErrUpgradeSHA256Malformed
+	}
+
+	return sum, nil
+}
+
+// WriteUpgradeBinary reads body, verifies it against the lowercase-hex SHA-256
+// in sha256Header, and only then writes the bytes to destPath (mode 0o755).
+// The destination is unlinked first so a chained upgrade (envd already running
+// from destPath) does not hit ETXTBSY on O_TRUNC.
+func WriteUpgradeBinary(destPath, sha256Header string, body io.Reader) error {
+	want, err := parseUpgradeSHA256Header(sha256Header)
+	if err != nil {
+		return err
+	}
+
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	got := sha256.Sum256(data)
+	if subtle.ConstantTimeCompare(got[:], want) != 1 {
+		return ErrUpgradeSHA256Mismatch
+	}
+
+	_ = os.Remove(destPath)
+	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	_, writeErr := f.Write(data)
+	closeErr := f.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+
+	return closeErr
+}

--- a/packages/envd/internal/services/process/upgrade_deliver_test.go
+++ b/packages/envd/internal/services/process/upgrade_deliver_test.go
@@ -1,0 +1,92 @@
+package process
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteUpgradeBinary_RejectsMissingHeader(t *testing.T) {
+	t.Parallel()
+	dest := filepath.Join(t.TempDir(), "envd.next")
+	err := WriteUpgradeBinary(dest, "", bytes.NewReader([]byte("payload")))
+	require.ErrorIs(t, err, ErrUpgradeSHA256Missing)
+	_, statErr := os.Stat(dest)
+	assert.True(t, os.IsNotExist(statErr), "must not write on missing digest")
+}
+
+func TestWriteUpgradeBinary_RejectsMalformedHeader(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		hdr  string
+	}{
+		{"empty-ish garbage", "not-hex"},
+		{"too short", "deadbeef"},
+		{"uppercase", "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"},
+		{"mixed case", "DeadBeefDeadBeefDeadBeefDeadBeefDeadBeefDeadBeefDeadBeefDeadBeef"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dest := filepath.Join(t.TempDir(), "envd.next")
+			err := WriteUpgradeBinary(dest, tc.hdr, bytes.NewReader([]byte("payload")))
+			require.ErrorIs(t, err, ErrUpgradeSHA256Malformed)
+			_, statErr := os.Stat(dest)
+			assert.True(t, os.IsNotExist(statErr), "must not write on malformed digest")
+		})
+	}
+}
+
+func TestWriteUpgradeBinary_RejectsWrongHash(t *testing.T) {
+	t.Parallel()
+	dest := filepath.Join(t.TempDir(), "envd.next")
+	wrong := sha256.Sum256([]byte("other"))
+	err := WriteUpgradeBinary(dest, hex.EncodeToString(wrong[:]), bytes.NewReader([]byte("payload")))
+	require.ErrorIs(t, err, ErrUpgradeSHA256Mismatch)
+	_, statErr := os.Stat(dest)
+	assert.True(t, os.IsNotExist(statErr), "must not write on digest mismatch")
+}
+
+func TestWriteUpgradeBinary_AcceptsCorrectHash(t *testing.T) {
+	t.Parallel()
+	dest := filepath.Join(t.TempDir(), "envd.next")
+	payload := []byte("envd-binary-bytes")
+	sum := sha256.Sum256(payload)
+	err := WriteUpgradeBinary(dest, hex.EncodeToString(sum[:]), bytes.NewReader(payload))
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+
+	fi, err := os.Stat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), fi.Mode().Perm())
+}
+
+func TestWriteUpgradeBinary_ReadErrorSurfaced(t *testing.T) {
+	t.Parallel()
+	dest := filepath.Join(t.TempDir(), "envd.next")
+	sum := sha256.Sum256(nil)
+	err := WriteUpgradeBinary(dest, hex.EncodeToString(sum[:]), errReader{})
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrUpgradeSHA256Missing))
+	assert.False(t, errors.Is(err, ErrUpgradeSHA256Malformed))
+	assert.False(t, errors.Is(err, ErrUpgradeSHA256Mismatch))
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) {
+	return 0, io.ErrUnexpectedEOF
+}

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
@@ -407,27 +407,25 @@ func run() error {
 		// If the new binary is streamed in the request body (the orchestrator's
 		// authenticated host-side delivery), write it to the fixed path before
 		// swapping. This avoids the unauthenticated /files path that fails on a
-		// runtime sandbox.
+		// runtime sandbox. A matching X-Envd-Upgrade-Sha256 is required so the
+		// guest only materializes bytes whose digest the caller attested.
 		if r.ContentLength != 0 {
 			newBin = processRpc.DefaultUpgradeBinPath
-			// On a chained upgrade this envd is itself running from
-			// DefaultUpgradeBinPath, so opening it O_TRUNC would fail with ETXTBSY.
-			// Unlink first: the create then lands on a fresh inode while the
-			// running process keeps executing its now-unlinked image.
-			_ = os.Remove(processRpc.DefaultUpgradeBinPath)
-			f, err := os.OpenFile(processRpc.DefaultUpgradeBinPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+			if err := processRpc.WriteUpgradeBinary(
+				processRpc.DefaultUpgradeBinPath,
+				r.Header.Get(processRpc.UpgradeSha256Header),
+				r.Body,
+			); err != nil {
+				status := http.StatusInternalServerError
+				if errors.Is(err, processRpc.ErrUpgradeSHA256Missing) ||
+					errors.Is(err, processRpc.ErrUpgradeSHA256Malformed) ||
+					errors.Is(err, processRpc.ErrUpgradeSHA256Mismatch) {
+					status = http.StatusBadRequest
+				}
+				http.Error(w, err.Error(), status)
 
 				return
 			}
-			if _, err := io.Copy(f, r.Body); err != nil {
-				f.Close()
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-
-				return
-			}
-			f.Close()
 		}
 		if err := doUpgrade(newBin); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/packages/orchestrator/pkg/sandbox/envd.go
+++ b/packages/orchestrator/pkg/sandbox/envd.go
@@ -5,6 +5,8 @@ package sandbox
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -238,6 +240,14 @@ func (s *Sandbox) CallEnvdUpgrade(ctx context.Context, localSrcPath, guestBinPat
 	}
 	defer f.Close()
 
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, f); err != nil {
+		return false, fmt.Errorf("hash envd source %s: %w", localSrcPath, err)
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return false, fmt.Errorf("rewind envd source %s: %w", localSrcPath, err)
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.envdServerURL()+"/upgrade", f)
 	if err != nil {
 		return false, fmt.Errorf("build upgrade request: %w", err)
@@ -249,6 +259,7 @@ func (s *Sandbox) CallEnvdUpgrade(ctx context.Context, localSrcPath, guestBinPat
 		req.Header.Set("X-Access-Token", *s.Config.Envd.AccessToken)
 	}
 	req.Header.Set("X-Envd-Upgrade-Bin", guestBinPath)
+	req.Header.Set("X-Envd-Upgrade-Sha256", hex.EncodeToString(hasher.Sum(nil)))
 
 	// Reuse the shared transport but drop sandboxHttpClient's short client-level
 	// Timeout (10s) — it would preempt the deliverTimeout ctx above and cut the

--- a/packages/orchestrator/pkg/sandbox/envd_upgrade_test.go
+++ b/packages/orchestrator/pkg/sandbox/envd_upgrade_test.go
@@ -4,13 +4,21 @@ package sandbox
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestIsUpgradeDeliveryFailure guards the distinction CallEnvdUpgrade relies on:
@@ -41,4 +49,51 @@ func TestIsUpgradeDeliveryFailure(t *testing.T) {
 			assert.Equal(t, tt.want, isUpgradeDeliveryFailure(tt.err))
 		})
 	}
+}
+
+func TestCallEnvdUpgrade_SetsBodySHA256Header(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte("fake-envd-binary")
+	wantSum := sha256.Sum256(payload)
+	wantHex := hex.EncodeToString(wantSum[:])
+
+	src := filepath.Join(t.TempDir(), "envd")
+	require.NoError(t, os.WriteFile(src, payload, 0o755))
+
+	var gotHex string
+	var gotLen int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/upgrade", r.URL.Path)
+		gotHex = r.Header.Get("X-Envd-Upgrade-Sha256")
+		gotLen = r.ContentLength
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Equal(t, payload, body)
+		// Simulate envd exec'ing without a response: close without writing.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err == nil {
+			_ = conn.Close()
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	token := "test-token"
+	s := &Sandbox{Metadata: &Metadata{
+		Config: &Config{
+			Envd: EnvdMetadata{AccessToken: &token},
+		},
+	}}
+	s.internalConfig.envdServerURLOverride = srv.URL
+
+	_, err := s.CallEnvdUpgrade(t.Context(), src, "/usr/bin/envd.next", 5*time.Second)
+	// Connection drop after body send is the expected success path.
+	require.NoError(t, err)
+	assert.Equal(t, wantHex, gotHex)
+	assert.Equal(t, int64(len(payload)), gotLen)
 }


### PR DESCRIPTION
## Summary
- Require `X-Envd-Upgrade-Sha256` (lowercase hex SHA-256 of the request body) when `POST /upgrade` carries a non-empty body; reject with 400 if the header is missing, malformed, or mismatches — **before** writing `/usr/bin/envd.next`.
- Empty-body upgrade (restart / re-exec without a new binary) is unchanged.
- Orchestrator `CallEnvdUpgrade` hashes the local envd binary and sets the header when streaming the body.
- Complements auth fail-closed work in #3535 with content integrity (secure defaults / hardening).

## Test plan
- [x] `go test ./internal/services/process/ -run WriteUpgradeBinary` (packages/envd) — missing / malformed / wrong / correct hash paths
- [x] `go build` packages/envd
- [ ] CI: `go test` packages/orchestrator/pkg/sandbox (`TestCallEnvdUpgrade_SetsBodySHA256Header`, linux) — not executable on darwin host here
- [ ] Manual: resume-path live upgrade still delivers via orchestrator with matching digest


Made with [Cursor](https://cursor.com)