### PR TITLE
fix(envd): cap PostInit request body at 1 MiB with MaxBytesReader

### DIFF
--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -137,13 +137,28 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 	logger := a.logger.With().Str(string(logs.OperationIDKey), operationID).Logger()
 
 	if r.Body != nil {
+		// Cap the body to 1 MiB before reading. The largest legitimate /init
+		// payload contains EnvVars and a CaBundle, but no bulk data; 1 MiB is
+		// a generous upper bound that no real orchestrator payload approaches.
+		// Without this limit a guest process can send an unbounded body and
+		// OOM-kill envd, the sandbox control plane, without any credentials.
+		// Capping also preserves the intent of memguard.WipeBytes below: if
+		// the body were huge, partial GC scans could page the secret to disk
+		// before the wipe runs.
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 		// Read raw body so we can wipe it after parsing
 		body, err := io.ReadAll(r.Body)
 		// Ensure body is wiped after we're done
 		defer memguard.WipeBytes(body)
 		if err != nil {
-			logger.Error().Msgf("Failed to read request body: %v", err)
-			w.WriteHeader(http.StatusBadRequest)
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				logger.Error().Msg("request body exceeds 1 MiB limit")
+				w.WriteHeader(http.StatusRequestEntityTooLarge)
+			} else {
+				logger.Error().Msgf("Failed to read request body: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+			}
 
 			return
 		}


### PR DESCRIPTION
## Problem

Closes #3563

`PostInit` read the full request body with no size cap:

```go
body, err := io.ReadAll(r.Body)  // no MaxBytesReader
defer memguard.WipeBytes(body)
```

Any process inside the VM that can reach the envd HTTP port can send an arbitrarily large body, allocating heap memory until envd is OOM-killed. The auth check happens *after* the full body is read, so no credentials are required.

envd is the **sandbox control plane** — OOM-killing it orphans all user processes, breaks graceful teardown (slot release, cleanup callbacks), and can corrupt pause/resume state.

**Secondary issue:** `memguard.WipeBytes(body)` is intended to scrub the access token from heap memory after use. If `body` is a multi-hundred-MiB allocation, Go's GC may have already paged parts of it to disk or the allocator may have moved the backing array before the deferred wipe runs, reducing the security guarantee.

## Fix

Wrap `r.Body` with `http.MaxBytesReader(w, r.Body, 1<<20)` before `io.ReadAll`. 1 MiB is a generous upper bound — the largest legitimate `/init` payload carries `EnvVars` and `CaBundle` (multiple PEM certs) but no bulk data.

Oversized requests now return **413 Request Entity Too Large** via a dedicated `*http.MaxBytesError` branch; all other read errors keep the existing 400 path.

## Changes

Single file, `packages/envd/internal/api/init.go` (+17/-2 lines):

| Change | Detail |
|--------|--------|
| `r.Body = http.MaxBytesReader(w, r.Body, 1<<20)` | Cap before `io.ReadAll` |
| `errors.As(err, &maxErr)` branch | Return 413 on oversized body |
| Existing 400 path preserved | All other read errors unchanged |

No import changes needed (`errors`, `io`, `net/http` already imported).

## Testing

- Normal orchestrator `/init` payloads are well under 1 MiB — no behaviour change for legitimate callers.
- A request with a body > 1 MiB now gets 413 and envd memory is unaffected.