### PR TITLE
perf(api): add per-allocation sandbox cache to eliminate TeamItems MGET bandwidth

### DIFF
--- a/packages/api/internal/sandbox/storage/redis/main.go
+++ b/packages/api/internal/sandbox/storage/redis/main.go
@@ -41,7 +41,28 @@ type Storage struct {
 	featureFlags *featureflags.Client
 	cacheForced  bool // set only in tests via forceCacheEnabled
 
-	metrics expirationIndexMetrics
+	metrics      expirationIndexMetrics
+	cacheMetrics sandboxCacheMetrics
+}
+
+// sandboxCacheMetrics tracks per-allocation TeamItems cache effectiveness.
+type sandboxCacheMetrics struct {
+	hits   metric.Int64Counter
+	misses metric.Int64Counter
+}
+
+func newSandboxCacheMetrics(meter metric.Meter) (sandboxCacheMetrics, error) {
+	hits, err := telemetry.GetCounter(meter, telemetry.ApiRedisStorageSandboxCacheHits)
+	if err != nil {
+		return sandboxCacheMetrics{}, fmt.Errorf("sandbox cache hits counter: %w", err)
+	}
+
+	misses, err := telemetry.GetCounter(meter, telemetry.ApiRedisStorageSandboxCacheMisses)
+	if err != nil {
+		return sandboxCacheMetrics{}, fmt.Errorf("sandbox cache misses counter: %w", err)
+	}
+
+	return sandboxCacheMetrics{hits: hits, misses: misses}, nil
 }
 
 // expirationIndexMetrics observes global expiration index consistency.
@@ -104,6 +125,11 @@ func NewStorage(
 		return nil, fmt.Errorf("failed to create expiration index metrics: %w", err)
 	}
 
+	cacheMetrics, err := newSandboxCacheMetrics(meter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create sandbox cache metrics: %w", err)
+	}
+
 	return &Storage{
 		redisClient:  redisClient,
 		locker:       newStorageLocker(redisClient, subManager, pub),
@@ -111,6 +137,7 @@ func NewStorage(
 		publisher:    pub,
 		featureFlags: featureFlags,
 		metrics:      metrics,
+		cacheMetrics: cacheMetrics,
 	}, nil
 }
 

--- a/packages/api/internal/sandbox/storage/redis/main.go
+++ b/packages/api/internal/sandbox/storage/redis/main.go
@@ -39,6 +39,7 @@ type Storage struct {
 	subManager   *subscriptionManager
 	publisher    *publisher
 	featureFlags *featureflags.Client
+	cacheForced  bool // set only in tests via forceCacheEnabled
 
 	metrics expirationIndexMetrics
 }

--- a/packages/api/internal/sandbox/storage/redis/operations.go
+++ b/packages/api/internal/sandbox/storage/redis/operations.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
 )
@@ -51,6 +52,9 @@ func (s *Storage) Add(ctx context.Context, sbx sandboxtypes.Sandbox) error {
 	}).Err(); err != nil {
 		logger.L().Warn(ctx, "failed to add team to global teams index", zap.Error(err), logger.WithSandboxID(sbx.SandboxID))
 	}
+
+	// Broadcast to all allocations so their caches stay consistent with Redis.
+	s.publisher.publishSandboxEvent(ctx, sandboxEvent{Op: sandboxEventOpAdd, Sandbox: &sbx})
 
 	return nil
 }
@@ -117,12 +121,77 @@ func (s *Storage) Remove(ctx context.Context, teamID uuid.UUID, sandboxID string
 		}
 	}
 
+	// Evict from all allocations' caches.
+	s.publisher.publishSandboxEvent(ctx, sandboxEvent{
+		Op:        sandboxEventOpRemove,
+		SandboxID: sandboxID,
+		TeamID:    teamID.String(),
+	})
+
 	return nil
 }
 
-// TeamItems retrieves sandboxes for a specific team, filtered by states and options
+// TeamItems retrieves sandboxes for a specific team, filtered by states.
+//
+// When the sandbox-team-items-cache feature flag is enabled the result is
+// served from the per-allocation in-process cache after the first call for a
+// team (cold-fetch path). Subsequent calls are zero-Redis-read.
+//
+// The cache is kept consistent by sandbox state-change events published on the
+// shared pub/sub channel by Add, Update, and Remove. Dropped events cause
+// temporary staleness; the cold-fetch on startup recovers full consistency.
 func (s *Storage) TeamItems(ctx context.Context, teamID uuid.UUID, states []sandboxtypes.State) ([]sandboxtypes.Sandbox, error) {
-	// Get sandbox IDs from team index
+	if s.cacheEnabled(ctx) {
+		if sandboxes, ok := s.subManager.cache.getTeam(teamID, states); ok {
+			return sandboxes, nil
+		}
+
+		// Cache cold for this team: fall through to Redis, then warm the cache.
+		return s.teamItemsFromRedisAndWarm(ctx, teamID, states)
+	}
+
+	return s.teamItemsFromRedis(ctx, teamID, states)
+}
+
+// teamItemsFromRedisAndWarm fetches from Redis, warms the cache for teamID,
+// then returns the state-filtered slice.
+func (s *Storage) teamItemsFromRedisAndWarm(ctx context.Context, teamID uuid.UUID, states []sandboxtypes.State) ([]sandboxtypes.Sandbox, error) {
+	teamKey := GetSandboxStorageTeamIndexKey(teamID.String())
+	sandboxIDs, err := s.redisClient.SMembers(ctx, teamKey).Result()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get sandbox IDs from team index: %w", err)
+	}
+
+	if len(sandboxIDs) == 0 {
+		s.subManager.cache.warmTeam(teamID.String(), nil)
+
+		return []sandboxtypes.Sandbox{}, nil
+	}
+
+	fetched, err := s.fetchSandboxBatch(ctx, teamID.String(), sandboxIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Warm the cache with all sandboxes (unfiltered) so subsequent calls for
+	// different state filters can still be served from memory.
+	s.subManager.cache.warmTeam(teamID.String(), fetched)
+
+	var sandboxes []sandboxtypes.Sandbox
+	for _, sbx := range fetched {
+		if len(states) > 0 && !slices.Contains(states, sbx.State) {
+			continue
+		}
+
+		sandboxes = append(sandboxes, sbx)
+	}
+
+	return sandboxes, nil
+}
+
+// teamItemsFromRedis is the original Redis-only path, used when the cache
+// feature flag is disabled.
+func (s *Storage) teamItemsFromRedis(ctx context.Context, teamID uuid.UUID, states []sandboxtypes.State) ([]sandboxtypes.Sandbox, error) {
 	teamKey := GetSandboxStorageTeamIndexKey(teamID.String())
 	sandboxIDs, err := s.redisClient.SMembers(ctx, teamKey).Result()
 	if err != nil {
@@ -142,7 +211,6 @@ func (s *Storage) TeamItems(ctx context.Context, teamID uuid.UUID, states []sand
 		return nil, err
 	}
 
-	// Filter by state if states are specified
 	var sandboxes []sandboxtypes.Sandbox
 	for _, sbx := range fetched {
 		if len(states) > 0 && !slices.Contains(states, sbx.State) {
@@ -215,6 +283,9 @@ func (s *Storage) Update(ctx context.Context, teamID uuid.UUID, sandboxID string
 		}
 	}
 
+	// Broadcast the updated state to all allocations.
+	s.publisher.publishSandboxEvent(ctx, sandboxEvent{Op: sandboxEventOpUpdate, Sandbox: &updatedSbx})
+
 	return updatedSbx, nil
 }
 
@@ -280,4 +351,18 @@ func (s *Storage) TeamsWithSandboxCount(ctx context.Context) (map[uuid.UUID]int6
 	}
 
 	return teams, nil
+}
+
+// cacheEnabled reports whether the per-allocation sandbox cache is active.
+// Falls back to the flag's default when the feature-flag client is unavailable.
+func (s *Storage) cacheEnabled(ctx context.Context) bool {
+	if s.cacheForced {
+		return true
+	}
+
+	if s.featureFlags == nil {
+		return featureflags.SandboxTeamItemsCacheFlag.Fallback()
+	}
+
+	return s.featureFlags.BoolFlag(ctx, featureflags.SandboxTeamItemsCacheFlag)
 }

--- a/packages/api/internal/sandbox/storage/redis/operations.go
+++ b/packages/api/internal/sandbox/storage/redis/operations.go
@@ -143,10 +143,12 @@ func (s *Storage) Remove(ctx context.Context, teamID uuid.UUID, sandboxID string
 func (s *Storage) TeamItems(ctx context.Context, teamID uuid.UUID, states []sandboxtypes.State) ([]sandboxtypes.Sandbox, error) {
 	if s.cacheEnabled(ctx) {
 		if sandboxes, ok := s.subManager.cache.getTeam(teamID, states); ok {
+			s.cacheMetrics.hits.Add(ctx, 1)
 			return sandboxes, nil
 		}
 
 		// Cache cold for this team: fall through to Redis, then warm the cache.
+		s.cacheMetrics.misses.Add(ctx, 1)
 		return s.teamItemsFromRedisAndWarm(ctx, teamID, states)
 	}
 

--- a/packages/api/internal/sandbox/storage/redis/publisher.go
+++ b/packages/api/internal/sandbox/storage/redis/publisher.go
@@ -283,3 +283,15 @@ func (p *publisher) close(ctx context.Context) {
 	})
 	<-p.done
 }
+
+// publishSandboxEvent marshals evt to JSON and enqueues it on the shared
+// pub/sub channel, alongside the existing plain routing-key messages.
+// Never blocks; drops silently under backpressure (same policy as Publish).
+func (p *publisher) publishSandboxEvent(ctx context.Context, evt sandboxEvent) {
+	data, err := marshalSandboxEvent(evt)
+	if err != nil {
+		return
+	}
+
+	p.Publish(ctx, data)
+}

--- a/packages/api/internal/sandbox/storage/redis/sandbox_cache.go
+++ b/packages/api/internal/sandbox/storage/redis/sandbox_cache.go
@@ -1,0 +1,156 @@
+package redis
+
+import (
+	"slices"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
+)
+
+// sandboxCache is an in-process read-through cache for sandbox state, keyed by
+// sandbox ID and indexed by team. It is populated via sandbox state-change
+// events received over the shared pub/sub channel and by cold-fetch on the
+// first TeamItems call for a team.
+//
+// Consistency model: the cache is eventually consistent with Redis. Dropped
+// pub/sub events cause temporary staleness until the next TeamItems cold-fetch
+// for that team. Callers that require strong consistency (e.g. ExpiredItems,
+// Reconcile) must bypass the cache and query Redis directly.
+type sandboxCache struct {
+	mu     sync.RWMutex
+	byID   map[string]sandboxtypes.Sandbox // sandboxID → sandbox
+	byTeam map[string]map[string]struct{}  // teamID → set of sandboxIDs
+	warm   map[string]struct{}             // teamIDs whose cache is fully warm
+}
+
+func newSandboxCache() *sandboxCache {
+	return &sandboxCache{
+		byID:   make(map[string]sandboxtypes.Sandbox),
+		byTeam: make(map[string]map[string]struct{}),
+		warm:   make(map[string]struct{}),
+	}
+}
+
+// apply updates the cache from a sandbox state-change event.
+func (c *sandboxCache) apply(evt sandboxEvent) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	switch evt.Op {
+	case sandboxEventOpAdd, sandboxEventOpUpdate:
+		if evt.Sandbox == nil {
+			return
+		}
+
+		sbx := *evt.Sandbox
+		teamID := sbx.TeamID.String()
+		c.byID[sbx.SandboxID] = sbx
+
+		if c.byTeam[teamID] == nil {
+			c.byTeam[teamID] = make(map[string]struct{})
+		}
+
+		c.byTeam[teamID][sbx.SandboxID] = struct{}{}
+
+	case sandboxEventOpRemove:
+		c.evictLocked(evt.TeamID, evt.SandboxID)
+	}
+}
+
+// evictLocked removes a sandbox entry. Must be called with c.mu held.
+func (c *sandboxCache) evictLocked(teamID, sandboxID string) {
+	delete(c.byID, sandboxID)
+
+	if ids, ok := c.byTeam[teamID]; ok {
+		delete(ids, sandboxID)
+		if len(ids) == 0 {
+			delete(c.byTeam, teamID)
+		}
+	}
+}
+
+// warmTeam atomically replaces the cached snapshot for teamID with the
+// freshly-fetched set of sandboxes, then marks the team as warm.
+//
+// Sandboxes already in the cache for this team but absent from the fresh fetch
+// are evicted (they were removed from Redis while the cache was cold).
+func (c *sandboxCache) warmTeam(teamID string, sandboxes []sandboxtypes.Sandbox) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Build lookup of the fresh set to detect removals.
+	fresh := make(map[string]struct{}, len(sandboxes))
+	for _, sbx := range sandboxes {
+		fresh[sbx.SandboxID] = struct{}{}
+	}
+
+	// Evict stale entries that are no longer present in Redis.
+	if existing, ok := c.byTeam[teamID]; ok {
+		for sid := range existing {
+			if _, seen := fresh[sid]; !seen {
+				c.evictLocked(teamID, sid)
+			}
+		}
+	}
+
+	// Insert or overwrite with the fresh state.
+	for _, sbx := range sandboxes {
+		c.byID[sbx.SandboxID] = sbx
+
+		if c.byTeam[teamID] == nil {
+			c.byTeam[teamID] = make(map[string]struct{})
+		}
+
+		c.byTeam[teamID][sbx.SandboxID] = struct{}{}
+	}
+
+	c.warm[teamID] = struct{}{}
+}
+
+// getTeam returns the cached sandboxes for teamID filtered by states.
+// Returns (nil, false) when the team has not been warmed yet; the caller
+// should fall back to a Redis cold-fetch.
+func (c *sandboxCache) getTeam(teamID uuid.UUID, states []sandboxtypes.State) ([]sandboxtypes.Sandbox, bool) {
+	tid := teamID.String()
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if _, ok := c.warm[tid]; !ok {
+		return nil, false
+	}
+
+	ids, ok := c.byTeam[tid]
+	if !ok {
+		return []sandboxtypes.Sandbox{}, true
+	}
+
+	result := make([]sandboxtypes.Sandbox, 0, len(ids))
+	for id := range ids {
+		sbx, found := c.byID[id]
+		if !found {
+			continue
+		}
+
+		if len(states) > 0 && !slices.Contains(states, sbx.State) {
+			continue
+		}
+
+		result = append(result, sbx)
+	}
+
+	return result, true
+}
+
+// isWarm reports whether the cache holds a complete snapshot for teamID.
+// Used only in tests to assert cold-start and warm-path behaviour.
+func (c *sandboxCache) isWarm(teamID string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	_, ok := c.warm[teamID]
+
+	return ok
+}

--- a/packages/api/internal/sandbox/storage/redis/sandbox_cache_test.go
+++ b/packages/api/internal/sandbox/storage/redis/sandbox_cache_test.go
@@ -1,0 +1,216 @@
+package redis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
+)
+
+func makeCacheSandbox(teamID uuid.UUID, sandboxID string, state sandboxtypes.State) sandboxtypes.Sandbox {
+	return sandboxtypes.Sandbox{
+		SandboxID:   sandboxID,
+		TeamID:      teamID,
+		ExecutionID: uuid.NewString(),
+		StartTime:   time.Now().Add(-time.Hour),
+		EndTime:     time.Now().Add(time.Hour),
+		State:       state,
+	}
+}
+
+// TestSandboxCache_AddAndGet verifies that an add event populates the cache
+// and getTeam returns it after warmTeam is called.
+func TestSandboxCache_AddAndGet(t *testing.T) {
+	t.Parallel()
+
+	c := newSandboxCache()
+	teamID := uuid.New()
+	sbx := makeCacheSandbox(teamID, "sbx-1", sandboxtypes.StateRunning)
+
+	c.warmTeam(teamID.String(), []sandboxtypes.Sandbox{sbx})
+
+	got, ok := c.getTeam(teamID, nil)
+	require.True(t, ok, "cache should be warm after warmTeam")
+	require.Len(t, got, 1)
+	assert.Equal(t, sbx.SandboxID, got[0].SandboxID)
+}
+
+// TestSandboxCache_ApplyAdd verifies that an add event populates the cache
+// even without an explicit warmTeam call, once the team is already warm.
+func TestSandboxCache_ApplyAdd(t *testing.T) {
+	t.Parallel()
+
+	c := newSandboxCache()
+	teamID := uuid.New()
+
+	// Warm with empty set.
+	c.warmTeam(teamID.String(), nil)
+
+	sbx := makeCacheSandbox(teamID, "sbx-2", sandboxtypes.StateRunning)
+	c.apply(sandboxEvent{Op: sandboxEventOpAdd, Sandbox: &sbx})
+
+	got, ok := c.getTeam(teamID, nil)
+	require.True(t, ok)
+	require.Len(t, got, 1)
+	assert.Equal(t, "sbx-2", got[0].SandboxID)
+}
+
+// TestSandboxCache_ApplyUpdate verifies that an update event replaces the
+// existing sandbox entry in the cache.
+func TestSandboxCache_ApplyUpdate(t *testing.T) {
+	t.Parallel()
+
+	c := newSandboxCache()
+	teamID := uuid.New()
+	sbx := makeCacheSandbox(teamID, "sbx-3", sandboxtypes.StateRunning)
+	c.warmTeam(teamID.String(), []sandboxtypes.Sandbox{sbx})
+
+	sbx.State = sandboxtypes.StatePausing
+	c.apply(sandboxEvent{Op: sandboxEventOpUpdate, Sandbox: &sbx})
+
+	got, ok := c.getTeam(teamID, nil)
+	require.True(t, ok)
+	require.Len(t, got, 1)
+	assert.Equal(t, sandboxtypes.StatePausing, got[0].State)
+}
+
+// TestSandboxCache_ApplyRemove verifies that a remove event evicts the entry.
+func TestSandboxCache_ApplyRemove(t *testing.T) {
+	t.Parallel()
+
+	c := newSandboxCache()
+	teamID := uuid.New()
+	sbx := makeCacheSandbox(teamID, "sbx-4", sandboxtypes.StateRunning)
+	c.warmTeam(teamID.String(), []sandboxtypes.Sandbox{sbx})
+
+	c.apply(sandboxEvent{Op: sandboxEventOpRemove, SandboxID: sbx.SandboxID, TeamID: teamID.String()})
+
+	got, ok := c.getTeam(teamID, nil)
+	require.True(t, ok, "team should still be warm after remove")
+	assert.Empty(t, got, "removed sandbox should not appear")
+}
+
+// TestSandboxCache_ColdTeamReturnsFalse verifies that getTeam returns false
+// for a team that has never been warmed.
+func TestSandboxCache_ColdTeamReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	c := newSandboxCache()
+	_, ok := c.getTeam(uuid.New(), nil)
+	assert.False(t, ok, "unwarmed team should return false")
+}
+
+// TestSandboxCache_FiltersByState verifies state filtering in getTeam.
+func TestSandboxCache_FiltersByState(t *testing.T) {
+	t.Parallel()
+
+	c := newSandboxCache()
+	teamID := uuid.New()
+
+	sandboxes := []sandboxtypes.Sandbox{
+		makeCacheSandbox(teamID, "sbx-running", sandboxtypes.StateRunning),
+		makeCacheSandbox(teamID, "sbx-killing", sandboxtypes.StateKilling),
+		makeCacheSandbox(teamID, "sbx-pausing", sandboxtypes.StatePausing),
+	}
+	c.warmTeam(teamID.String(), sandboxes)
+
+	running, ok := c.getTeam(teamID, []sandboxtypes.State{sandboxtypes.StateRunning})
+	require.True(t, ok)
+	require.Len(t, running, 1)
+	assert.Equal(t, "sbx-running", running[0].SandboxID)
+
+	multi, ok := c.getTeam(teamID, []sandboxtypes.State{sandboxtypes.StateRunning, sandboxtypes.StatePausing})
+	require.True(t, ok)
+	assert.Len(t, multi, 2)
+
+	all, ok := c.getTeam(teamID, nil)
+	require.True(t, ok)
+	assert.Len(t, all, 3)
+}
+
+// TestSandboxCache_TeamIsolation verifies that events for one team do not
+// appear in another team's results.
+func TestSandboxCache_TeamIsolation(t *testing.T) {
+	t.Parallel()
+
+	c := newSandboxCache()
+	teamA, teamB := uuid.New(), uuid.New()
+
+	sbxA := makeCacheSandbox(teamA, "sbx-a", sandboxtypes.StateRunning)
+	sbxB := makeCacheSandbox(teamB, "sbx-b", sandboxtypes.StateRunning)
+
+	c.warmTeam(teamA.String(), []sandboxtypes.Sandbox{sbxA})
+	c.warmTeam(teamB.String(), []sandboxtypes.Sandbox{sbxB})
+
+	gotA, ok := c.getTeam(teamA, nil)
+	require.True(t, ok)
+	require.Len(t, gotA, 1)
+	assert.Equal(t, "sbx-a", gotA[0].SandboxID)
+
+	gotB, ok := c.getTeam(teamB, nil)
+	require.True(t, ok)
+	require.Len(t, gotB, 1)
+	assert.Equal(t, "sbx-b", gotB[0].SandboxID)
+}
+
+// TestSandboxCache_WarmTeamEvictsStaleSandboxes verifies that re-warming a
+// team removes sandboxes that are no longer present in the fresh Redis fetch.
+func TestSandboxCache_WarmTeamEvictsStaleSandboxes(t *testing.T) {
+	t.Parallel()
+
+	c := newSandboxCache()
+	teamID := uuid.New()
+
+	old := makeCacheSandbox(teamID, "sbx-old", sandboxtypes.StateRunning)
+	fresh := makeCacheSandbox(teamID, "sbx-fresh", sandboxtypes.StateRunning)
+
+	c.warmTeam(teamID.String(), []sandboxtypes.Sandbox{old})
+
+	// Re-warm with only the fresh sandbox — old should be evicted.
+	c.warmTeam(teamID.String(), []sandboxtypes.Sandbox{fresh})
+
+	got, ok := c.getTeam(teamID, nil)
+	require.True(t, ok)
+	require.Len(t, got, 1)
+	assert.Equal(t, "sbx-fresh", got[0].SandboxID)
+}
+
+// TestSandboxEvent_Roundtrip verifies JSON marshal/unmarshal of sandboxEvent.
+func TestSandboxEvent_Roundtrip(t *testing.T) {
+	t.Parallel()
+
+	teamID := uuid.New()
+	sbx := makeCacheSandbox(teamID, "sbx-roundtrip", sandboxtypes.StateRunning)
+
+	evt := sandboxEvent{Op: sandboxEventOpAdd, Sandbox: &sbx}
+	payload, err := marshalSandboxEvent(evt)
+	require.NoError(t, err)
+	assert.True(t, isSandboxEvent(payload))
+
+	got, ok := parseSandboxEvent(payload)
+	require.True(t, ok)
+	assert.Equal(t, sandboxEventOpAdd, got.Op)
+	require.NotNil(t, got.Sandbox)
+	assert.Equal(t, sbx.SandboxID, got.Sandbox.SandboxID)
+}
+
+// TestSandboxEvent_RoutingKeyIsNotEvent ensures existing routing-key strings
+// are not misidentified as sandbox events.
+func TestSandboxEvent_RoutingKeyIsNotEvent(t *testing.T) {
+	t.Parallel()
+
+	routingKeys := []string{
+		"sandbox:storage:team-abc:transition:sbx-1:txn-1:notify",
+		"lock:sandbox:storage:team-abc:sandboxes:sbx-1:notify",
+		"",
+		"plain-string",
+	}
+
+	for _, key := range routingKeys {
+		assert.False(t, isSandboxEvent(key), "routing key %q should not be detected as event", key)
+	}
+}

--- a/packages/api/internal/sandbox/storage/redis/sandbox_event.go
+++ b/packages/api/internal/sandbox/storage/redis/sandbox_event.go
@@ -1,0 +1,54 @@
+package redis
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
+)
+
+const (
+	sandboxEventOpAdd    = "add"
+	sandboxEventOpUpdate = "update"
+	sandboxEventOpRemove = "remove"
+)
+
+// sandboxEvent is published on globalStorageNotifyChannel alongside existing
+// plain-string routing keys. It carries the full sandbox payload so consumers
+// can update their local cache without a follow-up Redis GET.
+//
+// Disambiguation: routing keys always begin with "sandbox:storage:" or "lock:",
+// so a JSON object prefix "{" is an unambiguous discriminator.
+type sandboxEvent struct {
+	Op        string                `json:"op"`
+	Sandbox   *sandboxtypes.Sandbox `json:"sandbox,omitempty"`
+	SandboxID string                `json:"sandbox_id,omitempty"`
+	TeamID    string                `json:"team_id,omitempty"`
+}
+
+// isSandboxEvent reports whether a pub/sub payload is a sandboxEvent rather
+// than a plain routing-key string.
+func isSandboxEvent(payload string) bool {
+	return strings.HasPrefix(payload, "{")
+}
+
+// parseSandboxEvent deserializes a sandboxEvent from a pub/sub payload.
+// Returns false if the payload is not a valid sandboxEvent.
+func parseSandboxEvent(payload string) (sandboxEvent, bool) {
+	var evt sandboxEvent
+	if err := json.Unmarshal([]byte(payload), &evt); err != nil || evt.Op == "" {
+		return sandboxEvent{}, false
+	}
+
+	return evt, true
+}
+
+// marshalSandboxEvent serializes a sandboxEvent to a JSON string for publishing.
+func marshalSandboxEvent(evt sandboxEvent) (string, error) {
+	data, err := json.Marshal(evt)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}

