### PR TITLE
perf(api): avoid cjson.decode in startTransitionScript hot path

### DIFF
--- a/packages/api/internal/sandbox/storage/redis/operations.go
+++ b/packages/api/internal/sandbox/storage/redis/operations.go
@@ -39,7 +39,8 @@ func (s *Storage) Add(ctx context.Context, sbx sandboxtypes.Sandbox) error {
 	}
 
 	// Execute Lua script for atomic SET + SADD
-	err = addSandboxScript.Run(ctx, s.redisClient, []string{key, teamKey}, data, sbx.SandboxID).Err()
+	eidKey := getSandboxExecutionIDKey(sbx.TeamID.String(), sbx.SandboxID)
+	err = addSandboxScript.Run(ctx, s.redisClient, []string{key, teamKey, eidKey}, data, sbx.SandboxID, sbx.ExecutionID).Err()
 	if err != nil {
 		return fmt.Errorf("failed to store sandbox in Redis: %w", err)
 	}
@@ -96,7 +97,8 @@ func (s *Storage) Remove(ctx context.Context, teamID uuid.UUID, sandboxID string
 	// Execute Lua script for atomic DEL + SREM; it returns the deleted JSON
 	// so the expiration-index cleanup below is scoped to the execution we
 	// actually removed.
-	raw, err := removeSandboxScript.Run(ctx, s.redisClient, []string{key, teamKey}, sandboxID).Text()
+	eidKey := getSandboxExecutionIDKey(teamID.String(), sandboxID)
+	raw, err := removeSandboxScript.Run(ctx, s.redisClient, []string{key, teamKey, eidKey}, sandboxID).Text()
 	if err != nil && !errors.Is(err, redis.Nil) {
 		return fmt.Errorf("failed to remove sandbox from Redis: %w", err)
 	}

--- a/packages/api/internal/sandbox/storage/redis/scripts.go
+++ b/packages/api/internal/sandbox/storage/redis/scripts.go
@@ -6,10 +6,11 @@ import "github.com/redis/go-redis/v9"
 // These scripts ensure true atomicity in Redis cluster mode
 var (
 	// addSandboxScript atomically stores a sandbox and adds it to the team index.
-	// KEYS[1] = sandbox key, KEYS[2] = team index key
-	// ARGV[1] = serialized sandbox data, ARGV[2] = sandbox ID
+	// KEYS[1] = sandbox key, KEYS[2] = team index key, KEYS[3] = execution ID key
+	// ARGV[1] = serialized sandbox data, ARGV[2] = sandbox ID, ARGV[3] = execution ID
 	addSandboxScript = redis.NewScript(`
 		redis.call('SET', KEYS[1], ARGV[1])
+		redis.call('SET', KEYS[3], ARGV[3])
 		redis.call('SADD', KEYS[2], ARGV[2])
 		return 1
 	`)
@@ -18,11 +19,12 @@ var (
 	// It returns the stored JSON (or nil if the key was already gone) so the
 	// caller knows exactly which execution it removed and can scope the
 	// expiration-index cleanup to that execution.
-	// KEYS[1] = sandbox key, KEYS[2] = team index key
+	// KEYS[1] = sandbox key, KEYS[2] = team index key, KEYS[3] = execution ID key
 	// ARGV[1] = sandbox ID
 	removeSandboxScript = redis.NewScript(`
 		local data = redis.call('GET', KEYS[1])
 		redis.call('DEL', KEYS[1])
+		redis.call('DEL', KEYS[3])
 		redis.call('SREM', KEYS[2], ARGV[1])
 		return data
 	`)
@@ -31,32 +33,55 @@ var (
 	// This is called AFTER Go code has validated the transition and prepared the new sandbox data.
 	//
 	// When ARGV[5] is set, the write only happens if the stored record is still
-	// that execution. This is the enforcement point for RemoveOpts.
-	// ExpectExecutionID, and it has to live in here rather than in Go: Add is
-	// lockless, so a resume can install a new incarnation between a Go-side
-	// comparison and this write, and the SET below would then overwrite the new
-	// live record with the stale one. Returns 0 without writing anything if the
-	// record is gone or is a different execution.
+	// that execution. This is the enforcement point for RemoveOpts.ExpectExecutionID,
+	// and it has to live in here rather than in Go: Add is lockless, so a resume
+	// can install a new incarnation between a Go-side comparison and this write,
+	// and the SET below would then overwrite the new live record with the stale one.
+	// Returns 0 without writing anything if the record is gone or is a different execution.
+	//
+	// The check reads KEYS[4] (a dedicated execution-ID key) instead of decoding
+	// the full sandbox JSON. This avoids running cjson.decode on the Redis event
+	// loop for every concurrent eviction call, which would otherwise serialize
+	// O(N-JSON) CPU work on the single-threaded Redis main thread.
+	//
+	// Migration note: KEYS[4] is absent for sandboxes created before this script
+	// was deployed. The fallback branch re-decodes the JSON so that in-flight
+	// sandboxes are still handled correctly. Once all pre-deploy sandboxes have
+	// expired the fallback is unreachable and can be removed.
+	//
 	// KEYS[1] = sandbox key
 	// KEYS[2] = transition key
 	// KEYS[3] = transition result key
+	// KEYS[4] = execution ID key
 	// ARGV[1] = new sandbox JSON data
 	// ARGV[2] = transition ID (UUID)
 	// ARGV[3] = transition key TTL in seconds
 	// ARGV[4] = result key TTL in seconds
 	// ARGV[5] = expected execution ID, or "" to write unconditionally
+	// ARGV[6] = new execution ID to persist in KEYS[4]
 	startTransitionScript = redis.NewScript(`
 		if ARGV[5] ~= '' then
-			local current = redis.call('GET', KEYS[1])
-			if not current then
-				return 0
-			end
-			local ok, decoded = pcall(cjson.decode, current)
-			if not ok or decoded['executionID'] ~= ARGV[5] then
-				return 0
+			local eid = redis.call('GET', KEYS[4])
+			if eid then
+				-- Fast path: dedicated eid key present; O(1) string compare.
+				if eid ~= ARGV[5] then
+					return 0
+				end
+			else
+				-- Migration fallback: eid key absent for pre-deploy sandboxes.
+				-- Fall back to JSON decode so existing sandboxes are still handled.
+				local current = redis.call('GET', KEYS[1])
+				if not current then
+					return 0
+				end
+				local ok, decoded = pcall(cjson.decode, current)
+				if not ok or decoded['executionID'] ~= ARGV[5] then
+					return 0
+				end
 			end
 		end
 		redis.call('SET', KEYS[1], ARGV[1])
+		redis.call('SET', KEYS[4], ARGV[6])
 		redis.call('SET', KEYS[2], ARGV[2], 'EX', ARGV[3])
 		redis.call('SET', KEYS[3], '', 'EX', ARGV[4])
 		return 1

--- a/packages/api/internal/sandbox/storage/redis/state_change.go
+++ b/packages/api/internal/sandbox/storage/redis/state_change.go
@@ -151,9 +151,10 @@ func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID
 	ttlSeconds := int(transitionKeyTTL.Seconds())
 	resultTtlSeconds := int(transitionResultKeyTTL.Seconds())
 
+	eidKey := getSandboxExecutionIDKey(teamID.String(), sandboxID)
 	written, err := startTransitionScript.Run(ctx, s.redisClient,
-		[]string{key, transitionKey, resultKey},
-		newData, transitionID, ttlSeconds, resultTtlSeconds, opts.ExpectExecutionID,
+		[]string{key, transitionKey, resultKey, eidKey},
+		newData, transitionID, ttlSeconds, resultTtlSeconds, opts.ExpectExecutionID, updated.ExecutionID,
 	).Int64()
 	if err != nil {
 		return sbx, false, nil, fmt.Errorf("failed to update sandbox state: %w", err)

--- a/packages/api/internal/sandbox/storage/redis/utils.go
+++ b/packages/api/internal/sandbox/storage/redis/utils.go
@@ -14,6 +14,7 @@ const (
 	transitionKeyPrefix = "transition"
 	lockKeyPrefix       = "lock"
 	notifySuffix        = "notify"
+	eidSuffix           = "eid"
 	sandboxesKey        = "sandboxes"
 	indexKey            = "index"
 )
@@ -65,6 +66,14 @@ func GetTeamPrefix(teamID string) string {
 
 func getSandboxKey(teamID, sandboxID string) string {
 	return redis_utils.CreateKey(GetTeamPrefix(teamID), sandboxesKey, sandboxID)
+}
+
+// getSandboxExecutionIDKey returns the key that stores the sandbox execution ID.
+// It shares the same {teamID} hash tag as the sandbox key, so both keys land
+// on the same Redis Cluster slot and can be read/written atomically in a single
+// Lua script.
+func getSandboxExecutionIDKey(teamID, sandboxID string) string {
+	return redis_utils.CreateKey(getSandboxKey(teamID, sandboxID), eidSuffix)
 }
 
 // GetSandboxStorageTeamIndexKey returns the storage team index key for external packages (e.g. reservations).


### PR DESCRIPTION
## Problem

Closes #3602.

`startTransitionScript` checks the expected `executionID` by decoding the full
sandbox JSON blob with `cjson.decode`. Because Redis executes all Lua on a
single-threaded event loop, this O(N) decode blocks **every other Redis command**
for its duration. Under production load (thousands of concurrent sandboxes) this
creates measurable latency spikes on all storage operations.

## Solution

Introduce a dedicated execution-ID key per sandbox:

```
sandbox:storage:{teamID}:sandboxes:{sandboxID}:eid
```

The key uses the same `{teamID}` hash tag as the main sandbox key, so it lands
in the same cluster slot and can be accessed atomically within Lua scripts.

### Changes

| File | Change |
|---|---|
| `utils.go` | Add `getSandboxExecutionIDKey` helper |
| `scripts.go` | Update all 3 Lua scripts to write/delete/read the eid key |
| `operations.go` | Pass eid key to `addSandboxScript` and `removeSandboxScript` |
| `state_change.go` | Pass eid key + updated executionID to `startTransitionScript` |

### Hot path before vs after

**Before** — every `StartRemoving` call with `ExpectExecutionID` set:
```lua
local current = redis.call('GET', KEYS[1])  -- fetch full JSON blob
local decoded = cjson.decode(current)        -- O(N) parse, blocks event loop
if decoded['executionID'] ~= ARGV[5] then return 0 end
```

**After** — O(1) string compare:
```lua
local eid = redis.call('GET', KEYS[4])  -- tiny string key
if eid ~= ARGV[5] then return 0 end
```

### Migration safety

The eid key does not exist for sandboxes created before this deploy. The script
detects this case and falls back to `cjson.decode` so pre-deploy sandboxes
continue to work correctly. The fallback becomes unreachable once all pre-deploy
sandboxes have expired and can be removed in a follow-up cleanup.

## Test plan

- [ ] Unit: verify `addSandboxScript` sets eid key with correct value
- [ ] Unit: verify `removeSandboxScript` deletes eid key
- [ ] Unit: verify `startTransitionScript` returns 0 on executionID mismatch (fast path)
- [ ] Unit: verify `startTransitionScript` falls back correctly when eid key absent (migration path)
- [ ] Integration: sandbox lifecycle (create → start removing → remove) completes without error
- [ ] Load: confirm reduced Redis command latency under concurrent sandbox operations