### PR TITLE
fix(api): validate timeout is positive in PostSandboxesSandboxIDConnect

### DIFF
--- a/packages/api/internal/handlers/sandbox_connect.go
+++ b/packages/api/internal/handlers/sandbox_connect.go
@@ -42,6 +42,12 @@ func (a *APIStore) PostSandboxesSandboxIDConnect(c *gin.Context, sandboxID api.S
 		return
 	}
 
+	if body.Timeout <= 0 {
+		a.sendAPIStoreError(c, http.StatusBadRequest, "Timeout must be greater than 0")
+
+		return
+	}
+
 	timeout := time.Duration(body.Timeout) * time.Second
 	if timeout > time.Duration(teamInfo.Limits.MaxLengthHours)*time.Hour {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Timeout cannot be greater than %d hours", teamInfo.Limits.MaxLengthHours))

--- a/packages/api/internal/handlers/sandbox_timeout_validation_test.go
+++ b/packages/api/internal/handlers/sandbox_timeout_validation_test.go
@@ -112,3 +112,43 @@ func TestSandboxFork_RejectsNonPositiveTimeout(t *testing.T) {
 		})
 	}
 }
+
+// TestSandboxConnect_RejectsNonPositiveTimeout verifies that POST /sandboxes/{id}/connect
+// returns 400 for zero and negative timeout values. The check runs before any
+// sandbox-ID length check or snapshot lookup.
+func TestSandboxConnect_RejectsNonPositiveTimeout(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		timeout int32
+	}{
+		{"zero", 0},
+		{"negative one", -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			store := &APIStore{}
+
+			recorder := httptest.NewRecorder()
+			ginCtx, _ := gin.CreateTestContext(recorder)
+
+			body, err := json.Marshal(api.PostSandboxesSandboxIDConnectJSONRequestBody{
+				Timeout: tc.timeout,
+			})
+			require.NoError(t, err)
+
+			ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodPost, "/sandboxes/abc/connect", bytes.NewReader(body))
+			ginCtx.Request.Header.Set("Content-Type", "application/json")
+			auth.SetTeamInfoForTest(t, ginCtx, minimalTeamInfo())
+
+			//nolint:contextcheck // handler reads ctx from ginCtx.Request.Context().
+			store.PostSandboxesSandboxIDConnect(ginCtx, "abc123")
+
+			assertBadRequestTimeout(t, recorder)
+		})
+	}
+}
+


### PR DESCRIPTION
Closes #3579

## Summary

- Enforce `if body.Timeout <= 0` validation in `PostSandboxesSandboxIDConnect` (`POST /sandboxes/{id}/connect`), returning `400 Bad Request` ("Timeout must be greater than 0") when timeout is non-positive.
- Bring `PostSandboxesSandboxIDConnect` in alignment with `PostSandboxes`, `PostSandboxesSandboxIDResume`, and `PostSandboxesSandboxIDFork`.
- Add unit test coverage in `packages/api/internal/handlers/sandbox_timeout_validation_test.go` verifying zero and negative timeout values are rejected early.

## Why

In `packages/api/internal/handlers/sandbox_connect.go`, `body.Timeout` was only validated against the maximum length limit (`MaxLengthHours`). Supplying `0` or negative values resulted in a negative/zero sandbox lifetime passed to `startSandbox`, which immediately terminated the connected sandbox due to the expiration timestamp being in the past.

## Diff Overview

```diff
 	body, err := ginutils.ParseBody[api.PostSandboxesSandboxIDConnectJSONRequestBody](ctx, c)
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Error when parsing request: %s", err))
 
 		telemetry.ReportCriticalError(ctx, "error when parsing request", err)
 
 		return
 	}
 
+	if body.Timeout <= 0 {
+		a.sendAPIStoreError(c, http.StatusBadRequest, "Timeout must be greater than 0")
+
+		return
+	}
+
 	timeout := time.Duration(body.Timeout) * time.Second
 	if timeout > time.Duration(teamInfo.Limits.MaxLengthHours)*time.Hour {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Timeout cannot be greater than %d hours", teamInfo.Limits.MaxLengthHours))
```

## Test Plan

- [x] Unit test: `go test -v ./packages/api/internal/handlers -run TestSandboxConnect_RejectsNonPositiveTimeout`
- [x] Package test suite passes: `go test -v ./packages/api/internal/handlers/...`
- [x] Linter & Formatter pass: `make fmt` and `make lint`
- [x] Confirmed `timeout: 0` and `timeout: -1` return `400 Bad Request` ("Timeout must be greater than 0")

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi