### PR TITLE
obs(api): add Redis storage layer metrics for lock, transition, scan, and index

### DIFF
--- a/packages/api/internal/sandbox/storage/redis/heal.go
+++ b/packages/api/internal/sandbox/storage/redis/heal.go
@@ -83,7 +83,50 @@ func (s *Storage) healExpirationIndex(ctx context.Context) (int, error) {
 		return healed, err
 	}
 
+	s.recordTeamIndexSizes(ctx)
+
+	// Sample the ZSET cardinality once per heal pass. A single ZCARD piggybacked
+	// here costs one Redis round-trip every 5 min — negligible next to the
+	// forEachSandboxBatch scan that precedes it.
+	if n, zErr := s.redisClient.ZCard(ctx, globalExpirationSet).Result(); zErr == nil {
+		s.metrics.indexSize.Record(ctx, n)
+	} else {
+		logger.L().Warn(ctx, "Failed to sample expiration index size", zap.Error(zErr))
+	}
+
 	return healed, nil
+}
+
+// recordTeamIndexSizes pipelines SCARD over every team's sandbox index SET and
+// records each result as a histogram observation. Called once per heal pass
+// (every 5 min) so the cost is negligible. Use the p99/max to detect
+// unbounded growth caused by stale entries that Remove() never cleaned up.
+func (s *Storage) recordTeamIndexSizes(ctx context.Context) {
+	teams, err := s.redisClient.ZRange(ctx, globalTeamsSet, 0, -1).Result()
+	if err != nil {
+		logger.L().Warn(ctx, "Failed to list teams for index-size metrics", zap.Error(err))
+		return
+	}
+	if len(teams) == 0 {
+		return
+	}
+
+	pipe := s.redisClient.Pipeline()
+	cmds := make([]*redis.IntCmd, len(teams))
+	for i, teamID := range teams {
+		cmds[i] = pipe.SCard(ctx, GetSandboxStorageTeamIndexKey(teamID))
+	}
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		logger.L().Warn(ctx, "Failed to pipeline SCARD for index-size metrics", zap.Error(err))
+		return
+	}
+
+	for _, cmd := range cmds {
+		if n := cmd.Val(); n > 0 {
+			s.metrics.teamIndexSize.Record(ctx, n)
+		}
+	}
 }
 
 // healSandboxBatch re-adds missing expiration index members for one bounded

--- a/packages/api/internal/sandbox/storage/redis/items.go
+++ b/packages/api/internal/sandbox/storage/redis/items.go
@@ -18,7 +18,12 @@ const expiredItemsBatchSize = 256
 // ExpiredItems returns running sandboxes whose EndTime has passed.
 // It bounds per-cycle work via LIMIT and cleans up orphaned ZSET entries.
 func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, error) {
-	now := time.Now()
+	sweepStart := time.Now()
+	defer func() {
+		s.metrics.sweepDuration.Record(ctx, time.Since(sweepStart).Milliseconds())
+	}()
+
+	now := sweepStart
 	nowMs := float64(now.UnixMilli())
 
 	// Fetch members whose score (EndTime in ms) is <= now, bounded to 256 per cycle.

--- a/packages/api/internal/sandbox/storage/redis/lock.go
+++ b/packages/api/internal/sandbox/storage/redis/lock.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bsm/redislock"
 	"github.com/redis/go-redis/v9"
 )
-
 type storageLocker struct {
 	redisClient redis.UniversalClient
 	client      *redislock.Client
@@ -99,4 +98,24 @@ func jitterBackoff(backoff time.Duration) time.Duration {
 	factor := 1 + lockRetryJitter*(2*rand.Float64()-1)
 
 	return time.Duration(float64(backoff) * factor)
+}
+
+// obtainLock wraps storageLocker.Obtain with wait-duration and timeout metrics.
+// On success it records the total wait time; on context expiry it increments the
+// timeout counter. All other errors pass through unrecorded.
+func (s *Storage) obtainLock(ctx context.Context, lockKey string, timeout time.Duration) (*storageLock, error) {
+	start := time.Now()
+
+	lock, err := s.locker.Obtain(ctx, lockKey, timeout)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			s.lockMet.timeouts.Add(context.WithoutCancel(ctx), 1)
+		}
+
+		return nil, err
+	}
+
+	s.lockMet.waitDuration.Record(ctx, time.Since(start).Milliseconds())
+
+	return lock, nil
 }