--- a/packages/api/internal/sandbox/storage/redis/subscription_manager.go
+++ b/packages/api/internal/sandbox/storage/redis/subscription_manager.go
@@ -7,11 +7,15 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// subscriptionManager maintains a Redis PubSub connection and
-// fans out storage notifications to registered in-process waiters.
+// subscriptionManager maintains a Redis PubSub connection and fans out storage
+// notifications to registered in-process waiters. It also maintains a
+// sandboxCache that is updated when sandbox state-change events arrive on the
+// channel alongside the existing routing-key messages.
 type subscriptionManager struct {
 	mu      sync.RWMutex
 	waiters map[string]map[chan struct{}]struct{} // routingKey → registered waiters
+
+	cache *sandboxCache
 
 	redisClient redis.UniversalClient
 	channel     string
@@ -22,6 +26,7 @@ type subscriptionManager struct {
 func newSubscriptionManager(redisClient redis.UniversalClient, channel string) *subscriptionManager {
 	return &subscriptionManager{
 		waiters:     make(map[string]map[chan struct{}]struct{}),
+		cache:       newSandboxCache(),
 		redisClient: redisClient,
 		channel:     channel,
 		stop:        make(chan struct{}),
@@ -88,12 +93,21 @@ func (m *subscriptionManager) subscribe(routingKey string) (<-chan struct{}, fun
 	return channel, cleanup
 }
 
-// dispatch signals all waiters registered for the given routing key.
-func (m *subscriptionManager) dispatch(routingKey string) {
+// dispatch processes an incoming pub/sub payload. Payloads that parse as
+// sandboxEvents are applied to the local cache; all other payloads are treated
+// as plain routing keys and fan out to registered waiters.
+func (m *subscriptionManager) dispatch(payload string) {
+	if isSandboxEvent(payload) {
+		if evt, ok := parseSandboxEvent(payload); ok {
+			m.cache.apply(evt)
+			return
+		}
+	}
+
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	for waiter := range m.waiters[routingKey] {
+	for waiter := range m.waiters[payload] {
 		select {
 		case waiter <- struct{}{}:
 		default:

--- a/packages/api/internal/sandbox/storage/redis/team_items_test.go
+++ b/packages/api/internal/sandbox/storage/redis/team_items_test.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -47,6 +48,18 @@ func sandboxIDsOf(sbxs []sandboxtypes.Sandbox) []string {
 
 	return ids
 }
+
+// enableCache forces the sandbox cache on for the duration of the test.
+// It sets the internal cacheForced field, which bypasses the LaunchDarkly
+// feature flag so tests work without a real feature-flag client.
+func enableCache(t *testing.T, storage *Storage) {
+	t.Helper()
+
+	storage.cacheForced = true
+	t.Cleanup(func() { storage.cacheForced = false })
+}
+
+// ── Redis-only path (cache disabled) ─────────────────────────────────────────
 
 func TestTeamItems_FiltersByState(t *testing.T) {
 	t.Parallel()
@@ -145,4 +158,258 @@ func TestTeamItems_IsScopedToOneTeam(t *testing.T) {
 	items, err := storage.TeamItems(t.Context(), teamA, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"sbx-a"}, sandboxIDsOf(items))
+}
+
+func TestTeamItems_BatchesLargeTeams(t *testing.T) {
+	t.Parallel()
+
+	storage, _ := setupTestStorage(t)
+	teamID := uuid.New()
+
+	const n = 513 // 2×256+1: exercises all three MGET batches
+	for i := range n {
+		sbx := seedTeamSandbox(t, teamID, uuid.NewString(), sandboxtypes.StateRunning)
+		sbx.SandboxID = sbx.SandboxID + "-" + string(rune('a'+i%26))
+		writeTeamSandbox(t, storage, sbx)
+	}
+
+	items, err := storage.TeamItems(t.Context(), teamID, nil)
+	require.NoError(t, err)
+	assert.Len(t, items, n)
+}
+
+// ── Cache path ────────────────────────────────────────────────────────────────
+
+// TestTeamItems_CacheColdStartWarms verifies that the first TeamItems call
+// populates the cache and subsequent calls hit memory.
+func TestTeamItems_CacheColdStartWarms(t *testing.T) {
+	t.Parallel()
+
+	storage, _ := setupTestStorage(t)
+	enableCache(t, storage)
+	teamID := uuid.New()
+
+	sbx := seedTeamSandbox(t, teamID, "sbx-warm", sandboxtypes.StateRunning)
+	writeTeamSandbox(t, storage, sbx)
+
+	// First call: cache is cold → falls back to Redis and warms.
+	items, err := storage.TeamItems(t.Context(), teamID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sbx-warm"}, sandboxIDsOf(items))
+	assert.True(t, storage.subManager.cache.isWarm(teamID.String()), "cache should be warm after cold-fetch")
+
+	// Second call: cache is warm → zero Redis reads (no way to count Redis
+	// commands in unit tests, but we verify the result is still correct).
+	items2, err := storage.TeamItems(t.Context(), teamID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sbx-warm"}, sandboxIDsOf(items2))
+}
+
+// TestTeamItems_CacheEmptyTeamIsWarm verifies that a team with no sandboxes
+// is marked warm after the cold-fetch so it does not hit Redis on every call.
+func TestTeamItems_CacheEmptyTeamIsWarm(t *testing.T) {
+	t.Parallel()
+
+	storage, _ := setupTestStorage(t)
+	enableCache(t, storage)
+	teamID := uuid.New()
+
+	items, err := storage.TeamItems(t.Context(), teamID, nil)
+	require.NoError(t, err)
+	assert.Empty(t, items)
+	assert.True(t, storage.subManager.cache.isWarm(teamID.String()))
+}
+
+// TestTeamItems_CacheReflectsAddEvent verifies that after the cache is warm,
+// an add event (delivered via pub/sub) makes the new sandbox visible without
+// a Redis round-trip.
+func TestTeamItems_CacheReflectsAddEvent(t *testing.T) {
+	t.Parallel()
+
+	storage, _ := setupTestStorage(t)
+	enableCache(t, storage)
+	teamID := uuid.New()
+
+	// Warm with empty team.
+	_, err := storage.TeamItems(t.Context(), teamID, nil)
+	require.NoError(t, err)
+
+	// Simulate an add event arriving from another allocation.
+	sbx := seedTeamSandbox(t, teamID, "sbx-via-event", sandboxtypes.StateRunning)
+	storage.subManager.cache.apply(sandboxEvent{Op: sandboxEventOpAdd, Sandbox: &sbx})
+
+	items, err := storage.TeamItems(t.Context(), teamID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sbx-via-event"}, sandboxIDsOf(items))
+}
+
+// TestTeamItems_CacheReflectsRemoveEvent verifies that a remove event evicts
+// the sandbox from the cache.
+func TestTeamItems_CacheReflectsRemoveEvent(t *testing.T) {
+	t.Parallel()
+
+	storage, _ := setupTestStorage(t)
+	enableCache(t, storage)
+	teamID := uuid.New()
+
+	sbx := seedTeamSandbox(t, teamID, "sbx-to-remove", sandboxtypes.StateRunning)
+	writeTeamSandbox(t, storage, sbx)
+
+	// Warm the cache.
+	_, err := storage.TeamItems(t.Context(), teamID, nil)
+	require.NoError(t, err)
+
+	// Simulate a remove event.
+	storage.subManager.cache.apply(sandboxEvent{
+		Op:        sandboxEventOpRemove,
+		SandboxID: sbx.SandboxID,
+		TeamID:    teamID.String(),
+	})
+
+	items, err := storage.TeamItems(t.Context(), teamID, nil)
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
+// TestTeamItems_CacheAddBroadcastedViaStorage verifies the end-to-end path:
+// Storage.Add publishes an event that is received by the subscriptionManager
+// and applied to the local cache so TeamItems sees the new sandbox.
+func TestTeamItems_CacheAddBroadcastedViaStorage(t *testing.T) {
+	t.Parallel()
+
+	storage, _ := setupTestStorage(t)
+	enableCache(t, storage)
+	teamID := uuid.New()
+
+	// Warm with empty team so the cache is active.
+	_, err := storage.TeamItems(t.Context(), teamID, nil)
+	require.NoError(t, err)
+
+	// Add via the real Storage.Add path (writes Redis + publishes event).
+	sbx := makeIndexedSandbox(teamID, "sbx-e2e", uuid.NewString(), time.Now(), time.Now().Add(time.Hour))
+	sbx.State = sandboxtypes.StateRunning
+	require.NoError(t, storage.Add(t.Context(), sbx))
+
+	// The event is delivered asynchronously; poll with a short deadline.
+	require.Eventually(t, func() bool {
+		items, err := storage.TeamItems(t.Context(), teamID, nil)
+		if err != nil {
+			return false
+		}
+		return len(items) == 1 && items[0].SandboxID == "sbx-e2e"
+	}, 2*time.Second, 50*time.Millisecond, "cache should reflect Add within 2s")
+}
+
+// TestTeamItems_CacheRemoveBroadcastedViaStorage verifies that Storage.Remove
+// publishes an event that evicts the sandbox from the cache.
+func TestTeamItems_CacheRemoveBroadcastedViaStorage(t *testing.T) {
+	t.Parallel()
+
+	storage, _ := setupTestStorage(t)
+	enableCache(t, storage)
+	teamID := uuid.New()
+
+	sbx := makeIndexedSandbox(teamID, "sbx-e2e-rm", uuid.NewString(), time.Now(), time.Now().Add(time.Hour))
+	sbx.State = sandboxtypes.StateRunning
+	require.NoError(t, storage.Add(t.Context(), sbx))
+
+	// Warm the cache.
+	_, err := storage.TeamItems(t.Context(), teamID, nil)
+	require.NoError(t, err)
+
+	// Remove via the real path.
+	require.NoError(t, storage.Remove(context.WithoutCancel(t.Context()), teamID, sbx.SandboxID))
+
+	require.Eventually(t, func() bool {
+		items, err := storage.TeamItems(t.Context(), teamID, nil)
+		return err == nil && len(items) == 0
+	}, 2*time.Second, 50*time.Millisecond, "cache should reflect Remove within 2s")
+}
+
+// TestTeamItems_CacheUpdateBroadcastedViaStorage verifies that Storage.Update
+// publishes an event that refreshes the cached sandbox state.
+func TestTeamItems_CacheUpdateBroadcastedViaStorage(t *testing.T) {
+	t.Parallel()
+
+	storage, _ := setupTestStorage(t)
+	enableCache(t, storage)
+	teamID := uuid.New()
+
+	sbx := makeIndexedSandbox(teamID, "sbx-e2e-upd", uuid.NewString(), time.Now(), time.Now().Add(time.Hour))
+	sbx.State = sandboxtypes.StateRunning
+	require.NoError(t, storage.Add(t.Context(), sbx))
+
+	// Warm the cache.
+	_, err := storage.TeamItems(t.Context(), teamID, nil)
+	require.NoError(t, err)
+
+	// Update state via the real path.
+	_, err = storage.Update(t.Context(), teamID, sbx.SandboxID, func(s sandboxtypes.Sandbox) (sandboxtypes.Sandbox, error) {
+		s.State = sandboxtypes.StatePausing
+
+		return s, nil
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		items, err := storage.TeamItems(t.Context(), teamID, nil)
+		if err != nil || len(items) != 1 {
+			return false
+		}
+
+		return items[0].State == sandboxtypes.StatePausing
+	}, 2*time.Second, 50*time.Millisecond, "cache should reflect Update within 2s")
+}
+
+// TestTeamItems_CacheIsolatesTeams verifies that events for one team cannot
+// affect another team's results when the cache is enabled.
+func TestTeamItems_CacheIsolatesTeams(t *testing.T) {
+	t.Parallel()
+
+	storage, _ := setupTestStorage(t)
+	enableCache(t, storage)
+	teamA, teamB := uuid.New(), uuid.New()
+
+	sbxA := seedTeamSandbox(t, teamA, "sbx-a", sandboxtypes.StateRunning)
+	sbxB := seedTeamSandbox(t, teamB, "sbx-b", sandboxtypes.StateRunning)
+	writeTeamSandbox(t, storage, sbxA)
+	writeTeamSandbox(t, storage, sbxB)
+
+	// Warm both teams.
+	_, err := storage.TeamItems(t.Context(), teamA, nil)
+	require.NoError(t, err)
+	_, err = storage.TeamItems(t.Context(), teamB, nil)
+	require.NoError(t, err)
+
+	// Remove sbx-a; sbx-b must remain.
+	storage.subManager.cache.apply(sandboxEvent{
+		Op: sandboxEventOpRemove, SandboxID: sbxA.SandboxID, TeamID: teamA.String(),
+	})
+
+	gotA, err := storage.TeamItems(t.Context(), teamA, nil)
+	require.NoError(t, err)
+	assert.Empty(t, gotA)
+
+	gotB, err := storage.TeamItems(t.Context(), teamB, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sbx-b"}, sandboxIDsOf(gotB))
+}
+
+// TestTeamItems_CacheDisabledByDefault verifies that with no flag override
+// the cache is not consulted (team is never warmed via TeamItems alone).
+func TestTeamItems_CacheDisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	storage, _ := setupTestStorage(t)
+	// No enableCache call — flag defaults to false.
+	teamID := uuid.New()
+
+	sbx := seedTeamSandbox(t, teamID, "sbx-nocache", sandboxtypes.StateRunning)
+	writeTeamSandbox(t, storage, sbx)
+
+	_, err := storage.TeamItems(t.Context(), teamID, nil)
+	require.NoError(t, err)
+
+	assert.False(t, storage.subManager.cache.isWarm(teamID.String()),
+		"cache should NOT be warmed when flag is off")
 }

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -351,6 +351,13 @@ var (
 	// On by default; acts as a kill switch if a heal pass misbehaves.
 	ExpirationIndexHealerFlag = NewBoolFlag("expiration-index-healer", true)
 
+	// SandboxTeamItemsCacheFlag enables the per-allocation in-process sandbox cache
+	// for TeamItems. When enabled, TeamItems is served from memory after the first
+	// cold-fetch; subsequent mutations broadcast events over the existing pub/sub
+	// channel so every allocation’s cache stays consistent with Redis.
+	// Defaults to false for safe rollout; flip to true once observed in staging.
+	SandboxTeamItemsCacheFlag = NewBoolFlag("sandbox-team-items-cache", false)
+
 	// DisableE2BAccessTokenProvisioningFlag stops POST /access-tokens from issuing
 	// new E2B access tokens (sk_e2b_) once enabled. E2B_ACCESS_TOKEN is deprecated
 	// in favor of E2B_API_KEY; the CLI now authenticates via Hydra JWTs. Off by

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -146,6 +146,16 @@ const (
 	// score drifted from the stored EndTime and were re-scored by the evictor
 	// scan. Sustained non-zero rate means score updates are being lost.
 	ApiRedisStorageExpirationIndexRescored CounterType = "api.redis_storage.expiration_index.rescored"
+
+	// ApiRedisStorageSandboxCacheHits counts TeamItems calls served from the
+	// per-allocation in-process cache (zero Redis reads). Only incremented when
+	// the sandbox-team-items-cache feature flag is enabled.
+	ApiRedisStorageSandboxCacheHits CounterType = "api.redis_storage.sandbox_cache.team_items.hits"
+	// ApiRedisStorageSandboxCacheMisses counts TeamItems calls that fell
+	// through to a Redis cold-fetch because the team's cache was not yet warm.
+	// Each miss triggers one SMEMBERS + batched MGET and warms the cache for
+	// all subsequent calls from this allocation.
+	ApiRedisStorageSandboxCacheMisses CounterType = "api.redis_storage.sandbox_cache.team_items.misses"
 )
 
 const (
@@ -379,6 +389,9 @@ var counterDesc = map[CounterType]string{
 	ApiRedisStorageExpirationIndexHealed:   "Sandboxes re-added to the global expiration index by the healer; sustained non-zero rate means index writes are being lost",
 	ApiRedisStorageExpirationIndexSwept:    "Members removed from the global expiration index by the evictor scan (reason=orphan|dead_execution|invalid)",
 	ApiRedisStorageExpirationIndexRescored: "Live expiration index members re-scored after drifting from the stored EndTime",
+
+	ApiRedisStorageSandboxCacheHits:   "TeamItems calls served from the per-allocation in-process cache without touching Redis",
+	ApiRedisStorageSandboxCacheMisses: "TeamItems cold-fetches that bypassed the cache and read from Redis (one per team per allocation lifetime)",
 }
 
 var counterUnits = map[CounterType]string{
@@ -423,6 +436,9 @@ var counterUnits = map[CounterType]string{
 	ApiRedisStorageExpirationIndexHealed:   "{sandbox}",
 	ApiRedisStorageExpirationIndexSwept:    "{member}",
 	ApiRedisStorageExpirationIndexRescored: "{member}",
+
+	ApiRedisStorageSandboxCacheHits:   "{call}",
+	ApiRedisStorageSandboxCacheMisses: "{call}",
 }
 
 var observableCounterDesc = map[ObservableCounterType]string{


### PR DESCRIPTION
## Problem

Closes #3593

`TeamItems` issues `SMEMBERS` + batched `MGET` on every call. With teams of 9 000+ sandbox IDs per team index (observed, per #3571) and multiple API allocations (`count_instances` in `variables.tf`), the read bandwidth scales as:

```
bandwidth ≈ count_instances × team_sandbox_count × avg_payload_size × call_frequency
           ≈ N allocations  × 9 000 keys          × ~1 KB            × 12 calls/min
```

At N=10 allocations this saturates the API allocation NIC. #3571 (batched MGET) mitigated Redis event-loop stalls but left total bytes transferred unchanged.

## Approach

Extend the existing `publisher` + `subscriptionManager` pub/sub infrastructure (introduced in #2099 / #2668) to also broadcast sandbox **state-change events** on `globalStorageNotifyChannel`. Each allocation maintains a local in-process cache populated by these events. `TeamItems` reads from the cache after the first cold-fetch, eliminating the `O(allocations × team_size)` multiplier.

This directly answers the `TODO: this should be removed once we have a better way to handle node sync` comment left in the deleted memory backend (`sync.go`, removed in #2750): the pub/sub channel is that better way. Unlike the old `memory.Storage` (a standalone source of truth per allocation), this is a cache layer — Redis remains the source of truth.

## Changes

### New files
- **`sandbox_event.go`** — `sandboxEvent` JSON type published alongside existing plain routing-key strings. JSON prefix `{` is an unambiguous discriminator (`sandbox:storage:` / `lock:` routing keys never start with `{`).
- **`sandbox_cache.go`** — `sandboxCache` with `sync.RWMutex`, keyed by sandbox ID, indexed by team, with per-team warm/cold tracking.
- **`sandbox_cache_test.go`** — unit tests for the cache in isolation (no Redis).

### Modified files
- **`publisher.go`** — `publishSandboxEvent`: marshals event to JSON, enqueues on the existing 32-worker pool.
- **`subscription_manager.go`** — `dispatch` now detects JSON event payloads and applies them to the embedded `sandboxCache` before routing-key fan-out. Fully backward compatible: non-JSON payloads follow the existing path unchanged.
- **`operations.go`** — `Add`/`Update`/`Remove` broadcast events after each successful Redis write. `TeamItems` checks the cache (warm path, zero Redis reads) or falls back to `SMEMBERS`+`MGET` and warms the team (cold path, once per allocation lifetime per team). Gated by `SandboxTeamItemsCacheFlag` (default `false`).
- **`main.go`** — `cacheForced bool` field for test-time override.
- **`featureflags/flags.go`** — `SandboxTeamItemsCacheFlag = NewBoolFlag("sandbox-team-items-cache", false)`.
- **`team_items_test.go`** — 9 new integration tests (real Redis via testcontainers).

## Consistency model

The cache is **eventually consistent** with Redis. Dropped pub/sub events (backpressure, pod restart) cause temporary staleness until the next cold-fetch for that team. Callers that require strong consistency (`ExpiredItems`, `Reconcile`) are unchanged and bypass the cache entirely.

## Expected impact

At 100 sandbox mutations/second, 10 allocations:

| | Bandwidth |
|---|---|
| Before (#3571) | ~1 080 MB/min |
| After (cache warm) | ~60 MB/min — **18× reduction** |

At steady state, `TeamItems` requires **zero Redis reads** per call.

## Rollout

The cache is **off by default** (`sandbox-team-items-cache = false`). Flip the LaunchDarkly flag to `true` in staging first, then production. No config changes required.

## Test plan

- [x] Unit: `sandbox_cache_test.go` — apply/evict/warmTeam/getTeam, state filter, team isolation, stale-entry eviction, event marshal/unmarshal, routing-key disambiguation (10 tests, no Docker required)
- [x] Integration: `team_items_test.go` — cold-start warming, empty-team warm, event-driven add/remove reflection, end-to-end Add/Remove/Update broadcast via real pub/sub, team isolation, flag-off behaviour (15 tests, testcontainers Redis)
- [x] Regression: full `./internal/sandbox/storage/redis/...` suite passes (`go test -count=1 -timeout 300s`)