### PR TITLE
orchestrator: make chrony time source selection observable in guests

### DIFF
--- a/packages/orchestrator/pkg/template/build/core/rootfs/files/chrony-source.sh.tpl
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/files/chrony-source.sh.tpl
@@ -16,9 +16,29 @@
 # same name (Alpine).
 set -eu
 
+# Record which source was chosen so an operator can tell, after the fact, why a
+# guest's clock did or didn't converge. The fallback to the public NTP pool is
+# the slow, network-dependent path; when it is taken silently there is nothing
+# to inspect after boot. We log to stderr (captured by the systemd journal / the
+# OpenRC service log), to syslog via logger when present, and to a stable marker
+# file that survives for the life of the boot.
+log() {
+    echo "e2b-chrony-source: $1" >&2
+    if command -v logger >/dev/null 2>&1; then
+        logger -t e2b-chrony-source "$1" || true
+    fi
+}
+
 mkdir -p /run/chrony-e2b
 if [ -e /dev/ptp0 ]; then
-    echo "refclock PHC /dev/ptp0 poll 2 dpoll 2" >/run/chrony-e2b/source.conf
+    source_line="refclock PHC /dev/ptp0 poll 2 dpoll 2"
+    selected="phc"
+    log "/dev/ptp0 present: using hypervisor PHC refclock"
 else
-    echo "pool pool.ntp.org iburst maxsources 3" >/run/chrony-e2b/source.conf
+    source_line="pool pool.ntp.org iburst maxsources 3"
+    selected="pool"
+    log "/dev/ptp0 absent: falling back to public NTP pool (pool.ntp.org) — first sync races iburst convergence over the network"
 fi
+
+echo "$source_line" >/run/chrony-e2b/source.conf
+echo "$selected" >/run/chrony-e2b/selected

--- a/packages/orchestrator/pkg/template/build/core/rootfs/files/chrony-source.sh.tpl
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/files/chrony-source.sh.tpl
@@ -22,8 +22,13 @@ set -eu
 # to inspect after boot. We log to stderr (captured by the systemd journal / the
 # OpenRC service log), to syslog via logger when present, and to a stable marker
 # file that survives for the life of the boot.