--- a/packages/api/internal/sandbox/storage/redis/main.go
+++ b/packages/api/internal/sandbox/storage/redis/main.go
@@ -40,7 +40,10 @@ type Storage struct {
 	publisher    *publisher
 	featureFlags *featureflags.Client
 
-	metrics expirationIndexMetrics
+	metrics       expirationIndexMetrics
+	lockMet       lockMetrics
+	transitionMet transitionMetrics
+	scanMet       scanMetrics
 }
 
 // expirationIndexMetrics observes global expiration index consistency.
@@ -53,6 +56,31 @@ type expirationIndexMetrics struct {
 	sweptOrphan        metric.MeasurementOption
 	sweptDeadExecution metric.MeasurementOption
 	sweptInvalid       metric.MeasurementOption
+
+	// teamIndexSize records each team's sandbox index SET cardinality once per heal pass.
+	teamIndexSize metric.Int64Histogram
+	// indexSize records the global expiration ZSET cardinality once per heal pass.
+	indexSize metric.Int64Histogram
+	// sweepDuration records wall-clock time of each ExpiredItems call.
+	sweepDuration metric.Int64Histogram
+}
+
+type lockMetrics struct {
+	waitDuration metric.Int64Histogram
+	timeouts     metric.Int64Counter
+}
+
+type transitionMetrics struct {
+	callbackFailures metric.Int64Counter
+	duration         metric.Int64Histogram
+	joined           metric.Int64Counter
+	fallbackPolls    metric.Int64Counter
+	mismatches       metric.Int64Counter
+}
+
+type scanMetrics struct {
+	teamsSkipped   metric.Int64Counter
+	corruptRecords metric.Int64Counter
 }
 
 const sweptReasonAttr = "reason"
@@ -73,6 +101,21 @@ func newExpirationIndexMetrics(meter metric.Meter) (expirationIndexMetrics, erro
 		return expirationIndexMetrics{}, fmt.Errorf("expiration index swept counter: %w", err)
 	}
 
+	teamIndexSize, err := telemetry.GetHistogram(meter, telemetry.ApiRedisStorageTeamIndexSize)
+	if err != nil {
+		return expirationIndexMetrics{}, fmt.Errorf("team index size histogram: %w", err)
+	}
+
+	indexSize, err := telemetry.GetHistogram(meter, telemetry.ApiRedisStorageExpirationIndexSize)
+	if err != nil {
+		return expirationIndexMetrics{}, fmt.Errorf("expiration index size histogram: %w", err)
+	}
+
+	sweepDuration, err := telemetry.GetHistogram(meter, telemetry.ApiRedisStorageExpirationIndexSweepDuration)
+	if err != nil {
+		return expirationIndexMetrics{}, fmt.Errorf("expiration index sweep duration histogram: %w", err)
+	}
+
 	return expirationIndexMetrics{
 		indexHealed:        healed,
 		indexRescored:      rescored,
@@ -80,10 +123,76 @@ func newExpirationIndexMetrics(meter metric.Meter) (expirationIndexMetrics, erro
 		sweptOrphan:        metric.WithAttributeSet(attribute.NewSet(attribute.String(sweptReasonAttr, "orphan"))),
 		sweptDeadExecution: metric.WithAttributeSet(attribute.NewSet(attribute.String(sweptReasonAttr, "dead_execution"))),
 		sweptInvalid:       metric.WithAttributeSet(attribute.NewSet(attribute.String(sweptReasonAttr, "invalid"))),
+		teamIndexSize:      teamIndexSize,
+		indexSize:          indexSize,
+		sweepDuration:      sweepDuration,
 	}, nil
 }
 
 const meterScope = "github.com/e2b-dev/infra/packages/api/internal/sandbox/storage/redis"
