### PR TITLE
fix(envd): guard MMDS-poll goroutine with CAS to prevent unbounded accumulation on /init retries

### DIFF
--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -206,11 +206,19 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 		a.initialized.Store(true)
 	}
 
-	go func() { //nolint:contextcheck // TODO: fix this later
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-		defer cancel()
-		host.PollForMMDSOpts(ctx, a.mmdsChan, a.defaults.EnvVars)
-	}()
+	// Only one MMDS-poll goroutine may be in flight at a time. Without this
+	// guard every /init retry (the orchestrator retries with infinite backoff
+	// until the sandbox responds) spawns a fresh goroutine that lives for 60 s
+	// and fires up to 1 200 HTTP requests — O(N) goroutines and O(N*1200)
+	// connections accumulate silently until they time out.
+	if a.mmdsPollRunning.CompareAndSwap(false, true) {
+		go func() { //nolint:contextcheck
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+			host.PollForMMDSOpts(ctx, a.mmdsChan, a.defaults.EnvVars)
+			a.mmdsPollRunning.Store(false)
+		}()
+	}
 
 	w.Header().Set("Cache-Control", "no-store")
 

--- a/packages/envd/internal/api/store.go
+++ b/packages/envd/internal/api/store.go
@@ -66,6 +66,13 @@ type API struct {
 	// re-adopted (possibly hostile) guest process can neither drive an upgrade
 	// nor be handed a running workload before /init has re-established auth.
 	initialized atomic.Bool
+
+	// mmdsPollRunning is set to true while a PollForMMDSOpts goroutine is
+	// in flight. CompareAndSwap on this flag prevents PostInit from spawning
+	// a new polling goroutine on every /init retry — each goroutine sends up
+	// to 1200 HTTP requests over its 60 s lifetime, so N concurrent retries
+	// would produce O(N*1200) MMDS calls and O(N) goroutine stack allocations.
+	mmdsPollRunning atomic.Bool
 }
 
 // Initialized reports whether the first authenticated /init has completed.


### PR DESCRIPTION
## Problem

Closes #3559

`PostInit` unconditionally spawns a new `PollForMMDSOpts` goroutine on **every call**:

```go
go func() { //nolint:contextcheck // TODO: fix this later
    ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
    defer cancel()
    host.PollForMMDSOpts(ctx, a.mmdsChan, a.defaults.EnvVars)
}()
```

The orchestrator retries `/init` with infinite backoff until the sandbox responds. During normal Firecracker boot MMDS fills asynchronously, so several retries arrive before MMDS is ready. Each goroutine:

- lives for up to **60 seconds**
- calls MMDS every **50 ms** for both token and opts = up to **1 200 HTTP requests**

With N concurrent retries this produces **O(N) goroutine stacks** and **O(N × 1200) MMDS connections** accumulating silently inside the VM until they time out.

## Fix

Add `mmdsPollRunning atomic.Bool` to `API` (alongside the existing `isMountingNFS` and `initialized` atomics) and gate the goroutine spawn with `CompareAndSwap`:

```go
if a.mmdsPollRunning.CompareAndSwap(false, true) {
    go func() { //nolint:contextcheck
        ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
        defer cancel()
        host.PollForMMDSOpts(ctx, a.mmdsChan, a.defaults.EnvVars)
        a.mmdsPollRunning.Store(false)  // reset so next /init can re-poll if needed
    }()
}
```

**Behaviour preserved:**
- First `/init` — CAS succeeds, goroutine starts, MMDS opts delivered normally.
- Subsequent retries while goroutine is running — CAS fails, no new goroutine; the already-running goroutine delivers the opts.
- If goroutine times out before MMDS is ready — flag resets to `false`, the next `/init` retry starts a fresh poll.

## Changes

| File | Change |
|------|--------|
| `packages/envd/internal/api/store.go` | Add `mmdsPollRunning atomic.Bool` field with explaining comment |
| `packages/envd/internal/api/init.go` | Wrap goroutine spawn in `CompareAndSwap`; reset flag on exit |

## Testing

The fix is a pure atomicity change on an existing `atomic.Bool` pattern already used for `isMountingNFS` in the same struct. No new dependencies.