+#
+# Logging is strictly best-effort and MUST NOT be able to abort this script:
+# with `set -e`, a failed write (e.g. a broken stderr) would otherwise bail
+# before chrony's source file is written, leaving chronyd with no source at all.
+# For the same reason all writes to source.conf happen before we log.
 log() {
-    echo "e2b-chrony-source: $1" >&2
+    echo "e2b-chrony-source: $1" >&2 2>/dev/null || true
     if command -v logger >/dev/null 2>&1; then
         logger -t e2b-chrony-source "$1" || true
     fi
@@ -33,12 +38,14 @@ mkdir -p /run/chrony-e2b
 if [ -e /dev/ptp0 ]; then
     source_line="refclock PHC /dev/ptp0 poll 2 dpoll 2"
     selected="phc"
-    log "/dev/ptp0 present: using hypervisor PHC refclock"
+    message="/dev/ptp0 present: using hypervisor PHC refclock"
 else
     source_line="pool pool.ntp.org iburst maxsources 3"
     selected="pool"
-    log "/dev/ptp0 absent: falling back to public NTP pool (pool.ntp.org) — first sync races iburst convergence over the network"
+    message="/dev/ptp0 absent: falling back to public NTP pool (pool.ntp.org) — first sync races iburst convergence over the network"
 fi
 
 echo "$source_line" >/run/chrony-e2b/source.conf
 echo "$selected" >/run/chrony-e2b/selected
+
+log "$message"

--- a/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
@@ -131,6 +131,18 @@ func TestAdditionalOCILayers(t *testing.T) {
 		assert.Contains(t, chronySource, "/run/chrony-e2b/source.conf")
 		assert.Contains(t, chronySource, "refclock PHC /dev/ptp0")
 		assert.Contains(t, chronySource, "pool pool.ntp.org")
+
+		// Ships verbatim into every guest boot; parse it the way the guest's sh will.
+		chronyScript := filepath.Join(t.TempDir(), "e2b-chrony-source")
+		require.NoError(t, os.WriteFile(chronyScript, []byte(chronySource), 0o700))
+		chronyOut, chronyErr := exec.Command("sh", "-n", chronyScript).CombinedOutput()
+		require.NoErrorf(t, chronyErr, "e2b-chrony-source is not valid sh:\n%s", chronyOut)
+
+		// The fallback to the public NTP pool is the slow, network-dependent path
+		// that makes "is the clock synchronized" flap; it must not be silent, so
+		// the selector logs the chosen source and records it in a stable marker.
+		assert.Contains(t, chronySource, "/run/chrony-e2b/selected")
+		assert.Contains(t, chronySource, "logger -t e2b-chrony-source")
 		assert.Contains(t, actualFiles["etc/systemd/system/e2b-chrony-source.service"],
 			"ExecStart=/usr/local/bin/e2b-chrony-source")
 		openrcChronySource := actualFiles["usr/local/share/e2b/chrony-source.openrc"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The staging periodic test `time is synchronized` flaps intermittently and self-resolves. The leading hypothesis is that when a guest lacks `/dev/ptp0`, `e2b-chrony-source` silently falls back to the public NTP pool (`pool.ntp.org`), and chrony then reports "not synchronised" until iburst converges over the public internet — a good match for an intermittent, self-clearing failure. The problem is that this fallback is **silent**: after boot there is nothing to inspect that tells you which source chrony picked, so every occurrence is unanswerable without live access to a sandbox.

This PR does not change clock-stepping behavior on a hunch. It makes the source selection observable so the next occurrence is diagnosable, and fixes an ordering bug found in review.

## What

In `e2b-chrony-source` (shared by the systemd unit and the Alpine OpenRC service):

- Write the chosen source to `/run/chrony-e2b/source.conf` **first**, then log — and make logging strictly best-effort (`|| true`, stderr errors swallowed). Under `set -e` a failed log write would otherwise abort the selector before the source file exists, leaving chronyd with no source at all (caught in review).
- Log the chosen source to stderr (systemd journal / OpenRC service log) and to syslog via `logger` when present.
- Write a stable `/run/chrony-e2b/selected` marker (`phc` or `pool`) so `cat /run/chrony-e2b/selected` answers "which source did this guest pick?" for the life of the boot.

`refclock PHC /dev/ptp0`, `pool pool.ntp.org`, and `/run/chrony-e2b/source.conf` are unchanged, so existing behavior is preserved and there is no baked-file count change.

## Reach / limitations (honest scope)

This is diagnostic-only and its reach is uneven:

- **systemd guests:** the log line lands in the journal, but the journal dies with the ephemeral sandbox, so it only helps a *live* sandbox unless the journal is exported.
- **Alpine guests:** no syslog daemon and no console capture, so the log line has nowhere durable to go; only the `/run/chrony-e2b/selected` marker helps, and only via a live `exec`.
- It does **not** reach a post-mortem of a sandbox that is already gone. Confirming the root cause on a *specific* past staging failure still needs live inspection or orchestrator-side logging.

## Test

Extended `TestAdditionalOCILayers` to:
- validate the shipped script parses as `sh -n` (it now defines a helper function), and
- assert the selector logs via `logger` and records `/run/chrony-e2b/selected`.

`go test -run TestAdditionalOCILayers ./pkg/template/build/core/rootfs/` passes.

## Next step to actually confirm the cause

The cheapest verification is whether staging nodes expose `/dev/ptp0` to guests at all. The guest kernel has `CONFIG_PTP_1588_CLOCK_KVM=y` built in, so `/dev/ptp0` appears only when KVM on that node can expose the host PHC — which is exactly what nested virtualization can withhold. Run `ls /dev/ptp0` in a fresh staging sandbox: if it exists, the pool fallback never fires and this whole theory is moot; if it doesn't, this PR's marker/log confirms the `pool` path on the next flap.

## Follow-up: behavior-change options (pick one, not shipped here)

1. **Wait for first sync at boot.** Unmask/enable `chrony-wait` so boot blocks until chrony reports synchronized — trades slightly slower boot for a converged clock before the test observes it.
2. **Use a faster/closer NTP source in the fallback.** Point the pool fallback at a low-latency internal/cloud NTP source (e.g. GCP's metadata NTP server) instead of public `pool.ntp.org`, cutting convergence time and jitter.

Note: envd already steps `CLOCK_REALTIME` from the host on every start/resume ([sandbox.go](https://github.com/e2b-dev/infra/blob/main/packages/orchestrator/pkg/sandbox/sandbox.go#L3339)), so the *wall clock* is corrected regardless of chrony. That means the failing signal is most likely chrony's own *synchronised state* (which stepping the wall clock does not satisfy), not wall-clock accuracy — which is why option 1 or 2, not envd, is the lever if we decide to act.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://e2b-team.slack.com/archives/C08PM91SQ7M/p1787529036340319?thread_ts=1787529036.340319&cid=C08PM91SQ7M)

<div><a href="https://cursor.com/agents/bc-77288b4c-16d9-5736-a4d5-6d6b3a78caa1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77288b4c-16d9-5736-a4d5-6d6b3a78caa1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

