### PR TITLE
fix(api): handle gRPC unavailable and deadline errors in volume orchestrator retry loop

### DIFF
--- a/packages/api/internal/handlers/volume_util.go
+++ b/packages/api/internal/handlers/volume_util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/e2b-dev/infra/packages/api/internal"
@@ -250,8 +251,16 @@ func isUnknownVolumeTypeError(err error) (string, bool) {
 }
 
 func isRetryableError(err error) bool {
-	if errors.Is(err, net.ErrClosed) || errors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, net.ErrClosed) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return true
+	}
+
+	st, ok := status.FromError(err)
+	if ok {
+		switch st.Code() {
+		case codes.Unavailable, codes.DeadlineExceeded, codes.Canceled:
+			return true
+		}
 	}
 
 	return false

--- a/packages/api/internal/handlers/volume_util_test.go
+++ b/packages/api/internal/handlers/volume_util_test.go
@@ -1,11 +1,16 @@
 package handlers
 
 import (
+	"context"
+	"errors"
+	"net"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/api/internal/cfg"
@@ -151,3 +156,73 @@ func TestFindNodesByVolumeLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestIsRetryableError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error is not retryable",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "net.ErrClosed is retryable",
+			err:      net.ErrClosed,
+			expected: true,
+		},
+		{
+			name:     "context.DeadlineExceeded is retryable",
+			err:      context.DeadlineExceeded,
+			expected: true,
+		},
+		{
+			name:     "context.Canceled is retryable",
+			err:      context.Canceled,
+			expected: true,
+		},
+		{
+			name:     "gRPC codes.Unavailable is retryable",
+			err:      status.Error(codes.Unavailable, "connection refused"),
+			expected: true,
+		},
+		{
+			name:     "gRPC codes.DeadlineExceeded is retryable",
+			err:      status.Error(codes.DeadlineExceeded, "context deadline exceeded"),
+			expected: true,
+		},
+		{
+			name:     "gRPC codes.Canceled is retryable",
+			err:      status.Error(codes.Canceled, "request canceled"),
+			expected: true,
+		},
+		{
+			name:     "gRPC codes.NotFound is not retryable",
+			err:      status.Error(codes.NotFound, "volume not found"),
+			expected: false,
+		},
+		{
+			name:     "gRPC codes.InvalidArgument is not retryable",
+			err:      status.Error(codes.InvalidArgument, "bad volume name"),
+			expected: false,
+		},
+		{
+			name:     "generic error is not retryable",
+			err:      errors.New("something went wrong"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, isRetryableError(tc.err))
+		})
+	}
+}
+


### PR DESCRIPTION
Closes #3577

## Summary

- Update `isRetryableError` in `packages/api/internal/handlers/volume_util.go` to extract `status.FromError(err)` and return `true` for `codes.Unavailable`, `codes.DeadlineExceeded`, and `codes.Canceled`.
- Ensure `executeOnOrchestratorByClusterID` properly retries subsequent candidate nodes in the cluster when an orchestrator node is down, unreachable, or timing out.
- Add comprehensive table-driven unit tests in `packages/api/internal/handlers/volume_util_test.go` covering standard errors and gRPC status codes.

## Why

In `packages/api/internal/handlers/volume_util.go`, when a volume creation or deletion RPC was attempted on a node that was rebooting or unavailable, gRPC returned `status.Error(codes.Unavailable, ...)`. Because `isRetryableError` only checked `errors.Is(err, net.ErrClosed)`, gRPC status errors evaluated to `false`, causing the loop to abort on the first node rather than failing over to other healthy nodes in the cluster pool.

## Diff Overview

```diff
 func isRetryableError(err error) bool {
-	if errors.Is(err, net.ErrClosed) || errors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, net.ErrClosed) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return true
 	}
 
+	st, ok := status.FromError(err)
+	if ok {
+		switch st.Code() {
+		case codes.Unavailable, codes.DeadlineExceeded, codes.Canceled:
+			return true
+		}
+	}
+
 	return false
 }
```

## Test Plan

- [x] Unit test: `go test -v ./packages/api/internal/handlers -run TestIsRetryableError` (10 test cases verified)
- [x] Package test suite passes: `go test -v ./packages/api/internal/handlers/...`
- [x] Linter & Formatter pass: `make fmt` and `make lint`
- [x] Verified `codes.Unavailable`, `codes.DeadlineExceeded`, and `codes.Canceled` return `true` while terminal errors return `false`

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi