### PR TITLE
obs(api): record team sandbox index SET size as a histogram

### DIFF
--- a/packages/api/internal/sandbox/storage/redis/heal.go
+++ b/packages/api/internal/sandbox/storage/redis/heal.go
@@ -83,7 +83,41 @@ func (s *Storage) healExpirationIndex(ctx context.Context) (int, error) {
 		return healed, err
 	}
 
+	s.recordTeamIndexSizes(ctx)
+
 	return healed, nil
+}
+
+// recordTeamIndexSizes pipelines SCARD over every team's sandbox index SET and
+// records each result as a histogram observation. Called once per heal pass
+// (every 5 min) so the cost is negligible. Use the p99/max to detect
+// unbounded growth caused by stale entries that Remove() never cleaned up.
+func (s *Storage) recordTeamIndexSizes(ctx context.Context) {
+	teams, err := s.redisClient.ZRange(ctx, globalTeamsSet, 0, -1).Result()
+	if err != nil {
+		logger.L().Warn(ctx, "Failed to list teams for index-size metrics", zap.Error(err))
+		return
+	}
+	if len(teams) == 0 {
+		return
+	}
+
+	pipe := s.redisClient.Pipeline()
+	cmds := make([]*redis.IntCmd, len(teams))
+	for i, teamID := range teams {
+		cmds[i] = pipe.SCard(ctx, GetSandboxStorageTeamIndexKey(teamID))
+	}
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		logger.L().Warn(ctx, "Failed to pipeline SCARD for index-size metrics", zap.Error(err))
+		return
+	}
+
+	for _, cmd := range cmds {
+		if n := cmd.Val(); n > 0 {
+			s.metrics.teamIndexSize.Record(ctx, n)
+		}
+	}
 }
 
 // healSandboxBatch re-adds missing expiration index members for one bounded

--- a/packages/api/internal/sandbox/storage/redis/main.go
+++ b/packages/api/internal/sandbox/storage/redis/main.go
@@ -53,6 +53,10 @@ type expirationIndexMetrics struct {
 	sweptOrphan        metric.MeasurementOption
 	sweptDeadExecution metric.MeasurementOption
 	sweptInvalid       metric.MeasurementOption
+
+	// teamIndexSize records each team's index SET cardinality once per heal
+	// pass. Use the p99/max to detect unbounded accumulation of stale entries.
+	teamIndexSize metric.Int64Histogram
 }
 
 const sweptReasonAttr = "reason"
@@ -73,6 +77,11 @@ func newExpirationIndexMetrics(meter metric.Meter) (expirationIndexMetrics, erro
 		return expirationIndexMetrics{}, fmt.Errorf("expiration index swept counter: %w", err)
 	}
 
+	teamIndexSize, err := telemetry.GetHistogram(meter, telemetry.ApiRedisStorageTeamIndexSize)
+	if err != nil {
+		return expirationIndexMetrics{}, fmt.Errorf("team index size histogram: %w", err)
+	}
+
 	return expirationIndexMetrics{
 		indexHealed:        healed,
 		indexRescored:      rescored,
@@ -80,6 +89,7 @@ func newExpirationIndexMetrics(meter metric.Meter) (expirationIndexMetrics, erro
 		sweptOrphan:        metric.WithAttributeSet(attribute.NewSet(attribute.String(sweptReasonAttr, "orphan"))),
 		sweptDeadExecution: metric.WithAttributeSet(attribute.NewSet(attribute.String(sweptReasonAttr, "dead_execution"))),
 		sweptInvalid:       metric.WithAttributeSet(attribute.NewSet(attribute.String(sweptReasonAttr, "invalid"))),
+		teamIndexSize:      teamIndexSize,
 	}, nil
 }
 

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -279,6 +279,11 @@ const (
 )
 
 const (
+	// ApiRedisStorageTeamIndexSize records the number of members in each team's
+	// sandbox index SET at the time of the periodic heal pass (every 5 min).
+	// Use the p99/max to detect unbounded growth caused by stale entries.
+	ApiRedisStorageTeamIndexSize HistogramType = "api.redis_storage.team_index.size"
+
 	ApiRedisStoragePublisherPublishDuration HistogramType = "api.redis_storage.publisher.publish.duration"
 
 	// Firecracker net histograms — per-sandbox distribution per metrics flush, no sandbox_id.
@@ -560,6 +565,7 @@ func GetGaugeInt(meter metric.Meter, name GaugeIntType) (metric.Int64ObservableG
 }
 
 var histogramDesc = map[HistogramType]string{
+	ApiRedisStorageTeamIndexSize:            "Number of members in a team's sandbox index SET; sampled once per heal pass (every 5 min)",
 	ApiRedisStoragePublisherPublishDuration: "Duration of a single Redis PUBLISH round-trip from the storage publisher",
 
 	BuildDurationHistogramName:                 "Time taken to build a template",
@@ -629,6 +635,7 @@ var histogramDesc = map[HistogramType]string{
 }
 
 var histogramUnits = map[HistogramType]string{
+	ApiRedisStorageTeamIndexSize:            "{entry}",
 	ApiRedisStoragePublisherPublishDuration: "ms",
 
 	BuildDurationHistogramName:                    "ms",


### PR DESCRIPTION
## Summary

Adds `api.redis_storage.team_index.size` (histogram, unit `{entry}`).

Once per heal pass (every 5 min) a new `recordTeamIndexSizes` helper pipelines `SCARD` over every team's sandbox index SET and records each cardinality as a histogram observation. Overhead is one `ZRange(globalTeamsSet)` + N `SCARD` (pipelined) per interval — negligible next to the `forEachSandboxBatch` SSCAN scan that already runs at the same cadence.

## Why

The team index SET can accumulate stale entries when sandbox keys disappear outside the normal `Remove()` path (Redis key eviction, crash, etc.) — see #3566. Before this change there was no way to observe whether accumulation was happening short of running `SCARD` manually or waiting for the Admin API.

With the histogram:
- **p99/max** detects unbounded growth before it affects query latency
- A widening gap between p99 and the live running-sandbox count is the signal that stale entries are accumulating
- After #3567 lands, the histogram confirms cleanup is working (p99 should converge back toward the live count)

## Changes

| File | Change |
|---|---|
| `shared/pkg/telemetry/meters.go` | Add `ApiRedisStorageTeamIndexSize` histogram constant, desc, unit |
| `redis/main.go` | Add `teamIndexSize metric.Int64Histogram` to `expirationIndexMetrics`; wire up in `newExpirationIndexMetrics` |
| `redis/heal.go` | Call `recordTeamIndexSizes` at end of each heal pass; add `recordTeamIndexSizes` method |

## Test plan

- [ ] Unit: `recordTeamIndexSizes` records correct SCARD values per team (testcontainers Redis)
- [ ] Unit: teams with SCARD == 0 are not recorded (avoids polluting histogram with empty-set noise)
- [ ] Integration: histogram emits observations after a heal pass completes

/cc @jakubno @dobrac @ValentaTomas