### PR TITLE
fix(alpine): fix glibc busybox sync and missing /usr/bin/ionice+nice for musl builds

### DIFF
--- a/packages/orchestrator/pkg/template/build/phases/base/distro/init.go
+++ b/packages/orchestrator/pkg/template/build/phases/base/distro/init.go
@@ -145,6 +145,12 @@ echo "Disabling the chronyd seccomp filter"
 mkdir -p /etc/conf.d
 echo 'command_args="-F 0"' >>"/etc/conf.d/$E2B_TIMESYNC_UNIT"
 
+echo "Symlink ionice and nice into /usr/bin for envd OOM wrapper"
+# envd hard-codes /usr/bin/ionice and /usr/bin/nice in its OOM-score wrapper.
+# util-linux-misc installs ionice to /bin/ionice (not /usr/bin); busybox ships
+# nice to /bin/nice. Without these symlinks every envd-spawned command exits 127.
+ln -sf /bin/ionice /usr/bin/ionice
+ln -sf /bin/nice   /usr/bin/nice
 echo "Enable envd autostart"
 # The service script is baked at a neutral path (envd.openrc.tpl) so the
 # Debian family's update-rc.d never sees it; install it for OpenRC here.

--- a/packages/orchestrator/pkg/template/build/phases/base/distro/init.go
+++ b/packages/orchestrator/pkg/template/build/phases/base/distro/init.go
@@ -75,6 +75,7 @@ systemctl mask e2scrub_reap.service`,
 	// boot sequence and wire the runlevels a container image ships without.
 	InitOpenRC: `echo "Installing boot inittab (busybox init -> OpenRC runlevels)"
 printf '%s\n' \
+    '::sysinit:/bin/sh -c "mkdir -p /dev/pts && mount -t devpts devpts /dev/pts 2>/dev/null; [ -c /dev/ptmx ] || mknod /dev/ptmx c 5 2 2>/dev/null"' \
     '::sysinit:/sbin/openrc sysinit' \
     '::sysinit:/sbin/openrc boot' \
     '::wait:/sbin/openrc default' \

--- a/packages/orchestrator/pkg/template/build/sandboxtools/command.go
+++ b/packages/orchestrator/pkg/template/build/sandboxtools/command.go
@@ -249,13 +249,17 @@ func SyncChangesToDisk(
 	proxy *proxy.SandboxProxy,
 	sandboxID string,
 ) error {
+	// Use plain "sync" with an explicit PATH so this works on musl-based distros
+	// (e.g. Alpine) where the glibc-linked /usr/bin/busybox injected by e2b
+	// cannot be executed.
 	return RunCommand(
 		ctx,
 		proxy,
 		sandboxID,
-		rootfs.SandboxBusyBoxPath+" sync",
+		"sync",
 		metadata.Context{
-			User: "root",
+			User:    "root",
+			EnvVars: map[string]string{"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 		},
 	)
 }


### PR DESCRIPTION
## Problem

Fixes #3597

Three bugs cause Alpine template builds/sandboxes to fail.

## Changes

### 1. `sandboxtools/command.go` — fix `SyncChangesToDisk` for musl/Alpine

`SyncChangesToDisk` was invoking `/usr/bin/busybox sync` (glibc-linked, injected by e2b). On Alpine (musl libc) this binary cannot be executed. Replace with plain `sync` + an explicit `PATH` so any distro's native `sync` is found.

### 2. `distro/init.go` — add `/usr/bin/{ionice,nice}` symlinks in Alpine InitOpenRC

envd's OOM wrapper hard-codes `/usr/bin/ionice` and `/usr/bin/nice`. On Alpine:

- `util-linux-misc` installs `ionice` to `/bin/ionice` (not `/usr/bin/ionice`)
- `nice` is only at `/bin/nice` (busybox symlink)

Verified: `docker run --rm alpine:3.22 sh -c 'apk add --no-cache util-linux-misc >/dev/null 2>&1; ls /usr/bin/ionice /usr/bin/nice 2>&1'` → both `No such file or directory`. Without symlinks every command envd spawns during the step layer exits 127.

### 3. `distro/init.go` — mount devpts + ensure `/dev/ptmx` exists at boot

Without devpts mounted at `/dev/pts`, opening `/dev/ptmx` fails with `ENOENT`, breaking all PTY/terminal connections (`e2b sbx cr` returns `open /dev/ptmx: no such file or directory`).

On Alpine with busybox init + OpenRC: devtmpfs may not auto-mount `/dev/ptmx`, and OpenRC's `devfs` service does not mount devpts. Add an early `::sysinit` inittab entry (runs before `openrc sysinit`) that:

1. Mounts devpts at `/dev/pts`
2. Creates `/dev/ptmx` via `mknod` as a fallback if devtmpfs hasn't created it

## Test plan

- [ ] Build an Alpine 3.22 template — base layer and step layer complete without `exit status 127`
- [ ] `e2b sbx cr <alpine-template>` — terminal connects successfully (no `/dev/ptmx` error)
- [ ] Verify Debian/Ubuntu templates still work (sync + PTY unaffected)
