### PR TITLE
fix(sandbox/storage): clean stale team-index entries when expiration-index orphan is swept

### DIFF
--- a/packages/api/internal/sandbox/storage/redis/items.go
+++ b/packages/api/internal/sandbox/storage/redis/items.go
@@ -102,14 +102,11 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, err
 		for i, raw := range batch.cmd.Val() {
 			ref := batch.refs[i]
 
-			// Sandbox key gone but ZSET entry remains — orphaned. Members are
-			// execution-scoped, so this removal can never unindex a fresh
-			// execution concurrently re-added under the same sandbox ID.
+			// Sandbox key gone but ZSET entry remains — orphaned.
 			// MGET confirmed the key is absent; SREM the stale team index entry
-			// so it does not accumulate indefinitely. A concurrent Add that
-			// writes the key after our MGET will SADD the sandboxID back, so
-			// this can at worst leave a brief gap in TeamItems results that the
-			// next Add corrects.
+			// so it does not accumulate indefinitely. Sandbox IDs are randomly
+			// generated and never reused, so a concurrent Add cannot write the
+			// same sandboxID back after this SREM.
 			if raw == nil {
 				staleMembers = append(staleMembers, ref.member)
 				orphanCount++

--- a/packages/api/internal/sandbox/storage/redis/items.go
+++ b/packages/api/internal/sandbox/storage/redis/items.go
@@ -38,6 +38,7 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, err
 	// Group by team for per-team MGET (Redis Cluster slot compatibility).
 	type memberRef struct {
 		member      string
+		teamID      string
 		sandboxID   string
 		executionID string
 	}
@@ -67,7 +68,7 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, err
 			teamSandboxes[teamID] = entry
 		}
 
-		entry.refs = append(entry.refs, memberRef{member: member, sandboxID: sandboxID, executionID: executionID})
+		entry.refs = append(entry.refs, memberRef{member: member, teamID: teamID, sandboxID: sandboxID, executionID: executionID})
 	}
 
 	pipe := s.redisClient.Pipeline()
@@ -104,9 +105,22 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, err
 			// Sandbox key gone but ZSET entry remains — orphaned. Members are
 			// execution-scoped, so this removal can never unindex a fresh
 			// execution concurrently re-added under the same sandbox ID.
+			// MGET confirmed the key is absent; SREM the stale team index entry
+			// so it does not accumulate indefinitely. A concurrent Add that
+			// writes the key after our MGET will SADD the sandboxID back, so
+			// this can at worst leave a brief gap in TeamItems results that the
+			// next Add corrects.
 			if raw == nil {
 				staleMembers = append(staleMembers, ref.member)
 				orphanCount++
+
+				teamIndexKey := GetSandboxStorageTeamIndexKey(ref.teamID)
+				if sremErr := s.redisClient.SRem(ctx, teamIndexKey, ref.sandboxID).Err(); sremErr != nil {
+					logger.L().Warn(ctx, "Failed to remove orphan from team index",
+						zap.Error(sremErr),
+						logger.WithSandboxID(ref.sandboxID),
+					)
+				}
 
 				continue
 			}


### PR DESCRIPTION

When ExpiredItems sweeps a ZSET member whose sandbox key is gone (orphaned entry), it only removed the ZSET member but left the corresponding sandboxID in the per-team SET index. These stale entries accumulate indefinitely because no other code path cleans the team index for absent sandbox keys:
- TeamItems / fetchSandboxBatch silently skip nil MGET results
- The healer only fills missing ZSET members, never prunes the team index
- Remove() / removeSandboxScript cleans the team index atomically, but only runs on the normal Remove call path, not on external key loss

Observed impact: teams with high sandbox churn and Redis key eviction (or restarts without full persistence) accumulated thousands of stale SET members, inflating team-index memory and slowing TeamItems SMEMBERS + MGET scans.

Fix: when an orphaned ZSET member is found (MGET returned nil), also SREM the sandboxID from the team index. Safety: MGET just confirmed the sandbox key is absent, so we cannot unindex a live sandbox. A concurrent Add that races our SREM will SADD the sandboxID back immediately after, so the worst outcome is a brief gap in TeamItems results for one eviction cycle.