### PR TITLE
fix(api): remove Loki startup dependency

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,8 +136,9 @@ The control-plane entry point (Gin, OpenAPI-generated from `spec/openapi.yml`, p
   client-proxy can wake paused sandboxes on incoming traffic.
 - Reads ClickHouse for sandbox/team metrics endpoints. Sandbox and template-build logs default to
   Loki, with a LaunchDarkly-gated ClickHouse read path for local-cluster logs during the log
-  storage migration. LaunchDarkly feature flags also gate placement parameters, rate limits, and
-  rollouts.
+  storage migration. Loki is optional at API startup; if the flag selects a path with no configured
+  local persistent-log backend, log reads return 503 rather than bypassing the flag or returning
+  empty results. LaunchDarkly feature flags also gate placement parameters, rate limits, and rollouts.
 
 ### Orchestrator (`packages/orchestrator`)
 

--- a/packages/api/internal/cfg/model.go
+++ b/packages/api/internal/cfg/model.go
@@ -43,7 +43,7 @@ type Config struct {
 	ClickhouseConnectionStrings []string `env:"CLICKHOUSE_CONNECTION_STRINGS" envSeparator:";"`
 
 	LokiPassword string `env:"LOKI_PASSWORD"`
-	LokiURL      string `env:"LOKI_URL,required"`
+	LokiURL      string `env:"LOKI_URL"`
 	LokiUser     string `env:"LOKI_USER"`
 
 	// ServiceDiscoveryProvider selects how the API discovers orchestrator and template-manager instances.

--- a/packages/api/internal/cfg/model_test.go
+++ b/packages/api/internal/cfg/model_test.go
@@ -33,6 +33,14 @@ func TestParse(t *testing.T) {
 		assert.ErrorContains(t, err, `environment variable "POSTGRES_CONNECTION_STRING" should not be empty`)
 	})
 
+	t.Run("Loki URL is optional", func(t *testing.T) { //nolint:paralleltest // cannot call t.Setenv and t.Parallel
+		removeEnv(t, "LOKI_URL")
+
+		result, err := Parse()
+		require.NoError(t, err)
+		assert.Empty(t, result.LokiURL)
+	})
+
 	t.Run("base64 signing key can be parsed", func(t *testing.T) {
 		content := []byte{1, 2, 3, 4, 5, 6}
 		encoded := base64.StdEncoding.EncodeToString(content)

--- a/packages/api/internal/clusters/resources_local.go
+++ b/packages/api/internal/clusters/resources_local.go
@@ -2,6 +2,7 @@ package clusters
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -31,6 +32,23 @@ type ClickhouseLogsReader interface {
 }
 
 var _ ClickhouseLogsReader = (*sandboxlogs.Reader)(nil)
+
+type lokiLogsReader interface {
+	QuerySandboxLogs(ctx context.Context, teamID string, sandboxID string, start, end time.Time, limit int, direction logproto.Direction, level *logs.LogLevel, search *string) ([]logs.LogEntry, error)
+	QueryBuildLogs(ctx context.Context, templateID, buildID string, start, end time.Time, limit int, offset int32, level *logs.LogLevel, direction logproto.Direction) ([]logs.LogEntry, error)
+}
+
+var _ lokiLogsReader = (*loki.LokiQueryProvider)(nil)
+
+var errPersistentLogsUnavailable = errors.New("persistent log backend is unavailable")
+
+type persistentLogBackend uint8
+
+const (
+	persistentLogBackendUnavailable persistentLogBackend = iota
+	persistentLogBackendLoki
+	persistentLogBackendClickhouse
+)
 
 // logReadMeter/logReadErrorCount count ClickHouse log read failures so
 // operators can alert on them, broken down by log kind.
@@ -62,7 +80,7 @@ func recordClickhouseLogReadError(ctx context.Context, kind string) {
 type LocalClusterResourceProvider struct {
 	config                      cfg.Config
 	querySandboxMetricsProvider clickhouse.SandboxQueriesProvider
-	queryLogsProvider           *loki.LokiQueryProvider
+	queryLogsProvider           lokiLogsReader
 	sandboxLogsReader           ClickhouseLogsReader
 	featureFlags                *featureflags.Client
 	instances                   *smap.Map[*Instance]
@@ -76,25 +94,42 @@ func newLocalClusterResourceProvider(
 	instances *smap.Map[*Instance],
 	config cfg.Config,
 ) ClusterResource {
+	var logsReader lokiLogsReader
+	if queryLogsProvider != nil {
+		logsReader = queryLogsProvider
+	}
+
 	return &LocalClusterResourceProvider{
 		config:                      config,
 		querySandboxMetricsProvider: querySandboxMetricsProvider,
-		queryLogsProvider:           queryLogsProvider,
+		queryLogsProvider:           logsReader,
 		sandboxLogsReader:           sandboxLogsReader,
 		featureFlags:                featureFlags,
 		instances:                   instances,
 	}
 }
 
-// readFromClickhouse reports whether log reads should hit ClickHouse. It is
-// true only when the logs-read-config flag is enabled AND a ClickHouse reader
-// is configured; otherwise reads stay on Loki (default behavior).
-func (l *LocalClusterResourceProvider) readFromClickhouse(ctx context.Context) bool {
-	if l.sandboxLogsReader == nil || l.featureFlags == nil {
-		return false
+// persistentLogBackend preserves logs-read-config as the routing authority.
+// ClickHouse is selected only when the flag is enabled and its reader exists;
+// otherwise Loki remains the fallback when configured.
+func (l *LocalClusterResourceProvider) persistentLogBackend(ctx context.Context) persistentLogBackend {
+	if l.featureFlags != nil && l.featureFlags.BoolFlag(ctx, featureflags.LogsReadConfigFlag) && l.sandboxLogsReader != nil {
+		return persistentLogBackendClickhouse
 	}
 
-	return l.featureFlags.BoolFlag(ctx, featureflags.LogsReadConfigFlag)
+	if l.queryLogsProvider != nil {
+		return persistentLogBackendLoki
+	}
+
+	return persistentLogBackendUnavailable
+}
+
+func persistentLogsUnavailableError() *api.APIError {
+	return &api.APIError{
+		Err:       fmt.Errorf("%w: Loki is not configured and ClickHouse is not selected or available", errPersistentLogsUnavailable),
+		ClientMsg: "Persistent logs are temporarily unavailable",
+		Code:      http.StatusServiceUnavailable,
+	}
 }
 
 // apiLogDirectionToSandboxLogsSortOrder converts an API log direction into the
@@ -203,7 +238,8 @@ func (l *LocalClusterResourceProvider) GetSandboxLogs(ctx context.Context, teamI
 		raw []logs.LogEntry
 		err error
 	)
-	if l.readFromClickhouse(ctx) {
+	switch l.persistentLogBackend(ctx) {
+	case persistentLogBackendClickhouse:
 		teamUUID, parseErr := uuid.Parse(teamID)
 		if parseErr != nil {
 			return api.SandboxLogs{}, &api.APIError{
@@ -217,8 +253,10 @@ func (l *LocalClusterResourceProvider) GetSandboxLogs(ctx context.Context, teamI
 		if err != nil {
 			recordClickhouseLogReadError(ctx, "sandbox")
 		}
-	} else {
+	case persistentLogBackendLoki:
 		raw, err = l.queryLogsProvider.QuerySandboxLogs(ctx, teamID, sandboxID, start, end, limit, apiLogDirectionToLokiProtoDirection(qDirection), level, search)
+	case persistentLogBackendUnavailable:
+		return api.SandboxLogs{}, persistentLogsUnavailableError()
 	}
 	if err != nil {
 		return api.SandboxLogs{}, &api.APIError{
@@ -263,10 +301,15 @@ func (l *LocalClusterResourceProvider) GetBuildLogs(
 	start, end := LogQueryWindow(cursor, direction)
 
 	var persistentFetcher logSourceFunc
-	if l.readFromClickhouse(ctx) {
+	switch l.persistentLogBackend(ctx) {
+	case persistentLogBackendClickhouse:
 		persistentFetcher = l.logsFromClickhouse(ctx, templateID, buildID, start, end, int(limit), offset, level, apiLogDirectionToSandboxLogsSortOrder(&direction))
-	} else {
+	case persistentLogBackendLoki:
 		persistentFetcher = l.logsFromLocalLoki(ctx, templateID, buildID, start, end, int(limit), offset, level, apiLogDirectionToLokiProtoDirection(&direction))
+	case persistentLogBackendUnavailable:
+		persistentFetcher = func() ([]logs.LogEntry, *api.APIError) {
+			return nil, persistentLogsUnavailableError()
+		}
 	}
 
 	return getBuildLogsWithSources(ctx, l.instances, nodeID, templateID, buildID, offset, limit, level, cursor, direction, source, persistentFetcher)

--- a/packages/api/internal/clusters/resources_local_test.go
+++ b/packages/api/internal/clusters/resources_local_test.go
@@ -3,16 +3,32 @@ package clusters
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/launchdarkly/go-server-sdk/v7/testhelpers/ldtestdata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
+	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/clickhouse/pkg/sandboxlogs"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logs"
 )
+
+var testLogReadMetricReader = metric.NewManualReader()
+
+func TestMain(m *testing.M) {
+	otel.SetMeterProvider(metric.NewMeterProvider(metric.WithReader(testLogReadMetricReader)))
+	m.Run()
+}
 
 type stubClickhouseLogsReader struct {
 	sandbox func(context.Context, uuid.UUID, string, time.Time, time.Time, int, sandboxlogs.SortOrder, *logs.LogLevel, *string) ([]logs.LogEntry, error)
@@ -25,6 +41,220 @@ func (s *stubClickhouseLogsReader) QuerySandboxLogs(ctx context.Context, teamID 
 
 func (s *stubClickhouseLogsReader) QueryBuildLogs(ctx context.Context, templateID, buildID string, start, end time.Time, limit int, offset int32, level *logs.LogLevel, order sandboxlogs.SortOrder) ([]logs.LogEntry, error) {
 	return s.build(ctx, templateID, buildID, start, end, limit, offset, level, order)
+}
+
+type stubLokiLogsReader struct {
+	sandbox func(context.Context, string, string, time.Time, time.Time, int, logproto.Direction, *logs.LogLevel, *string) ([]logs.LogEntry, error)
+	build   func(context.Context, string, string, time.Time, time.Time, int, int32, *logs.LogLevel, logproto.Direction) ([]logs.LogEntry, error)
+}
+
+func (s *stubLokiLogsReader) QuerySandboxLogs(ctx context.Context, teamID string, sandboxID string, start, end time.Time, limit int, direction logproto.Direction, level *logs.LogLevel, search *string) ([]logs.LogEntry, error) {
+	return s.sandbox(ctx, teamID, sandboxID, start, end, limit, direction, level, search)
+}
+
+func (s *stubLokiLogsReader) QueryBuildLogs(ctx context.Context, templateID, buildID string, start, end time.Time, limit int, offset int32, level *logs.LogLevel, direction logproto.Direction) ([]logs.LogEntry, error) {
+	return s.build(ctx, templateID, buildID, start, end, limit, offset, level, direction)
+}
+
+func newLogsReadFeatureFlags(t *testing.T, enabled bool) *featureflags.Client {
+	t.Helper()
+
+	source := ldtestdata.DataSource()
+	source.Update(source.Flag(featureflags.LogsReadConfigFlag.Key()).VariationForAll(enabled))
+	client, err := featureflags.NewClientWithDatasource(source)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close(context.WithoutCancel(t.Context())))
+	})
+
+	return client
+}
+
+func assertPersistentLogsUnavailable(t *testing.T, apiErr *api.APIError) {
+	t.Helper()
+	require.NotNil(t, apiErr)
+	assert.Equal(t, http.StatusServiceUnavailable, apiErr.Code)
+	assert.Equal(t, "Persistent logs are temporarily unavailable", apiErr.ClientMsg)
+	assert.ErrorIs(t, apiErr.Err, errPersistentLogsUnavailable)
+}
+
+func TestLocalLogsUseClickhouseWhenFlagEnabledWithoutLoki(t *testing.T) {
+	t.Parallel()
+
+	sandboxEntry := logs.LogEntry{Raw: "sandbox from ClickHouse", Message: "sandbox from ClickHouse"}
+	buildEntry := logs.LogEntry{Raw: "build from ClickHouse", Message: "build from ClickHouse"}
+	provider := &LocalClusterResourceProvider{
+		sandboxLogsReader: &stubClickhouseLogsReader{
+			sandbox: func(_ context.Context, _ uuid.UUID, _ string, _ time.Time, _ time.Time, _ int, _ sandboxlogs.SortOrder, _ *logs.LogLevel, _ *string) ([]logs.LogEntry, error) {
+				return []logs.LogEntry{sandboxEntry}, nil
+			},
+			build: func(_ context.Context, _, _ string, _, _ time.Time, _ int, _ int32, _ *logs.LogLevel, _ sandboxlogs.SortOrder) ([]logs.LogEntry, error) {
+				return []logs.LogEntry{buildEntry}, nil
+			},
+		},
+		featureFlags: newLogsReadFeatureFlags(t, true),
+	}
+
+	sandboxResult, sandboxErr := provider.GetSandboxLogs(t.Context(), uuid.NewString(), "sandbox-id", nil, nil, nil, nil, nil, nil)
+	require.Nil(t, sandboxErr)
+	require.Len(t, sandboxResult.LogEntries, 1)
+	assert.Equal(t, sandboxEntry.Message, sandboxResult.LogEntries[0].Message)
+
+	source := api.LogsSourcePersistent
+	buildResult, buildErr := provider.GetBuildLogs(t.Context(), nil, "template-id", "build-id", 0, 100, nil, nil, api.LogsDirectionForward, &source)
+	require.Nil(t, buildErr)
+	assert.Equal(t, []logs.LogEntry{buildEntry}, buildResult)
+}
+
+func TestLocalLogsWithoutLokiReturnUnavailableWhenFlagDisabled(t *testing.T) {
+	t.Parallel()
+
+	provider := &LocalClusterResourceProvider{
+		sandboxLogsReader: &stubClickhouseLogsReader{
+			sandbox: func(_ context.Context, _ uuid.UUID, _ string, _ time.Time, _ time.Time, _ int, _ sandboxlogs.SortOrder, _ *logs.LogLevel, _ *string) ([]logs.LogEntry, error) {
+				t.Fatal("ClickHouse must not be used while logs-read-config is disabled")
+
+				return nil, nil
+			},
+			build: func(_ context.Context, _, _ string, _, _ time.Time, _ int, _ int32, _ *logs.LogLevel, _ sandboxlogs.SortOrder) ([]logs.LogEntry, error) {
+				t.Fatal("ClickHouse must not be used while logs-read-config is disabled")
+
+				return nil, nil
+			},
+		},
+		featureFlags: newLogsReadFeatureFlags(t, false),
+	}
+
+	_, sandboxErr := provider.GetSandboxLogs(t.Context(), uuid.NewString(), "sandbox-id", nil, nil, nil, nil, nil, nil)
+	assertPersistentLogsUnavailable(t, sandboxErr)
+
+	source := api.LogsSourcePersistent
+	_, buildErr := provider.GetBuildLogs(t.Context(), nil, "template-id", "build-id", 0, 100, nil, nil, api.LogsDirectionForward, &source)
+	assertPersistentLogsUnavailable(t, buildErr)
+}
+
+func TestLocalLogsWithoutAnyBackendReturnUnavailableWhenClickhouseFlagEnabled(t *testing.T) {
+	t.Parallel()
+
+	provider := &LocalClusterResourceProvider{featureFlags: newLogsReadFeatureFlags(t, true)}
+
+	_, sandboxErr := provider.GetSandboxLogs(t.Context(), uuid.NewString(), "sandbox-id", nil, nil, nil, nil, nil, nil)
+	assertPersistentLogsUnavailable(t, sandboxErr)
+
+	source := api.LogsSourcePersistent
+	_, buildErr := provider.GetBuildLogs(t.Context(), nil, "template-id", "build-id", 0, 100, nil, nil, api.LogsDirectionForward, &source)
+	assertPersistentLogsUnavailable(t, buildErr)
+}
+
+func TestLocalLogsPreserveLokiFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		clickhouseFlagEnabled bool
+		withClickhouseReader  bool
+	}{
+		{name: "flag disabled", clickhouseFlagEnabled: false, withClickhouseReader: true},
+		{name: "flag enabled without ClickHouse reader", clickhouseFlagEnabled: true, withClickhouseReader: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sandboxEntry := logs.LogEntry{Raw: "sandbox from Loki", Message: "sandbox from Loki"}
+			buildEntry := logs.LogEntry{Raw: "build from Loki", Message: "build from Loki"}
+			provider := &LocalClusterResourceProvider{
+				queryLogsProvider: &stubLokiLogsReader{
+					sandbox: func(_ context.Context, _, _ string, _, _ time.Time, _ int, _ logproto.Direction, _ *logs.LogLevel, _ *string) ([]logs.LogEntry, error) {
+						return []logs.LogEntry{sandboxEntry}, nil
+					},
+					build: func(_ context.Context, _, _ string, _, _ time.Time, _ int, _ int32, _ *logs.LogLevel, _ logproto.Direction) ([]logs.LogEntry, error) {
+						return []logs.LogEntry{buildEntry}, nil
+					},
+				},
+				featureFlags: newLogsReadFeatureFlags(t, tt.clickhouseFlagEnabled),
+			}
+			if tt.withClickhouseReader {
+				provider.sandboxLogsReader = &stubClickhouseLogsReader{
+					sandbox: func(_ context.Context, _ uuid.UUID, _ string, _ time.Time, _ time.Time, _ int, _ sandboxlogs.SortOrder, _ *logs.LogLevel, _ *string) ([]logs.LogEntry, error) {
+						t.Fatal("ClickHouse must not bypass logs-read-config")
+
+						return nil, nil
+					},
+					build: func(_ context.Context, _, _ string, _, _ time.Time, _ int, _ int32, _ *logs.LogLevel, _ sandboxlogs.SortOrder) ([]logs.LogEntry, error) {
+						t.Fatal("ClickHouse must not bypass logs-read-config")
+
+						return nil, nil
+					},
+				}
+			}
+
+			sandboxResult, sandboxErr := provider.GetSandboxLogs(t.Context(), uuid.NewString(), "sandbox-id", nil, nil, nil, nil, nil, nil)
+			require.Nil(t, sandboxErr)
+			require.Len(t, sandboxResult.LogEntries, 1)
+			assert.Equal(t, sandboxEntry.Message, sandboxResult.LogEntries[0].Message)
+
+			source := api.LogsSourcePersistent
+			buildResult, buildErr := provider.GetBuildLogs(t.Context(), nil, "template-id", "build-id", 0, 100, nil, nil, api.LogsDirectionForward, &source)
+			require.Nil(t, buildErr)
+			assert.Equal(t, []logs.LogEntry{buildEntry}, buildResult)
+		})
+	}
+}
+
+func TestClickhouseLogReadErrorsAreCountedByKind(t *testing.T) {
+	t.Parallel()
+
+	clickhouseErr := errors.New("clickhouse unavailable")
+	provider := &LocalClusterResourceProvider{
+		sandboxLogsReader: &stubClickhouseLogsReader{
+			sandbox: func(_ context.Context, _ uuid.UUID, _ string, _ time.Time, _ time.Time, _ int, _ sandboxlogs.SortOrder, _ *logs.LogLevel, _ *string) ([]logs.LogEntry, error) {
+				return nil, clickhouseErr
+			},
+			build: func(_ context.Context, _, _ string, _, _ time.Time, _ int, _ int32, _ *logs.LogLevel, _ sandboxlogs.SortOrder) ([]logs.LogEntry, error) {
+				return nil, clickhouseErr
+			},
+		},
+		featureFlags: newLogsReadFeatureFlags(t, true),
+	}
+
+	_, sandboxErr := provider.GetSandboxLogs(t.Context(), uuid.NewString(), "sandbox-id", nil, nil, nil, nil, nil, nil)
+	require.NotNil(t, sandboxErr)
+	require.ErrorIs(t, sandboxErr.Err, clickhouseErr)
+
+	_, buildErr := provider.logsFromClickhouse(t.Context(), "template-id", "build-id", time.Now().Add(-time.Minute), time.Now(), 100, 0, nil, sandboxlogs.SortOrderForward)()
+	require.NotNil(t, buildErr)
+	require.ErrorIs(t, buildErr.Err, clickhouseErr)
+
+	var metrics metricdata.ResourceMetrics
+	require.NoError(t, testLogReadMetricReader.Collect(t.Context(), &metrics))
+
+	want := []attribute.Set{
+		attribute.NewSet(attribute.String("kind", "sandbox")),
+		attribute.NewSet(attribute.String("kind", "build")),
+	}
+	found := make([]bool, len(want))
+	for _, scope := range metrics.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != "log_read_clickhouse_error_count" {
+				continue
+			}
+
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			for _, point := range sum.DataPoints {
+				for i, attributes := range want {
+					if point.Value > 0 && point.Attributes.Equals(&attributes) {
+						found[i] = true
+					}
+				}
+			}
+		}
+	}
+	for i, attributes := range want {
+		assert.True(t, found[i], "no error count with attributes %v", attributes.Encoded(attribute.DefaultEncoder()))
+	}
 }
 
 // TestBuildLogsFromClickhouseFailsFast asserts that a ClickHouse read error

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -66,6 +66,14 @@ func newInClusterKubeClient() (kubernetes.Interface, error) {
 	return c, nil
 }
 
+func newLokiQueryProvider(config cfg.Config) (*loki.LokiQueryProvider, error) {
+	if config.LokiURL == "" {
+		return nil, nil
+	}
+
+	return loki.NewLokiQueryProvider(config.LokiURL, config.LokiUser, config.LokiPassword)
+}
+
 var _ api.ServerInterface = (*APIStore)(nil)
 
 type teamRunningSandboxCounter interface {
@@ -229,7 +237,7 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client, redisClient redis.U
 		templateBuilderDiscovery = clustersdiscovery.NewLocalDiscovery(consts.LocalClusterID, nomadClient)
 	}
 
-	queryLogsProvider, err := loki.NewLokiQueryProvider(config.LokiURL, config.LokiUser, config.LokiPassword)
+	queryLogsProvider, err := newLokiQueryProvider(config)
 	if err != nil {
 		logger.L().Fatal(ctx, "error when getting logs query provider", zap.Error(err))
 	}

--- a/packages/api/internal/handlers/store_test.go
+++ b/packages/api/internal/handlers/store_test.go
@@ -12,8 +12,33 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
+	"github.com/e2b-dev/infra/packages/api/internal/cfg"
 	"github.com/e2b-dev/infra/packages/shared/pkg/apierrors"
 )
+
+func TestNewLokiQueryProvider(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty URL disables Loki", func(t *testing.T) {
+		t.Parallel()
+
+		provider, err := newLokiQueryProvider(cfg.Config{})
+		require.NoError(t, err)
+		assert.Nil(t, provider)
+	})
+
+	t.Run("nonempty URL initializes Loki", func(t *testing.T) {
+		t.Parallel()
+
+		provider, err := newLokiQueryProvider(cfg.Config{
+			LokiURL:      "http://loki:3100",
+			LokiUser:     "user",
+			LokiPassword: "password",
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, provider)
+	})
+}
 
 func TestSendAPIError_BodyCarriesSemanticErrorCode(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- make `LOKI_URL` optional and only construct the Loki query provider when it is configured
- keep `logs-read-config` as the routing authority: enabled reads use the existing ClickHouse reader, while an unavailable ClickHouse reader falls back to Loki only when Loki exists
- return a stable 503 for local sandbox/build persistent-log reads when the selected/fallback backend is unavailable instead of panicking, returning empty logs, or forcing ClickHouse
- leave remote cluster/edge routing, the feature-flag default, and the existing `sandbox_logs` schema/migration unchanged

## Validation

- `make test` in `packages/api` (full API unit suite with `-race`)
- `make lint` in `packages/api` (`golangci-lint run --fix ./...`, 0 issues)
- `go test -race ./pkg/sandboxlogs` in `packages/clickhouse`
- `gopls check` on all changed Go files
- `git diff --check`

## Rollout

No DDL, LaunchDarkly, image, Argo, or infrastructure changes are included. Activating this behavior requires building a new API image and updating Argo separately. Before removing `LOKI_URL` from a deployment, keep `logs-read-config` enabled and the ClickHouse log reader configured; if the flag is disabled/unavailable and Loki is absent, local persistent-log reads intentionally return 503.