+
+func newLockMetrics(meter metric.Meter) (lockMetrics, error) {
+	waitDur, err := telemetry.GetHistogram(meter, telemetry.ApiRedisStorageLockWaitDuration)
+	if err != nil {
+		return lockMetrics{}, fmt.Errorf("lock wait duration histogram: %w", err)
+	}
+
+	timeouts, err := telemetry.GetCounter(meter, telemetry.ApiRedisStorageLockTimeouts)
+	if err != nil {
+		return lockMetrics{}, fmt.Errorf("lock timeouts counter: %w", err)
+	}
+
+	return lockMetrics{waitDuration: waitDur, timeouts: timeouts}, nil
+}
+
+func newTransitionMetrics(meter metric.Meter) (transitionMetrics, error) {
+	cbFails, err := telemetry.GetCounter(meter, telemetry.ApiRedisStorageTransitionCallbackFailures)
+	if err != nil {
+		return transitionMetrics{}, fmt.Errorf("transition callback failures counter: %w", err)
+	}
+
+	dur, err := telemetry.GetHistogram(meter, telemetry.ApiRedisStorageTransitionDuration)
+	if err != nil {
+		return transitionMetrics{}, fmt.Errorf("transition duration histogram: %w", err)
+	}
+
+	joined, err := telemetry.GetCounter(meter, telemetry.ApiRedisStorageTransitionJoined)
+	if err != nil {
+		return transitionMetrics{}, fmt.Errorf("transition joined counter: %w", err)
+	}
+
+	fallbacks, err := telemetry.GetCounter(meter, telemetry.ApiRedisStorageTransitionFallbackPolls)
+	if err != nil {
+		return transitionMetrics{}, fmt.Errorf("transition fallback polls counter: %w", err)
+	}
+
+	mismatches, err := telemetry.GetCounter(meter, telemetry.ApiRedisStorageTransitionExecutionMismatches)
+	if err != nil {
+		return transitionMetrics{}, fmt.Errorf("transition execution mismatches counter: %w", err)
+	}
+
+	return transitionMetrics{
+		callbackFailures: cbFails,
+		duration:         dur,
+		joined:           joined,
+		fallbackPolls:    fallbacks,
+		mismatches:       mismatches,
+	}, nil
+}
+
+func newScanMetrics(meter metric.Meter) (scanMetrics, error) {
+	skipped, err := telemetry.GetCounter(meter, telemetry.ApiRedisStorageScanTeamsSkipped)
+	if err != nil {
+		return scanMetrics{}, fmt.Errorf("scan teams skipped counter: %w", err)
+	}
+
+	corrupt, err := telemetry.GetCounter(meter, telemetry.ApiRedisStorageScanCorruptRecords)
+	if err != nil {
+		return scanMetrics{}, fmt.Errorf("scan corrupt records counter: %w", err)
+	}
+
+	return scanMetrics{teamsSkipped: skipped, corruptRecords: corrupt}, nil
+}
 
 func NewStorage(
 	redisClient redis.UniversalClient,
@@ -103,13 +212,31 @@ func NewStorage(
 		return nil, fmt.Errorf("failed to create expiration index metrics: %w", err)
 	}
 
+	lockMet, err := newLockMetrics(meter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create lock metrics: %w", err)
+	}
+
+	transitionMet, err := newTransitionMetrics(meter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transition metrics: %w", err)
+	}
+
+	scanMet, err := newScanMetrics(meter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create scan metrics: %w", err)
+	}
+
 	return &Storage{
-		redisClient:  redisClient,
-		locker:       newStorageLocker(redisClient, subManager, pub),
-		subManager:   subManager,
-		publisher:    pub,
-		featureFlags: featureFlags,
-		metrics:      metrics,
+		redisClient:   redisClient,
+		locker:        newStorageLocker(redisClient, subManager, pub),
+		subManager:    subManager,
+		publisher:     pub,
+		featureFlags:  featureFlags,
+		metrics:       metrics,
+		lockMet:       lockMet,
+		transitionMet: transitionMet,
+		scanMet:       scanMet,
 	}, nil
 }
 

--- a/packages/api/internal/sandbox/storage/redis/scan.go
+++ b/packages/api/internal/sandbox/storage/redis/scan.go
@@ -42,6 +42,7 @@ func (s *Storage) forEachSandboxBatch(ctx context.Context, fn func(teamID string
 				zap.Error(err),
 				logger.WithTeamID(teamID),
 			)
+			s.scanMet.teamsSkipped.Add(ctx, 1)
 
 			continue
 		}
