### PR TITLE
fix(envd): bind HTTP listener before sync init chain to eliminate startup race

### DIFF
--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -179,6 +180,20 @@ func run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Bind the listener before any blocking initializer so the TCP port is
+	// reachable from process start. Incoming connections are queued in the
+	// kernel's accept backlog; nothing is dispatched until s.Serve(ln) below.
+	// Without this, a slow or hanging initializer (e.g. writeCgroupProp under
+	// memory pressure) produces a window where the process is alive but the port
+	// returns ECONNREFUSED — indistinguishable from a crashed envd to any
+	// TCP-based health check or orchestrator readiness probe.
+	ln, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
+	if err != nil {
+		return fmt.Errorf("bind envd listener: %w", err)
+	}
+	defer ln.Close()
+	fmt.Fprintf(os.Stderr, "envd: HTTP listener bound on :%d\n", port)
+
 	if err := os.MkdirAll(host.E2BRunDir, 0o755); err != nil {
 		fmt.Fprintf(os.Stderr, "error creating E2B run directory: %v\n", err)
 	}
@@ -207,7 +222,9 @@ func run() error {
 	fsLogger := l.With().Str("logger", "filesystem").Logger()
 	filesystemService := filesystemRpc.Handle(m, &fsLogger, defaults)
 
+	fmt.Fprintf(os.Stderr, "envd startup: creating cgroup manager\n")
 	cgroupManager := createCgroupManager()
+	fmt.Fprintf(os.Stderr, "envd startup: cgroup manager ready\n")
 	defer func() {
 		err := cgroupManager.Close()
 		if err != nil {
@@ -445,7 +462,7 @@ func run() error {
 		}
 	})
 
-	err := s.ListenAndServe()
+	err = s.Serve(ln)
 	// Signal goroutines to stop before deferred cleanup closes their resources.
 	// TODO: shutdown synchronization needs to be revisited.
 	cancel()

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.7.0" // x-release-please-version
+const Version = "0.7.1" // x-release-please-version


### PR DESCRIPTION
## Problem

Closes #3610

`run()` in `packages/envd/main.go` calls `s.ListenAndServe()` as the last statement, after a long synchronous init chain. Any blocking call in that chain — most concretely `writeCgroupProp` writing `memory.high`/`memory.max` to cgroupv2 under host memory pressure — leaves port `:49983` returning `ECONNREFUSED` for the entire init duration while the process appears alive.

Verified on dev (main branch, Linux 6.8, cgroupv2):

```
# 200ms synthetic init delay, current behaviour
[0–200ms]  ECONNREFUSED — process alive but no listener
[201ms]    port open

# same delay, with this fix
[0ms]      port open — kernel queues SYNs during init
[201ms]    port open — Serve() starts accepting
```

## Changes

**`packages/envd/main.go`** (+19 / -1)

- Call `net.Listen(tcp, addr)` at the top of `run()`, before any blocking initializer.  
  Incoming connections are queued in the kernel accept backlog (`SO_BACKLOG`) and dispatched once `s.Serve(ln)` starts — HTTP semantics are unchanged.
- Replace `s.ListenAndServe()` with `s.Serve(ln)`.
- Add `defer ln.Close()` so the port is released on any early-return error path.
- Add stderr phase logs (`envd startup: creating cgroup manager` / `ready`) around the most likely blocking point, so a hung init appears in logs rather than a silent stall.

**`packages/envd/pkg/version.go`**

- Bump `0.7.0` → `0.7.1` (behaviour change per project convention).

## Why this is safe

`net.Listener` + `Server.Serve` is exactly what `ListenAndServe` does internally — this splits it into two steps with no semantic difference. Connections that arrive while init is still running are held in the kernel backlog and processed normally once `Serve` starts accepting.

## Testing

- All existing tests pass (the two `TestIsPathOnNetworkMount` / `TestCreateWatcherOnNetworkMount` failures are pre-existing: `bindfs` not installed in dev).
- Manually confirmed on dev: `envd: HTTP listener bound on :49983` appears as the first stderr line, port visible in `ss -tlnp` within 50 ms of process start, before `envd startup: cgroup manager ready`.