### PR TITLE
fix(envd): clean up error formatting when watch path is not a directory

### DIFF
--- a/packages/envd/internal/services/filesystem/watch.go
+++ b/packages/envd/internal/services/filesystem/watch.go
@@ -41,7 +41,7 @@ func (s Service) watchHandler(ctx context.Context, req *connect.Request[rpc.Watc
 	}
 
 	if !info.IsDir() {
-		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("path %s not a directory: %w", watchPath, err))
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("path %s is not a directory", watchPath))
 	}
 
 	// Check if path is on a network filesystem mount

--- a/packages/envd/internal/services/filesystem/watch_sync.go
+++ b/packages/envd/internal/services/filesystem/watch_sync.go
@@ -168,7 +168,7 @@ func (s Service) CreateWatcher(ctx context.Context, req *connect.Request[rpc.Cre
 	}
 
 	if !info.IsDir() {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("path %s not a directory: %w", watchPath, err))
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("path %s is not a directory", watchPath))
 	}
 
 	// Check if path is on a network filesystem mount

--- a/packages/envd/internal/services/filesystem/watch_test.go
+++ b/packages/envd/internal/services/filesystem/watch_test.go
@@ -215,3 +215,25 @@ func TestCreateWatcherOnNetworkMount(t *testing.T) {
 	})
 	assert.NotEmpty(t, watcherID)
 }
+
+func TestCreateWatcher_NotADirectory(t *testing.T) {
+	t.Parallel()
+
+	u, err := user.Current()
+	require.NoError(t, err)
+
+	filePath := filepath.Join(t.TempDir(), "file.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("content"), 0o644))
+
+	svc := mockService()
+	ctx := authn.SetInfo(t.Context(), u)
+
+	_, err = svc.CreateWatcher(ctx, connect.NewRequest(&filesystem.CreateWatcherRequest{
+		Path: filePath,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "is not a directory")
+	assert.NotContains(t, err.Error(), "%!w")
+}
+


### PR DESCRIPTION
Closes #3581

## Summary

- Remove `%w` formatting verb on `nil` error in `packages/envd/internal/services/filesystem/watch.go` and `watch_sync.go` when the requested watch path is not a directory.
- Return clean error message: `path <path> is not a directory` instead of `path <path> not a directory: %!w(<nil>)`.
- Add unit test `TestCreateWatcher_NotADirectory` in `packages/envd/internal/services/filesystem/watch_test.go` asserting clean error strings without `%!w`.

## Why

In `watch.go` and `watch_sync.go`, when `os.Stat` succeeds for a non-directory path, `err` is `nil`. Calling `fmt.Errorf("path %s not a directory: %w", watchPath, err)` resulted in `%!w(<nil>)` being appended to the error string returned across the Connect-RPC wire and emitted in server logs.

## Diff Overview

```diff
 	if !info.IsDir() {
-		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("path %s not a directory: %w", watchPath, err))
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("path %s is not a directory", watchPath))
 	}
```

## Test Plan

- [x] Unit test: `go test -v ./packages/envd/internal/services/filesystem -run TestCreateWatcher_NotADirectory`
- [x] Package test suite passes: `go test -v ./packages/envd/internal/services/filesystem/...`
- [x] Linter & Formatter pass: `make fmt` and `make lint`
- [x] Verified error output contains `"is not a directory"` and does not contain `"%!w"`

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi