### PR TITLE
orchestrator: include current/max counts in ResourceExhausted error messages

### DIFF
--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -152,7 +152,7 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 	if runningSandboxes >= maxRunningSandboxesPerNode {
 		telemetry.ReportEvent(ctx, "max number of running sandboxes reached")
 
-		return nil, status.Errorf(codes.ResourceExhausted, "max number of running sandboxes on node reached (%d), please retry", maxRunningSandboxesPerNode)
+		return nil, status.Errorf(codes.ResourceExhausted, "max number of running sandboxes on node reached: current=%d, max=%d, please retry", runningSandboxes, maxRunningSandboxesPerNode)
 	}
 
 	// Check if we've reached the max number of starting instances on this node
@@ -166,7 +166,7 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 		if !acquired {
 			telemetry.ReportEvent(ctx, "too many starting sandboxes on node")
 
-			return nil, status.Errorf(codes.ResourceExhausted, "too many sandboxes starting on this node, please retry")
+			return nil, status.Errorf(codes.ResourceExhausted, "too many sandboxes starting on this node: current=%d, max=%d, please retry", s.startingSandboxes.Current(), s.startingSandboxes.Limit())
 		}
 	}
 	defer s.startingSandboxes.Release(1)

--- a/packages/orchestrator/pkg/server/utils.go
+++ b/packages/orchestrator/pkg/server/utils.go
@@ -22,7 +22,7 @@ func (s *Server) waitForAcquire(ctx context.Context) error {
 	if err != nil {
 		telemetry.ReportEvent(ctx, "too many resuming sandboxes on node")
 
-		return status.Errorf(codes.ResourceExhausted, "too many sandboxes resuming on this node, please retry")
+		return status.Errorf(codes.ResourceExhausted, "too many sandboxes resuming on this node: current=%d, max=%d, please retry", s.startingSandboxes.Current(), s.startingSandboxes.Limit())
 	}
 
 	return nil

--- a/packages/shared/pkg/utils/resizable_semaphore.go
+++ b/packages/shared/pkg/utils/resizable_semaphore.go
@@ -92,6 +92,20 @@ func (s *AdjustableSemaphore) SetLimit(limit int64) error {
 	return nil
 }
 
+func (s *AdjustableSemaphore) Current() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.used
+}
+
+func (s *AdjustableSemaphore) Limit() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.limit
+}
+
 func (s *AdjustableSemaphore) Release(n int64) {
 	if n <= 0 {
 		panic("Release: n must be > 0")


### PR DESCRIPTION
Fixes #3583

## Problem

When the orchestrator returns a `ResourceExhausted` gRPC error and the API logs "Node exhausted, trying another node", the attached error string carries no count information. All three `ResourceExhausted` sites were either missing the current value or missing both current and max:

```
// only max, no current:
"max number of running sandboxes on node reached (%d), please retry"

// no numbers at all:
"too many sandboxes starting on this node, please retry"
"too many sandboxes resuming on this node, please retry"
```

## Changes

- **`packages/shared/pkg/utils/resizable_semaphore.go`**: Add `Current() int64` and `Limit() int64` accessors to `AdjustableSemaphore`
- **`packages/orchestrator/pkg/server/sandboxes.go`**: Include `current=N, max=M` in both running-sandboxes and starting-sandboxes error messages
- **`packages/orchestrator/pkg/server/utils.go`**: Include `current=N, max=M` in the resuming-sandboxes error message

## After this change

```
"max number of running sandboxes on node reached: current=50, max=50, please retry"
"too many sandboxes starting on this node: current=10, max=10, please retry"
"too many sandboxes resuming on this node: current=10, max=10, please retry"
```

This makes the "Node exhausted, trying another node" log line actionable — operators can now tell at a glance whether the node is fully saturated or just throttled on in-flight starts.

## Test plan

- [ ] Verify `go build ./packages/shared/...` passes
- [ ] Verify `go vet ./packages/shared/pkg/utils/...` passes
- [ ] Manually trigger a sandbox create against a node at its `MaxSandboxesPerNode` limit and confirm the log line now includes current/max counts