### PR TITLE
docs(architecture): fix volume-content diagram rendering

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -381,7 +381,7 @@ sequenceDiagram
     API->>PG: persist / load volume row
     API->>API: mint JWT (aud = https://api.&lt;domain&gt;)<br/>resolve domain
     API-->>U: { volumeID, name, token, domain? }
-    Note over U: domain is returned only for BYOC teams;<br/>SDK stores it and falls back to api.&lt;E2B_DOMAIN&gt; otherwise
+    Note over U: domain is returned only for BYOC teams#59;<br/>SDK stores it and falls back to api.&lt;E2B_DOMAIN&gt; otherwise
     U->>VC: /volumecontent/{id}/... at api.&lt;domain&gt;<br/>Authorization: Bearer token
     VC->>VC: verify token (audience must match its own origin)
     VC-->>U: file content


### PR DESCRIPTION
The volume-content sequence diagram in `docs/ARCHITECTURE.md` fails to render on GitHub because the semicolon after `BYOC teams` is parsed as a statement separator. Escape it as `#59;` so the note displays as written.

<details>
<summary>Rendering before and after</summary>

**Before** ([current main](https://github.com/e2b-dev/infra/blob/3cbcd6419c1a6dcf78b72b0239fd471c9e038af2/docs/ARCHITECTURE.md#volume-content))

GitHub displays `Unable to render rich display`:

```text
Parse error on line 12:
... for BYOC teams;<br/>SDK stores it and f
-----------------------^
```

**After** ([updated file](https://github.com/HeyiSun/infra/blob/8d4d30dd66a079692dff2d2ed44ba4535e1d1ac3/docs/ARCHITECTURE.md#volume-content))

```mermaid
sequenceDiagram
    autonumber
    participant U as SDK
    participant API as API
    participant PG as PostgreSQL
    participant VC as volume-content API (belt)

    U->>API: POST /volumes (create) or GET /volumes/{id}
    API->>PG: persist / load volume row
    API->>API: mint JWT (aud = https://api.&lt;domain&gt;)<br/>resolve domain
    API-->>U: { volumeID, name, token, domain? }
    Note over U: domain is returned only for BYOC teams#59;<br/>SDK stores it and falls back to api.&lt;E2B_DOMAIN&gt; otherwise
    U->>VC: /volumecontent/{id}/... at api.&lt;domain&gt;<br/>Authorization: Bearer token
    VC->>VC: verify token (audience must match its own origin)
    VC-->>U: file content
```

</details>

Checked all six diagrams with Mermaid 11.17.2 and in GitHub's preview. `git diff --check` passes.

AI-assisted: yes.
