### PR TITLE
nfsproxy: preserve caching handler through middleware chain

### DIFF
--- a/packages/orchestrator/pkg/nfsproxy/logged/handler.go
+++ b/packages/orchestrator/pkg/nfsproxy/logged/handler.go
@@ -3,6 +3,7 @@ package logged
 import (
 	"context"
 	"fmt"
+	iofs "io/fs"
 	"net"
 
 	"github.com/go-git/go-billy/v5"
@@ -17,7 +18,10 @@ type loggedHandler struct {
 	config cfg.Config
 }
 
-var _ nfs.Handler = (*loggedHandler)(nil)
+var (
+	_ nfs.Handler        = (*loggedHandler)(nil)
+	_ nfs.CachingHandler = (*loggedHandler)(nil)
+)
 
 func WrapWithLogging(ctx context.Context, handler nfs.Handler, config cfg.Config) nfs.Handler {
 	return loggedHandler{ctx: ctx, inner: handler, config: config}
@@ -95,4 +99,22 @@ func (e loggedHandler) HandleLimit() int {
 	defer finish(e.ctx, nil)
 
 	return e.inner.HandleLimit()
+}
+
+func (e loggedHandler) VerifierFor(path string, contents []iofs.FileInfo) uint64 {
+	handler, ok := e.inner.(nfs.CachingHandler)
+	if !ok {
+		return 0
+	}
+
+	return handler.VerifierFor(path, contents)
+}
+
+func (e loggedHandler) DataForVerifier(path string, verifier uint64) []iofs.FileInfo {
+	handler, ok := e.inner.(nfs.CachingHandler)
+	if !ok {
+		return nil
+	}
+
+	return handler.DataForVerifier(path, verifier)
 }

--- a/packages/orchestrator/pkg/nfsproxy/metrics/handler.go
+++ b/packages/orchestrator/pkg/nfsproxy/metrics/handler.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"fmt"
+	iofs "io/fs"
 	"net"
 
 	"github.com/go-git/go-billy/v5"
@@ -16,7 +17,10 @@ type metricsHandler struct {
 	config cfg.Config
 }
 
-var _ nfs.Handler = (*metricsHandler)(nil)
+var (
+	_ nfs.Handler        = (*metricsHandler)(nil)
+	_ nfs.CachingHandler = (*metricsHandler)(nil)
+)
 
 func WrapWithMetrics(handler nfs.Handler, config cfg.Config) nfs.Handler {
 	return &metricsHandler{inner: handler, config: config}
@@ -97,4 +101,22 @@ func (m *metricsHandler) InvalidateHandle(ctx context.Context, filesystem billy.
 
 func (m *metricsHandler) HandleLimit() int {
 	return m.inner.HandleLimit()
+}
+
+func (m *metricsHandler) VerifierFor(path string, contents []iofs.FileInfo) uint64 {
+	handler, ok := m.inner.(nfs.CachingHandler)
+	if !ok {
+		return 0
+	}
+
+	return handler.VerifierFor(path, contents)
+}
+
+func (m *metricsHandler) DataForVerifier(path string, verifier uint64) []iofs.FileInfo {
+	handler, ok := m.inner.(nfs.CachingHandler)
+	if !ok {
+		return nil
+	}
+
+	return handler.DataForVerifier(path, verifier)
 }

--- a/packages/orchestrator/pkg/nfsproxy/recovery/cache_passthrough_test.go
+++ b/packages/orchestrator/pkg/nfsproxy/recovery/cache_passthrough_test.go
@@ -1,0 +1,62 @@
+package recovery
+
+import (
+	iofs "io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	nfs "github.com/willscott/go-nfs"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/nfsproxy/cfg"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/nfsproxy/logged"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/nfsproxy/metrics"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/nfsproxy/tracing"
+)
+
+type cachingHandlerStub struct {
+	nfs.Handler
+
+	verifier         uint64
+	contents         []iofs.FileInfo
+	verifierPath     string
+	verifierContents []iofs.FileInfo
+	dataPath         string
+	dataVerifier     uint64
+}
+
+func (h *cachingHandlerStub) VerifierFor(path string, contents []iofs.FileInfo) uint64 {
+	h.verifierPath = path
+	h.verifierContents = contents
+
+	return h.verifier
+}
+
+func (h *cachingHandlerStub) DataForVerifier(path string, verifier uint64) []iofs.FileInfo {
+	h.dataPath = path
+	h.dataVerifier = verifier
+
+	return h.contents
+}
+
+func TestCachingHandlerPassthroughThroughMiddlewareChain(t *testing.T) {
+	t.Parallel()
+
+	contents := []iofs.FileInfo{nil}
+	inner := &cachingHandlerStub{verifier: 42, contents: contents}
+	config := cfg.Config{}
+
+	var handler nfs.Handler = inner
+	handler = tracing.WrapWithTracing(handler, config)
+	handler = metrics.WrapWithMetrics(handler, config)
+	handler = logged.WrapWithLogging(t.Context(), handler, config)
+	handler = WrapWithRecovery(t.Context(), handler)
+
+	cachingHandler, ok := handler.(nfs.CachingHandler)
+	require.True(t, ok)
+	require.Equal(t, uint64(42), cachingHandler.VerifierFor("/dir", contents))
+	require.Equal(t, contents, cachingHandler.DataForVerifier("/dir", 42))
+	require.Equal(t, "/dir", inner.verifierPath)
+	require.Equal(t, contents, inner.verifierContents)
+	require.Equal(t, "/dir", inner.dataPath)
+	require.Equal(t, uint64(42), inner.dataVerifier)
+}

--- a/packages/orchestrator/pkg/nfsproxy/recovery/main.go
+++ b/packages/orchestrator/pkg/nfsproxy/recovery/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	iofs "io/fs"
 	"net"
 
 	"github.com/go-git/go-billy/v5"
@@ -18,7 +19,10 @@ type Handler struct {
 	ctx   context.Context //nolint:containedctx // can't change the API, still need it
 }
 
-var _ nfs.Handler = (*Handler)(nil)
+var (
+	_ nfs.Handler        = (*Handler)(nil)
+	_ nfs.CachingHandler = (*Handler)(nil)
+)
 
 func WrapWithRecovery(ctx context.Context, h nfs.Handler) *Handler {
 	return &Handler{inner: h, ctx: ctx}
@@ -67,6 +71,28 @@ func (h Handler) HandleLimit() int {
 	defer tryRecovery(h.ctx, "HandleLimit")
 
 	return h.inner.HandleLimit()
+}
+
+func (h Handler) VerifierFor(path string, contents []iofs.FileInfo) (verifier uint64) {
+	defer tryRecovery(h.ctx, "VerifierFor")
+
+	handler, ok := h.inner.(nfs.CachingHandler)
+	if !ok {
+		return 0
+	}
+
+	return handler.VerifierFor(path, contents)
+}
+
+func (h Handler) DataForVerifier(path string, verifier uint64) (contents []iofs.FileInfo) {
+	defer tryRecovery(h.ctx, "DataForVerifier")
+
+	handler, ok := h.inner.(nfs.CachingHandler)
+	if !ok {
+		return nil
+	}
+
+	return handler.DataForVerifier(path, verifier)
 }
 
 // tryRecovery must be called via `defer` directly so that recover() runs in

--- a/packages/orchestrator/pkg/nfsproxy/tracing/handler.go
+++ b/packages/orchestrator/pkg/nfsproxy/tracing/handler.go
@@ -3,6 +3,7 @@ package tracing
 import (
 	"context"
 	"fmt"
+	iofs "io/fs"
 	"net"
 
 	"github.com/go-git/go-billy/v5"
@@ -17,7 +18,10 @@ type tracingHandler struct {
 	config cfg.Config
 }
 
-var _ nfs.Handler = (*tracingHandler)(nil)
+var (
+	_ nfs.Handler        = (*tracingHandler)(nil)
+	_ nfs.CachingHandler = (*tracingHandler)(nil)
+)
 
 func WrapWithTracing(handler nfs.Handler, config cfg.Config) nfs.Handler {
 	return &tracingHandler{inner: handler, config: config}
@@ -100,4 +104,22 @@ func (e *tracingHandler) InvalidateHandle(ctx context.Context, filesystem billy.
 
 func (e *tracingHandler) HandleLimit() int {
 	return e.inner.HandleLimit()
+}
+
+func (e *tracingHandler) VerifierFor(path string, contents []iofs.FileInfo) uint64 {
+	handler, ok := e.inner.(nfs.CachingHandler)
+	if !ok {
+		return 0
+	}
+
+	return handler.VerifierFor(path, contents)
+}
+
+func (e *tracingHandler) DataForVerifier(path string, verifier uint64) []iofs.FileInfo {
+	handler, ok := e.inner.(nfs.CachingHandler)
+	if !ok {
+		return nil
+	}
+
+	return handler.DataForVerifier(path, verifier)
 }


### PR DESCRIPTION
Fixes https://github.com/e2b-dev/infra/issues/3552.
## Problem

The NFS proxy creates a `helpers.CachingHandler` to cache directory listings by their NFS cookie verifier. However, the caching handler is subsequently wrapped by tracing, metrics, logging, and recovery middleware.

go-nfs detects verifier caching support by asserting the outermost handler as `nfs.CachingHandler`:

```go
handler, ok := userHandle.(nfs.CachingHandler)
```

The middleware handlers only implemented `nfs.Handler`, so this assertion failed before reaching the underlying caching handler. Because the recovery middleware is always installed, verifier caching was bypassed regardless of whether the optional tracing, metrics, or logging middleware was enabled.

As a result, paginated `READDIR` and `READDIRPLUS` requests could not reuse the directory listing associated with their verifier and had to read the directory again.

## Fix

Preserve `nfs.CachingHandler` through the complete middleware chain by forwarding `VerifierFor` and `DataForVerifier` to the wrapped handler.

| Behavior | Before | After |
|---|---|---|
| Outermost handler implements `nfs.CachingHandler` | No | Yes |
| Verifier cache reaches `helpers.CachingHandler` | No | Yes |
| Directory listings can be reused across paginated requests | No | Yes |

## Changes

- Add `nfs.CachingHandler` compile-time interface assertions to the tracing, metrics, logging, and recovery handlers.
- Forward `VerifierFor` and `DataForVerifier` through each middleware layer.
- Preserve panic recovery for verifier cache operations in the recovery handler.
- Add a middleware-chain test that verifies the outer handler satisfies `nfs.CachingHandler` and forwards arguments and return values to the underlying handler.

## Testing

```text
go test ./pkg/nfsproxy/... -count=1
go test -race ./pkg/nfsproxy/... -count=1
```

## Risk: activeVerifiers Cache Key Collision Across Sandboxes

Enabling verifier caching introduces a potential cache-key collision in
`activeVerifiers`. If the mount path and an enumerated file name are identical,
they may produce the same ID. This could cause cache entries to be reused across
different sandboxes, violating cache isolation and potentially leading to
incorrect verifier or file-handle resolution.

If this scenario is possible, the current cache should not be used as-is.
The cache should either be disabled or redesigned with mount-point-scoped, collision-resistant keys.

This risk is related to [#3555](https://github.com/e2b-dev/infra/issues/3555).
The proposed solution is to allocate an independent file-handle cache for each
mount point, using the mount-point identity as the cache
shard key. This prevents cache eviction, lookup, and synchronization in one
sandbox from affecting another.