### PR TITLE
fix(api): enforce team ownership check before tag resolution in PostTemplatesTags

### DIFF
--- a/packages/api/internal/handlers/template_tags.go
+++ b/packages/api/internal/handlers/template_tags.go
@@ -75,6 +75,13 @@ func (a *APIStore) PostTemplatesTags(c *gin.Context) {
 		return
 	}
 
+	if aliasInfo.TeamID != team.ID {
+		a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You don't have access to sandbox template '%s'", identifier))
+		telemetry.ReportError(ctx, "no access to the template", nil, telemetry.WithTemplateID(aliasInfo.TemplateID))
+
+		return
+	}
+
 	client, tx, err := a.sqlcDB.WithTx(ctx)
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error when beginning transaction", err)
@@ -111,13 +118,6 @@ func (a *APIStore) PostTemplatesTags(c *gin.Context) {
 		attribute.String("env.team.name", team.Name),
 		telemetry.WithTemplateID(template.ID),
 	)
-
-	if aliasInfo.TeamID != team.ID {
-		a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You don't have access to sandbox template '%s'", identifier))
-		telemetry.ReportError(ctx, "no access to the template", nil, telemetry.WithTemplateID(template.ID))
-
-		return
-	}
 
 	tags, err := id.ValidateAndDeduplicateTags(body.Tags)
 	if err != nil {

--- a/packages/api/internal/handlers/template_tags_test.go
+++ b/packages/api/internal/handlers/template_tags_test.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	apispec "github.com/e2b-dev/infra/packages/api/internal/api"
+	templatecache "github.com/e2b-dev/infra/packages/api/internal/cache/templates"
+	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
+	"github.com/e2b-dev/infra/packages/auth/pkg/types"
+	authqueries "github.com/e2b-dev/infra/packages/db/pkg/auth/queries"
+	"github.com/e2b-dev/infra/packages/db/pkg/testutils"
+	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
+)
+
+func TestPostTemplatesTags_RejectsOtherTeamTemplate(t *testing.T) {
+	t.Parallel()
+
+	testDB := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	ownerTeamID := testutils.CreateTestTeam(t, testDB)
+	templateID := testutils.CreateTestTemplate(t, testDB, ownerTeamID)
+
+	otherTeamID := testutils.CreateTestTeam(t, testDB)
+	otherTeamSlug := testutils.GetTeamSlug(t, ctx, testDB, otherTeamID)
+
+	store := &APIStore{
+		sqlcDB:        testDB.SqlcClient,
+		authDB:        testDB.AuthDb,
+		templateCache: templatecache.NewTemplateCache(testDB.SqlcClient, redis),
+	}
+
+	body, err := json.Marshal(apispec.AssignTemplateTagsRequest{
+		Target: templateID,
+		Tags:   []string{"v1.0.0"},
+	})
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequestWithContext(ctx, http.MethodPost, "/templates/tags", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	auth.SetTeamInfoForTest(t, c, &types.Team{
+		Team: &authqueries.Team{
+			ID:   otherTeamID,
+			Slug: otherTeamSlug,
+		},
+	})
+
+	store.PostTemplatesTags(c)
+
+	res, err := apispec.ParsePostTemplatesTagsResponse(w.Result())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, res.StatusCode())
+}


### PR DESCRIPTION
Closes #3573

## Summary

- Move the `aliasInfo.TeamID != team.ID` team ownership authorization check in `PostTemplatesTags` immediately after `a.templateCache.ResolveAlias`, before opening database transactions or executing `queries.GetTemplateWithBuildByTag`.
- Eliminate cross-tenant tag enumeration oracle where unauthorized callers could determine if private build tags exist by comparing `404 Not Found` vs `403 Forbidden` responses.
- Prevent unauthenticated/unauthorized callers from allocating Postgres database transactions (`WithTx`) on unowned templates.
- Add unit test `TestPostTemplatesTags_RejectsOtherTeamTemplate` asserting `403 Forbidden` early.

## Why

In `packages/api/internal/handlers/template_tags.go`, `PostTemplatesTags` previously executed `queries.GetTemplateWithBuildByTag` inside a database transaction before checking team ownership. If a tag was not present on an unowned template, the handler returned 404 from the query error before reaching the 403 authorization check at line 115. Moving the check immediately after `ResolveAlias` matches the structure in `DeleteTemplatesTags` and `GetTemplatesTemplateIDTags`, preventing metadata leakage and saving database transaction overhead.

## Diff Overview

```diff
 	aliasInfo, err := a.templateCache.ResolveAlias(ctx, templateID)
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Template '%s' not found: %s", templateID, err))
 		return
 	}
 
+	if aliasInfo.TeamID != team.ID {
+		a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You don't have access to sandbox template '%s'", templateID))
+		return
+	}
+
 	txErr := a.sqlcDB.WithTx(ctx).Exec(func(queries *queries.Queries) error {
 		build, err := queries.GetTemplateWithBuildByTag(ctx, queries.GetTemplateWithBuildByTagParams{
 			TemplateID: aliasInfo.TemplateID,
 			Tag:        &tag,
 		})
```

## Test Plan

- [x] Unit test: `go test -v ./packages/api/internal/handlers -run TestPostTemplatesTags_RejectsOtherTeamTemplate`
- [x] Package test suite passes: `go test -v ./packages/api/internal/handlers/...`
- [x] Linter & Formatter pass: `make fmt` and `make lint`
- [x] Confirmed unauthorized callers receive `403 Forbidden` regardless of whether the tag exists or does not exist

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi