### PR TITLE
fix(proxy): pick JSON vs HTML errors by intent, not User-Agent

### DIFF
--- a/packages/shared/pkg/proxy/template/template.go
+++ b/packages/shared/pkg/proxy/template/template.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"net/http"
 	"regexp"
+	"strings"
 )
 
 var browserRegex = regexp.MustCompile(`(?i)mozilla|chrome|safari|firefox|edge|opera|msie`)
@@ -43,7 +44,7 @@ func (e *TemplatedError[T]) HandleError(
 		return fmt.Errorf("invalid status code: %d", e.vars.StatusCode())
 	}
 
-	if isBrowser(r) {
+	if wantsHtml(r) {
 		body, buildErr := e.buildHtml()
 		if buildErr != nil {
 			return buildErr
@@ -73,6 +74,42 @@ func (e *TemplatedError[T]) HandleError(
 	}
 
 	return nil
+}
+
+// wantsHtml reports whether the error should be rendered as the browser error
+// page rather than as JSON.
+//
+// Intent comes first, because a fetch() from page scripts carries the browser's
+// own User-Agent and cannot override it — sniffing the User-Agent alone hands an
+// HTML page to a caller that is about to parse it as JSON. Sniffing is left as
+// the fallback, where it only catches genuine top-level navigations.
+func wantsHtml(r *http.Request) bool {
+	if prefersJson(r) || isScriptInitiated(r) {
+		return false
+	}
+
+	return isBrowser(r)
+}
+
+// prefersJson reports whether the Accept header asks for JSON over HTML.
+func prefersJson(r *http.Request) bool {
+	accept := strings.ToLower(r.Header.Get("Accept"))
+
+	return strings.Contains(accept, "application/json") && !strings.Contains(accept, "text/html")
+}
+
+// isScriptInitiated reports whether the request was made by page scripts rather
+// than by navigating to the URL. Sec-Fetch-Mode is set by the browser itself and
+// is a forbidden header name for scripts; X-Requested-With covers older clients.
+func isScriptInitiated(r *http.Request) bool {
+	// A top-level navigation, which is what the HTML pages are for, sends
+	// "navigate" instead.
+	switch strings.ToLower(r.Header.Get("Sec-Fetch-Mode")) {
+	case "cors", "no-cors", "same-origin":
+		return true
+	}
+
+	return r.Header.Get("X-Requested-With") != ""
 }
 
 func isBrowser(r *http.Request) bool {

--- a/packages/shared/pkg/proxy/template/template_test.go
+++ b/packages/shared/pkg/proxy/template/template_test.go
@@ -1,0 +1,101 @@
+package template
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const chromeUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
+
+// Browser JS cannot override the User-Agent, so User-Agent sniffing alone sends
+// an HTML page to callers that are about to parse it as JSON.
+func TestHandleErrorContentNegotiation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		htmlContentType = "text/html; charset=utf-8"
+		jsonContentType = "application/json; charset=utf-8"
+	)
+
+	for _, tt := range []struct {
+		name        string
+		headers     map[string]string
+		contentType string
+	}{
+		{
+			name:        "no user agent",
+			contentType: jsonContentType,
+		},
+		{
+			name:        "top-level navigation",
+			headers:     map[string]string{"User-Agent": chromeUserAgent, "Sec-Fetch-Mode": "navigate", "Accept": "text/html,application/xhtml+xml,*/*"},
+			contentType: htmlContentType,
+		},
+		{
+			name:        "bare browser user agent",
+			headers:     map[string]string{"User-Agent": chromeUserAgent},
+			contentType: htmlContentType,
+		},
+		{
+			name:        "browser user agent accepting html",
+			headers:     map[string]string{"User-Agent": chromeUserAgent, "Accept": "text/html"},
+			contentType: htmlContentType,
+		},
+		{
+			name:        "browser user agent accepting json",
+			headers:     map[string]string{"User-Agent": chromeUserAgent, "Accept": "application/json"},
+			contentType: jsonContentType,
+		},
+		{
+			// What a default fetch() from page scripts looks like: browser
+			// User-Agent, no JSON preference in Accept.
+			name:        "cross-origin fetch",
+			headers:     map[string]string{"User-Agent": chromeUserAgent, "Sec-Fetch-Mode": "cors", "Accept": "*/*"},
+			contentType: jsonContentType,
+		},
+		{
+			name:        "same-origin fetch",
+			headers:     map[string]string{"User-Agent": chromeUserAgent, "Sec-Fetch-Mode": "same-origin", "Accept": "*/*"},
+			contentType: jsonContentType,
+		},
+		{
+			name:        "legacy xhr",
+			headers:     map[string]string{"User-Agent": chromeUserAgent, "X-Requested-With": "XMLHttpRequest"},
+			contentType: jsonContentType,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
+			for header, value := range tt.headers {
+				r.Header.Set(header, value)
+			}
+			w := httptest.NewRecorder()
+
+			require.NoError(t, NewSandboxNotFoundError("im9r2ycjiy2534qsdy1oo", "e2b.app").HandleError(w, r))
+
+			assert.Equal(t, http.StatusBadGateway, w.Code)
+			assert.Equal(t, tt.contentType, w.Header().Get("Content-Type"))
+		})
+	}
+}
+
+func TestHandleErrorRejectsInvalidStatusCode(t *testing.T) {
+	t.Parallel()
+
+	e := &TemplatedError[sandboxNotFoundData]{
+		template: sandboxNotFoundHtmlTemplate,
+		vars:     sandboxNotFoundData{Code: 0},
+	}
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	require.Error(t, e.HandleError(w, r))
+	assert.Empty(t, w.Body.String())
+}


### PR DESCRIPTION
Extracted from #3389, which bundled this with the CORS fix. This half stands alone.

## Problem

The proxy's synthesized error responses (`packages/shared/pkg/proxy/template/`) chose the HTML error page over JSON by sniffing the User-Agent. A `fetch()` from page scripts carries the browser's own User-Agent and cannot override it — UA is a [forbidden header name](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name) — so an SDK call from a browser got the HTML error page where it expects JSON. `Accept` was ignored entirely:

```
no UA                                -> 502 application/json
chrome UA                            -> 502 text/html
chrome UA + Accept: application/json -> 502 text/html   <- Accept ignored
```

## Change

Intent decides first, in `wantsHtml`:

- **`Accept` prefers JSON** (`application/json` present, `text/html` absent) → JSON.
- **`Sec-Fetch-Mode` is `cors` / `no-cors` / `same-origin`**, or `X-Requested-With` is set → JSON. Both are set by the browser, not by the caller; a genuine top-level navigation sends `Sec-Fetch-Mode: navigate` instead.
- Otherwise fall back to the existing User-Agent sniff, which now only catches those top-level navigations — which is what the HTML pages are for.

This is one choke point: `TemplatedError.HandleError` covers all eight error templates.

## Tests

`packages/shared/pkg/proxy/template/template_test.go` — a table over the negotiation matrix (bare browser UA, navigation, `Accept: application/json`, cross-origin fetch, same-origin fetch, legacy XHR, no UA). Checked to have teeth by reverting `wantsHtml` back to `isBrowser` and watching 4 cases fail.

Verified with `go test -race ./packages/shared/pkg/proxy/...`, `make fmt`, `make lint`. The two remaining lint failures (`envd/internal/services/process/dup3_other.go`, `orchestrator/cmd/create-build/proxyport_test.go`) are pre-existing on `main` and platform-related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)