@@ -115,6 +116,7 @@ func (s *Storage) fetchSandboxBatch(ctx context.Context, teamID string, sandboxI
 				zap.Error(err),
 				logger.WithTeamID(teamID),
 			)
+			s.scanMet.corruptRecords.Add(ctx, 1)
 
 			continue
 		}

--- a/packages/api/internal/sandbox/storage/redis/state_change.go
+++ b/packages/api/internal/sandbox/storage/redis/state_change.go
@@ -33,12 +33,14 @@ import (
 // The callback is critical: it deletes the transition key
 // and sets the result value with short TTL to notify waiters of the outcome.
 func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID string, opts sandboxtypes.RemoveOpts) (sandboxtypes.Sandbox, bool, func(context.Context, error), error) {
+	transitionStart := time.Now()
+
 	key := getSandboxKey(teamID.String(), sandboxID)
 	transitionKey := getTransitionKey(teamID.String(), sandboxID)
 	lockKey := redis_utils.GetLockKey(key)
 
 	// Acquire distributed lock
-	lock, err := s.locker.Obtain(ctx, lockKey, lockTimeout)
+	lock, err := s.obtainLock(ctx, lockKey, lockTimeout)
 	if err != nil {
 		return sandboxtypes.Sandbox{}, false, nil, fmt.Errorf("failed to obtain lock: %w", err)
 	}
@@ -79,6 +81,8 @@ func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID
 	// The authority is the equivalent check inside startTransitionScript, which
 	// is atomic with that write.
 	if opts.ExpectExecutionID != "" && sbx.ExecutionID != opts.ExpectExecutionID {
+		s.transitionMet.mismatches.Add(ctx, 1)
+
 		return sbx, false, nil, fmt.Errorf(
 			"sandbox %q is execution %q, expected %q: %w",
 			sandboxID, sbx.ExecutionID, opts.ExpectExecutionID, sandboxtypes.ErrExecutionMismatch,
@@ -162,6 +166,8 @@ func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID
 		// The pin no longer holds. Add is lockless, so the incarnation can have
 		// been replaced since the check above; the script refused rather than
 		// overwrite whatever is there now, and nothing has been written.
+		s.transitionMet.mismatches.Add(ctx, 1)
+
 		return sbx, false, nil, fmt.Errorf(
 			"sandbox %q is no longer execution %q: %w",
 			sandboxID, opts.ExpectExecutionID, sandboxtypes.ErrExecutionMismatch,
@@ -170,15 +176,17 @@ func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID
 
 	logger.L().Debug(ctx, "Started state transition", logger.WithSandboxID(sandboxID), zap.String("state", string(newState)), zap.String("transitionID", transitionID))
 
-	return updated, false, s.createCallback(teamID, sandboxID, transitionKey, resultKey, transitionID, opts.Action), nil
+	return updated, false, s.createCallback(teamID, sandboxID, transitionKey, resultKey, transitionID, opts.Action, transitionStart), nil
 }
 
 // createCallback returns a callback function for completing a transition.
 // For transient actions, it first restores the sandbox state to Running.
 // On success, the callback deletes the transition key and sets empty result.
 // On error, the callback deletes the transition key and sets error message in result.
-func (s *Storage) createCallback(teamID uuid.UUID, sandboxID, transitionKey, resultKey, transitionID string, stateAction sandboxtypes.StateAction) func(context.Context, error) {
+func (s *Storage) createCallback(teamID uuid.UUID, sandboxID, transitionKey, resultKey, transitionID string, stateAction sandboxtypes.StateAction, start time.Time) func(context.Context, error) {
 	return func(cbCtx context.Context, cbErr error) {
+		s.transitionMet.duration.Record(cbCtx, time.Since(start).Milliseconds())
+
 		logger.L().Debug(cbCtx, "Transition complete", logger.WithSandboxID(sandboxID), zap.String("state", string(stateAction.TargetState)), zap.String("transitionID", transitionID), zap.Error(cbErr))
 
 		var restoreErr error
@@ -187,9 +195,10 @@ func (s *Storage) createCallback(teamID uuid.UUID, sandboxID, transitionKey, res
 		}
 
 		lockKey := redis_utils.GetLockKey(transitionKey)
-		lock, err := s.locker.Obtain(cbCtx, lockKey, lockTimeout)
+		lock, err := s.obtainLock(cbCtx, lockKey, lockTimeout)
 		if err != nil {
 			logger.L().Warn(cbCtx, "Failed to obtain lock in callback", logger.WithSandboxID(sandboxID), zap.String("transitionID", transitionID), zap.Error(err))
+			s.transitionMet.callbackFailures.Add(context.WithoutCancel(cbCtx), 1)
 
 			return
 		}
@@ -300,6 +309,8 @@ func (s *Storage) waitForTransition(
 		case <-ch:
 			return s.checkTransitionResult(ctx, resultKey)
 		case <-ticker.C:
+			s.transitionMet.fallbackPolls.Add(ctx, 1)
+
 			// Fallback poll: check whether the transition key is still present.
 			currentID, err := s.redisClient.Get(ctx, transitionKey).Result()
 			if errors.Is(err, redis.Nil) || currentID != transitionID {
@@ -354,6 +365,7 @@ func (s *Storage) handleExistingTransition(
 		// The caller inherits the in-flight transition's result without
 		// doing the work itself: this is a joiner.
 		joined.Mark(ctx)
+		s.transitionMet.joined.Add(ctx, 1)
 
 		logger.L().Debug(ctx, "State transition already in progress to the same state, waiting",
 			logger.WithSandboxID(sbx.SandboxID),

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -146,6 +146,34 @@ const (
 	// score drifted from the stored EndTime and were re-scored by the evictor
 	// scan. Sustained non-zero rate means score updates are being lost.
 	ApiRedisStorageExpirationIndexRescored CounterType = "api.redis_storage.expiration_index.rescored"
+
+	// ApiRedisStorageLockTimeouts counts Obtain calls whose context expired
+	// while waiting for the distributed sandbox lock.
+	ApiRedisStorageLockTimeouts CounterType = "api.redis_storage.lock.timeout_total"
+
+	// ApiRedisStorageTransitionCallbackFailures counts createCallback closures
+	// that could not obtain the lock, leaving waiters without a result notification.
+	ApiRedisStorageTransitionCallbackFailures CounterType = "api.redis_storage.transition.callback_failures_total"
+
+	// ApiRedisStorageTransitionJoined counts StartRemoving calls that joined an
+	// in-flight transition to the same target state rather than starting their own.
+	ApiRedisStorageTransitionJoined CounterType = "api.redis_storage.transition.joined_total"
+
+	// ApiRedisStorageTransitionFallbackPolls counts waitForTransition iterations
+	// driven by the 1-second fallback ticker (PubSub notification was missed).
+	ApiRedisStorageTransitionFallbackPolls CounterType = "api.redis_storage.transition.wait_fallback_polls_total"
+
+	// ApiRedisStorageTransitionExecutionMismatches counts StartRemoving calls
+	// refused because the sandbox ExecutionID did not match the caller's pin.
+	ApiRedisStorageTransitionExecutionMismatches CounterType = "api.redis_storage.transition.execution_mismatch_total"
+
+	// ApiRedisStorageScanTeamsSkipped counts per-team scan failures silenced
+	// by forEachSandboxBatch (the team is skipped; remaining teams still scan).
+	ApiRedisStorageScanTeamsSkipped CounterType = "api.redis_storage.scan.teams_skipped_total"
+
+	// ApiRedisStorageScanCorruptRecords counts sandbox records that failed
+	// JSON unmarshal during a scan batch and were skipped.
+	ApiRedisStorageScanCorruptRecords CounterType = "api.redis_storage.scan.corrupt_records_total"
 )
 
 const (
@@ -281,6 +309,26 @@ const (
 const (
 	ApiRedisStoragePublisherPublishDuration HistogramType = "api.redis_storage.publisher.publish.duration"
 
+	// ApiRedisStorageTeamIndexSize records the SCARD of each team's sandbox
+	// index SET once per heal pass (every 5 min). p99/max detects unbounded growth.
+	ApiRedisStorageTeamIndexSize HistogramType = "api.redis_storage.team_index.size"
+
+	// ApiRedisStorageExpirationIndexSize records the global expiration ZSET
+	// cardinality once per heal pass.
+	ApiRedisStorageExpirationIndexSize HistogramType = "api.redis_storage.expiration_index.size"
+
+	// ApiRedisStorageExpirationIndexSweepDuration records the wall-clock time
+	// of each ExpiredItems (evictor scan) call in milliseconds.
+	ApiRedisStorageExpirationIndexSweepDuration HistogramType = "api.redis_storage.expiration_index.sweep_duration"
+
+	// ApiRedisStorageLockWaitDuration records the total wait time inside Obtain
+	// (first tryLock attempt until the lock is held), per successful acquisition.
+	ApiRedisStorageLockWaitDuration HistogramType = "api.redis_storage.lock.wait_duration"
+
+	// ApiRedisStorageTransitionDuration records the wall-clock time from
+	// StartRemoving setting the transition key until the callback writes the result.
+	ApiRedisStorageTransitionDuration HistogramType = "api.redis_storage.transition.duration"
+
 	// Firecracker net histograms — per-sandbox distribution per metrics flush, no sandbox_id.
 	// Firecracker serializes SharedIncMetric as per-flush deltas (default flush interval: 60 s).
 	// Symmetric TX/RX metrics carry a direction=tx/rx attribute; TX-only metrics always use direction=tx.
@@ -379,6 +427,14 @@ var counterDesc = map[CounterType]string{
 	ApiRedisStorageExpirationIndexHealed:   "Sandboxes re-added to the global expiration index by the healer; sustained non-zero rate means index writes are being lost",
 	ApiRedisStorageExpirationIndexSwept:    "Members removed from the global expiration index by the evictor scan (reason=orphan|dead_execution|invalid)",
 	ApiRedisStorageExpirationIndexRescored: "Live expiration index members re-scored after drifting from the stored EndTime",
+
+	ApiRedisStorageLockTimeouts:                 "Obtain calls whose context expired while waiting for the distributed sandbox lock",
+	ApiRedisStorageTransitionCallbackFailures:   "createCallback closures that could not obtain the lock, leaving waiters without a result notification",
+	ApiRedisStorageTransitionJoined:             "StartRemoving calls that joined an in-flight transition to the same target state instead of starting a new one",
+	ApiRedisStorageTransitionFallbackPolls:      "waitForTransition loop iterations driven by the 1-second fallback ticker (PubSub notification missed)",
+	ApiRedisStorageTransitionExecutionMismatches: "StartRemoving calls refused because the sandbox ExecutionID did not match the caller's pin",
+	ApiRedisStorageScanTeamsSkipped:             "Per-team scan failures silenced by forEachSandboxBatch; the team is skipped but remaining teams still scan",
+	ApiRedisStorageScanCorruptRecords:           "Sandbox records that failed JSON unmarshal during a scan batch and were skipped",
 }
 
 var counterUnits = map[CounterType]string{
@@ -423,6 +479,14 @@ var counterUnits = map[CounterType]string{
 	ApiRedisStorageExpirationIndexHealed:   "{sandbox}",
 	ApiRedisStorageExpirationIndexSwept:    "{member}",
 	ApiRedisStorageExpirationIndexRescored: "{member}",
+
+	ApiRedisStorageLockTimeouts:                  "{call}",
+	ApiRedisStorageTransitionCallbackFailures:     "{callback}",
+	ApiRedisStorageTransitionJoined:              "{call}",
+	ApiRedisStorageTransitionFallbackPolls:       "{poll}",
+	ApiRedisStorageTransitionExecutionMismatches: "{call}",
+	ApiRedisStorageScanTeamsSkipped:              "{team}",
+	ApiRedisStorageScanCorruptRecords:            "{record}",
 }
 
 var observableCounterDesc = map[ObservableCounterType]string{
@@ -562,6 +626,12 @@ func GetGaugeInt(meter metric.Meter, name GaugeIntType) (metric.Int64ObservableG
 var histogramDesc = map[HistogramType]string{
 	ApiRedisStoragePublisherPublishDuration: "Duration of a single Redis PUBLISH round-trip from the storage publisher",
 
+	ApiRedisStorageTeamIndexSize:                "SCARD of a team's sandbox index SET sampled once per heal pass; p99/max detects unbounded growth",
+	ApiRedisStorageExpirationIndexSize:          "Global expiration ZSET cardinality sampled once per heal pass",
+	ApiRedisStorageExpirationIndexSweepDuration: "Wall-clock time of each ExpiredItems (evictor scan) call",
+	ApiRedisStorageLockWaitDuration:             "Total wait time in Obtain from first tryLock attempt until the lock is held, per successful acquisition",
+	ApiRedisStorageTransitionDuration:           "Wall-clock time from StartRemoving setting the transition key until the callback writes the result",
+
 	BuildDurationHistogramName:                 "Time taken to build a template",
 	BuildPhaseDurationHistogramName:            "Time taken to build each phase of a template",
 	BuildStepDurationHistogramName:             "Time taken to build each step of a template",
@@ -630,6 +700,12 @@ var histogramDesc = map[HistogramType]string{
 
 var histogramUnits = map[HistogramType]string{
 	ApiRedisStoragePublisherPublishDuration: "ms",
+
+	ApiRedisStorageTeamIndexSize:                "{entry}",
+	ApiRedisStorageExpirationIndexSize:          "{entry}",
+	ApiRedisStorageExpirationIndexSweepDuration: "ms",
+	ApiRedisStorageLockWaitDuration:             "ms",
+	ApiRedisStorageTransitionDuration:           "ms",
 
 	BuildDurationHistogramName:                    "ms",
 	BuildPhaseDurationHistogramName:               "ms",


### PR DESCRIPTION
## Summary

Implements the 8 observability gaps identified in #3607, plus the index-size and sweep-duration instrumentation from the related issues (#3605 / #3606).

**Lock** (`lock.go`)
- `api.redis_storage.lock.wait_duration` ms histogram — total wait in `Obtain` per successful acquisition, via a new `obtainLock` wrapper on `Storage`. Replaces the two direct `s.locker.Obtain` call sites in `state_change.go`.
- `api.redis_storage.lock.timeout_total` counter — `Obtain` calls whose context expired before the lock was held.

**Transition** (`state_change.go`)
- `api.redis_storage.transition.duration` ms histogram — wall-clock from `StartRemoving` setting the transition key until the callback writes the result (`transitionStart` captured before the lock, passed into the callback closure).
- `api.redis_storage.transition.execution_mismatch_total` counter — both `ErrExecutionMismatch` paths in `StartRemoving` (early refusal + Lua script refused).
- `api.redis_storage.transition.callback_failures_total` counter — callback closures that returned early because the callback lock was not obtained (waiters receive no result notification on this path).
- `api.redis_storage.transition.joined_total` counter — `StartRemoving` calls that joined an in-flight transition to the same target state.
- `api.redis_storage.transition.wait_fallback_polls_total` counter — each 1-second ticker iteration in `waitForTransition` (PubSub notification missed or dropped).

**Scan** (`scan.go`)
- `api.redis_storage.scan.teams_skipped_total` counter — per-team failures silenced by `forEachSandboxBatch`'s `continue`.
- `api.redis_storage.scan.corrupt_records_total` counter — records failing `json.Unmarshal` in `fetchSandboxBatch`.

**Index size / sweep** (`heal.go`, `items.go`)
- `api.redis_storage.team_index.size` {entry} histogram — per-team `SCARD` pipelined in `recordTeamIndexSizes`, once per heal pass (5 min). p99/max detects unbounded growth.
- `api.redis_storage.expiration_index.size` {entry} histogram — global expiration ZSET `ZCARD`, piggybacked on the same heal pass.
- `api.redis_storage.expiration_index.sweep_duration` ms histogram — wall-clock of each `ExpiredItems` (evictor scan) call.

All metric names registered in `packages/shared/pkg/telemetry/meters.go` with descriptions and units.

Closes #3607

## Test plan

- [ ] `go build ./packages/api/internal/sandbox/storage/redis/...` passes (verified locally)
- [ ] `go vet ./packages/api/internal/sandbox/storage/redis/... ./packages/shared/pkg/telemetry/...` clean (verified locally)
- [ ] Integration tests pass in CI (requires Docker / Redis testcontainer)
- [ ] After deploy: `api.redis_storage.lock.wait_duration`, `transition.duration`, `expiration_index.sweep_duration` histograms visible in Grafana
- [ ] Confirm `transition.execution_mismatch_total` stays near-zero under normal traffic; spikes on execution-pinned kill races