### PR TITLE
fix(orchestrator): close TOCTOU race in Cleanup.Add/AddPriority

### DIFF
--- a/packages/orchestrator/pkg/sandbox/cleanup.go
+++ b/packages/orchestrator/pkg/sandbox/cleanup.go
@@ -37,7 +37,7 @@ func (c *Cleanup) AddNoContext(ctx context.Context, f func() error) {
 }
 
 func (c *Cleanup) Add(ctx context.Context, f func(ctx context.Context) error) {
-	if c.hasRun.Load() == true {
+	if c.hasRun.Load() {
 		err := f(context.WithoutCancel(ctx))
 		if err != nil {
 			logger.L().Error(ctx, "failed to run function after cleanup has run", zap.Error(err))
@@ -47,13 +47,25 @@ func (c *Cleanup) Add(ctx context.Context, f func(ctx context.Context) error) {
 	}
 
 	c.mu.Lock()
+	// Double-check under lock: run() may have completed between the Load above
+	// and acquiring mu, silently dropping f into an already-drained slice.
+	if c.hasRun.Load() {
+		c.mu.Unlock()
+
+		err := f(context.WithoutCancel(ctx))
+		if err != nil {
+			logger.L().Error(ctx, "failed to run function after cleanup has run", zap.Error(err))
+		}
+
+		return
+	}
 	defer c.mu.Unlock()
 
 	c.cleanup = append(c.cleanup, f)
 }
 
 func (c *Cleanup) AddPriority(ctx context.Context, f func(ctx context.Context) error) {
-	if c.hasRun.Load() == true {
+	if c.hasRun.Load() {
 		err := f(context.WithoutCancel(ctx))
 		if err != nil {
 			logger.L().Error(ctx, "failed to run priority function after cleanup has run", zap.Error(err))
@@ -63,6 +75,18 @@ func (c *Cleanup) AddPriority(ctx context.Context, f func(ctx context.Context) e
 	}
 
 	c.mu.Lock()
+	// Double-check under lock: run() may have completed between the Load above
+	// and acquiring mu, silently dropping f into an already-drained slice.
+	if c.hasRun.Load() {
+		c.mu.Unlock()
+
+		err := f(context.WithoutCancel(ctx))
+		if err != nil {
+			logger.L().Error(ctx, "failed to run priority function after cleanup has run", zap.Error(err))
+		}
+
+		return
+	}
 	defer c.mu.Unlock()
 
 	c.priorityCleanup = append(c.priorityCleanup, f)
@@ -77,10 +101,14 @@ func (c *Cleanup) Run(ctx context.Context) error {
 }
 
 func (c *Cleanup) run(ctx context.Context) {
-	c.hasRun.Store(true)
-
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	// Set hasRun inside the lock so Add/AddPriority's double-check (also under
+	// mu) sees the updated value before the slice is drained. Without this,
+	// Add can observe hasRun==false, lose the race to run(), and append f to an
+	// already-drained slice where it will never be executed.
+	c.hasRun.Store(true)
 
 	var errs []error
 


### PR DESCRIPTION
## Problem

Closes #3557

`Cleanup.Add` and `Cleanup.AddPriority` had a TOCTOU race against `Cleanup.run` that silently discarded cleanup functions, causing permanent resource leaks on the host.

**The race window:**

```
Goroutine A (Add):   hasRun.Load() == false  →  [not yet holding mu]
Goroutine B (run):   hasRun.Store(true)  →  Lock()  →  drain slice  →  Unlock()
Goroutine A (Add):   Lock()  →  append(f)   ← f is in a drained slice, never executed
```

`sync.Once` in `Run()` prevents `run()` from firing a second time, so `f` is permanently lost — no log, no error, no signal.

With **28 call sites** in the sandbox startup path registering operations like closing overlay filesystems, releasing network slots, removing Firecracker/UFFD sockets, and stopping the Firecracker process, any one of these dropped in a concurrent teardown leaves a leaked resource until the orchestrator restarts.

## Fix

Two changes to `cleanup.go`:

**1. Move `hasRun.Store(true)` inside the lock in `run()`**

```go
// before
func (c *Cleanup) run(ctx context.Context) {
    c.hasRun.Store(true)   // ← outside lock
    c.mu.Lock()
    defer c.mu.Unlock()
    ...
}

// after
func (c *Cleanup) run(ctx context.Context) {
    c.mu.Lock()
    defer c.mu.Unlock()
    c.hasRun.Store(true)   // ← inside lock, closes the window
    ...
}
```

**2. Add a double-check of `hasRun` after acquiring `mu` in `Add`/`AddPriority`**

```go
c.mu.Lock()
if c.hasRun.Load() {   // ← double-check: catches goroutines that lost the race
    c.mu.Unlock()
    err := f(context.WithoutCancel(ctx))
    ...
    return
}
defer c.mu.Unlock()
c.cleanup = append(c.cleanup, f)
```

The optimistic fast-path `Load()` before the lock is kept to avoid lock contention in the common post-run case (already-torn-down sandbox), but is no longer the only gate.

## Test plan

- [ ] Existing sandbox lifecycle tests pass
- [ ] Manual: concurrent `Add` and `Run` calls no longer drop functions (race detector: `go test -race ./packages/orchestrator/pkg/sandbox/...`)

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi @tomassrnka Looking forward to your code review.