### PR TITLE
fix(api): expose sandbox placement failure reason in error message

### DIFF
--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -357,6 +357,12 @@ func (o *Orchestrator) CreateSandbox(
 			o.maybeRemapResumeOriginNode(ctx, snapshotSandboxID, team, sbxData.NodeID, placed.WarmedNode)
 		}
 
+		logger.L().Error(ctx, "failed to place sandbox",
+			logger.WithSandboxID(sandboxID),
+			logger.WithTemplateID(sbxData.TemplateID),
+			zap.Error(err),
+		)
+
 		return sandbox.Sandbox{}, &api.APIError{
 			Code:      http.StatusInternalServerError,
 			ClientMsg: "Failed to place sandbox",

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -359,7 +359,7 @@ func (o *Orchestrator) CreateSandbox(
 
 		return sandbox.Sandbox{}, &api.APIError{
 			Code:      http.StatusInternalServerError,
-			ClientMsg: "Failed to place sandbox",
+			ClientMsg: fmt.Sprintf("Failed to place sandbox: %s", err),
 			Err:       fmt.Errorf("failed to place sandbox: %w", err),
 		}
 	}

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -357,9 +357,15 @@ func (o *Orchestrator) CreateSandbox(
 			o.maybeRemapResumeOriginNode(ctx, snapshotSandboxID, team, sbxData.NodeID, placed.WarmedNode)
 		}
 
+		clientMsg := "Failed to place sandbox"
+		var placeErr placement.FailedToPlaceSandboxError
+		if errors.As(err, &placeErr) {
+			clientMsg = fmt.Sprintf("Failed to place sandbox: %s", placeErr)
+		}
+
 		return sandbox.Sandbox{}, &api.APIError{
 			Code:      http.StatusInternalServerError,
-			ClientMsg: fmt.Sprintf("Failed to place sandbox: %s", err),
+			ClientMsg: clientMsg,
 			Err:       fmt.Errorf("failed to place sandbox: %w", err),
 		}
 	}

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -357,15 +357,9 @@ func (o *Orchestrator) CreateSandbox(
 			o.maybeRemapResumeOriginNode(ctx, snapshotSandboxID, team, sbxData.NodeID, placed.WarmedNode)
 		}
 
-		clientMsg := "Failed to place sandbox"
-		var placeErr placement.FailedToPlaceSandboxError
-		if errors.As(err, &placeErr) {
-			clientMsg = fmt.Sprintf("Failed to place sandbox: %s", placeErr)
-		}
-
 		return sandbox.Sandbox{}, &api.APIError{
 			Code:      http.StatusInternalServerError,
-			ClientMsg: clientMsg,
+			ClientMsg: "Failed to place sandbox",
 			Err:       fmt.Errorf("failed to place sandbox: %w", err),
 		}
 	}

--- a/packages/api/internal/orchestrator/placement/placement_best_of_K.go
+++ b/packages/api/internal/orchestrator/placement/placement_best_of_K.go
@@ -88,13 +88,22 @@ func (b *BestOfK) UpdateConfig(config BestOfKConfig) {
 	b.config = config
 }
 
+// nodeRejectionCounts tracks how many nodes were filtered out for each reason
+// during a single placement attempt.
+type nodeRejectionCounts struct {
+	notAccepting  int
+	cpuMismatch   int
+	labelMismatch int
+	excluded      int
+}
+
 // chooseNode selects the best node for placing a VM with the given quota
 func (b *BestOfK) chooseNode(_ context.Context, nodes []*nodemanager.Node, excludedNodes map[string]struct{}, resources nodemanager.SandboxResources, buildMachineInfo machineinfo.MachineInfo, filterByLabels bool, requiredLabels []string) (bestNode *nodemanager.Node, err error) {
 	// Fix the config, we want to dynamically update it
 	config := b.getConfig()
 
 	// Filter eligible nodes
-	candidates := b.sample(nodes, config, excludedNodes, buildMachineInfo, filterByLabels, requiredLabels)
+	candidates, rejections := b.sample(nodes, config, excludedNodes, buildMachineInfo, filterByLabels, requiredLabels)
 
 	// Find the best node among candidates
 	bestScore := math.MaxFloat64
@@ -114,6 +123,8 @@ func (b *BestOfK) chooseNode(_ context.Context, nodes []*nodemanager.Node, exclu
 			filterByLabels:   filterByLabels,
 			requiredLabels:   requiredLabels,
 			buildMachineInfo: buildMachineInfo,
+			totalNodes:       len(nodes),
+			rejections:       rejections,
 		}
 	}
 
@@ -124,24 +135,41 @@ type FailedToPlaceSandboxError struct {
 	filterByLabels   bool
 	requiredLabels   []string
 	buildMachineInfo machineinfo.MachineInfo
+	totalNodes       int
+	rejections       nodeRejectionCounts
 }
 
 var _ error = FailedToPlaceSandboxError{}
 
 func (e FailedToPlaceSandboxError) Error() string {
-	message := fmt.Sprintf("no node available with required metadata: machine=%v", e.buildMachineInfo)
+	r := e.rejections
+	msg := fmt.Sprintf(
+		"no compatible node found (%d nodes checked: %d not-accepting, %d cpu-incompatible, %d label-filtered, %d excluded)",
+		e.totalNodes, r.notAccepting, r.cpuMismatch, r.labelMismatch, r.excluded,
+	)
 
-	if e.filterByLabels {
-		message += fmt.Sprintf(", labels=%v", e.requiredLabels)
+	if e.buildMachineInfo.CPUArchitecture != "" {
+		msg += fmt.Sprintf(
+			"; build cpu: arch=%s family=%s model=%s",
+			e.buildMachineInfo.CPUArchitecture,
+			e.buildMachineInfo.CPUFamily,
+			e.buildMachineInfo.CPUModel,
+		)
 	}
 
-	return message
+	if e.filterByLabels && len(e.requiredLabels) > 0 {
+		msg += fmt.Sprintf("; required labels: %v", e.requiredLabels)
+	}
+
+	return msg
 }
 
 // sample returns up to k items chosen uniformly from those passing ok.
-func (b *BestOfK) sample(items []*nodemanager.Node, config BestOfKConfig, excludedNodes map[string]struct{}, buildMachineInfo machineinfo.MachineInfo, filterByLabels bool, requiredLabels []string) []*nodemanager.Node {
+func (b *BestOfK) sample(items []*nodemanager.Node, config BestOfKConfig, excludedNodes map[string]struct{}, buildMachineInfo machineinfo.MachineInfo, filterByLabels bool, requiredLabels []string) ([]*nodemanager.Node, nodeRejectionCounts) {
+	var rejections nodeRejectionCounts
+
 	if config.K <= 0 || len(items) == 0 {
-		return nil
+		return nil, rejections
 	}
 
 	indices := make([]int, len(items))
@@ -165,26 +193,30 @@ func (b *BestOfK) sample(items []*nodemanager.Node, config BestOfKConfig, exclud
 
 		// Excluded filter
 		if _, ok := excludedNodes[n.ID]; ok {
+			rejections.excluded++
 			continue
 		}
 
 		// If the node can't take new sandboxes, skip it
 		if !n.CanAcceptNewRequests() {
+			rejections.notAccepting++
 			continue
 		}
 
 		// Skip if node is not CPU compatible
 		if !isNodeCPUCompatible(n, buildMachineInfo) {
+			rejections.cpuMismatch++
 			continue
 		}
 
 		// Skip if node doesn't have the required labels
 		if filterByLabels && !isNodeLabelsCompatible(n, requiredLabels) {
+			rejections.labelMismatch++
 			continue
 		}
 
 		candidates = append(candidates, n)
 	}
 
-	return candidates
+	return candidates, rejections
 }

--- a/packages/api/internal/orchestrator/placement/placement_best_of_K_test.go
+++ b/packages/api/internal/orchestrator/placement/placement_best_of_K_test.go
@@ -1,7 +1,6 @@
 package placement
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -179,7 +178,7 @@ func TestBestOfK_ChooseNode_NoAvailableNodes(t *testing.T) {
 	selected, err := algo.chooseNode(ctx, nodes, excludedNodes, resources, machineinfo.MachineInfo{}, false, nil)
 	require.Error(t, err)
 	assert.Nil(t, selected)
-	assert.Contains(t, err.Error(), "no node available")
+	assert.Contains(t, err.Error(), "no compatible node found")
 }
 
 func TestFailedToPlaceSandboxError_Error(t *testing.T) {
@@ -196,6 +195,8 @@ func TestFailedToPlaceSandboxError_Error(t *testing.T) {
 		name           string
 		filterByLabels bool
 		requiredLabels []string
+		rejections     nodeRejectionCounts
+		totalNodes     int
 		wantContains   []string
 		wantNotContain string
 	}{
@@ -203,39 +204,54 @@ func TestFailedToPlaceSandboxError_Error(t *testing.T) {
 			name:           "without label filtering",
 			filterByLabels: false,
 			requiredLabels: nil,
+			totalNodes:     10,
+			rejections:     nodeRejectionCounts{cpuMismatch: 10},
 			wantContains: []string{
-				"no node available with required metadata",
-				fmt.Sprintf("machine=%v", machine),
+				"no compatible node found",
+				"10 nodes checked",
+				"10 cpu-incompatible",
+				"arch=x86_64",
+				"model=" + machineinfo.IceLakeModel,
 			},
-			wantNotContain: "labels=",
+			wantNotContain: "required labels",
 		},
 		{
 			name:           "with label filtering",
 			filterByLabels: true,
 			requiredLabels: []string{"gpu", "fast-disk"},
+			totalNodes:     5,
+			rejections:     nodeRejectionCounts{notAccepting: 2, labelMismatch: 3},
 			wantContains: []string{
-				"no node available with required metadata",
-				fmt.Sprintf("machine=%v", machine),
-				"labels=[gpu fast-disk]",
+				"no compatible node found",
+				"5 nodes checked",
+				"2 not-accepting",
+				"3 label-filtered",
+				"required labels: [gpu fast-disk]",
 			},
 		},
 		{
 			name:           "label filtering enabled with no labels",
 			filterByLabels: true,
 			requiredLabels: nil,
+			totalNodes:     3,
+			rejections:     nodeRejectionCounts{notAccepting: 3},
 			wantContains: []string{
-				"no node available with required metadata",
-				"labels=[]",
+				"no compatible node found",
+				"3 nodes checked",
 			},
 		},
 		{
 			name:           "labels present but filtering disabled",
 			filterByLabels: false,
 			requiredLabels: []string{"gpu"},
+			totalNodes:     4,
+			rejections:     nodeRejectionCounts{excluded: 4},
 			wantContains: []string{
-				"no node available with required metadata",
+				"no compatible node found",
+				"4 nodes checked",
+				"4 excluded",
 			},
-			wantNotContain: "labels=",
+			wantNotContain: "required labels",
 		},
 	}
 
@@ -247,6 +263,8 @@ func TestFailedToPlaceSandboxError_Error(t *testing.T) {
 				filterByLabels:   tt.filterByLabels,
 				requiredLabels:   tt.requiredLabels,
 				buildMachineInfo: machine,
+				totalNodes:       tt.totalNodes,
+				rejections:       tt.rejections,
 			}
 
 			msg := err.Error()
@@ -302,8 +320,8 @@ func TestBestOfK_ChooseNode_ReturnsPlacementError(t *testing.T) {
 	var placeErr FailedToPlaceSandboxError
 	require.ErrorAs(t, err, &placeErr)
 	assert.Equal(t, requiredLabels, placeErr.requiredLabels)
-	assert.Contains(t, err.Error(), "labels=[gpu]")
-	assert.Contains(t, err.Error(), fmt.Sprintf("machine=%v", machine))
+	assert.Contains(t, err.Error(), "required labels: [gpu]")
+	assert.Contains(t, err.Error(), "not-accepting")
 }
 
 func TestBestOfK_Sample(t *testing.T) {
@@ -321,7 +339,7 @@ func TestBestOfK_Sample(t *testing.T) {
 	excludedNodes := make(map[string]struct{})
 
 	// Test sampling fewer nodes than available
-	sampled := algo.sample(nodes, config, excludedNodes, machineinfo.MachineInfo{}, false, nil)
+	sampled, _ := algo.sample(nodes, config, excludedNodes, machineinfo.MachineInfo{}, false, nil)
 	assert.LessOrEqual(t, len(sampled), 3)
 
 	// Check all sampled nodes are unique
@@ -334,7 +352,7 @@ func TestBestOfK_Sample(t *testing.T) {
 	// Test sampling with exclusions
 	excludedNodes["a"] = struct{}{}
 	excludedNodes["b"] = struct{}{}
-	sampled = algo.sample(nodes, config, excludedNodes, machineinfo.MachineInfo{}, false, nil)
+	sampled, _ = algo.sample(nodes, config, excludedNodes, machineinfo.MachineInfo{}, false, nil)
 
 	for _, n := range sampled {
 		assert.NotEqual(t, "a", n.ID)


### PR DESCRIPTION
Fixes #3553

## What

When `BestOfK.chooseNode` finds no eligible node it returns a `FailedToPlaceSandboxError`, but `create_instance.go` only uses the internal `Err` field and returns the opaque `"Failed to place sandbox"` to the client.

This PR makes the error actionable:

1. **`BestOfK.sample()`** now counts how many nodes were rejected at each filter stage: `not-accepting`, `cpu-incompatible`, `label-filtered`, `excluded`.
2. **`FailedToPlaceSandboxError.Error()`** emits a structured message with those counts plus the build CPU constraints and required labels.
3. **`create_instance.go`** propagates `err.Error()` to `ClientMsg` so the caller receives the full diagnosis.

**Before:**
```
500: Failed to place sandbox
```

**After:**
```
500: Failed to place sandbox: no compatible node found (38 nodes checked: 0 not-accepting, 38 cpu-incompatible, 0 label-filtered, 0 excluded); build cpu: arch=x86_64 family=6 model=207
```

## Why this is safe to expose

The message reveals CPU generation and scheduling labels — information already visible through the admin `GET /nodes` endpoint. No secrets or topology details are disclosed.

## Changes

- `packages/api/internal/orchestrator/placement/placement_best_of_K.go` — add `nodeRejectionCounts`, thread through `sample()`, populate `FailedToPlaceSandboxError`, update `Error()`
- `packages/api/internal/orchestrator/create_instance.go` — `ClientMsg` now includes `err.Error()`
- `packages/api/internal/orchestrator/placement/placement_best_of_K_test.go` — update assertions for new error format

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi @tomassrnka Looking forward to your code review.
