### PR TITLE
fix(envd): mount sandbox volumes with nolock to stop flock hang (#3619)

### DIFF
--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -618,6 +618,12 @@ var nfsOptions = strings.Join([]string{
 	"nfsvers=3",      // nfs proxy is nfs version 3
 	"noacl",          // no reason for acl in the sandbox
 
+	// Resolve locks node-locally. The nfs proxy has no lock manager and its
+	// portmap never registers NLM, so without this a hard-mounted lock request
+	// (e.g. flock) is sent to the proxy, gets port 0, and retries forever in
+	// uninterruptible sleep. See github.com/e2b-dev/infra issue #3619.
+	"nolock",
+
 	// disable caching so that pause/resume works correctly
 	"noac",
 	"lookupcache=none",

--- a/packages/envd/internal/services/cgroups/hierarchy.go
+++ b/packages/envd/internal/services/cgroups/hierarchy.go
@@ -16,24 +16,23 @@ const ProcSelfCgroup = "/proc/self/cgroup"
 // path in the resume, not by caution -- a list that grew with the customer population
 // would defeat the point of walking the hierarchy in the first place.
 //
-//   - init.scope holds systemd (PID 1). The resume thaw is deferred inside the /init
-//     handler, so it runs after setupNFS; volume mounts are nfsvers=3 without nolock, so
-//     mount.nfs needs rpc.statd, which it asks systemd to start. Freeze PID 1 and every
-//     volume-mounting sandbox hangs to the NFS mount timeout and fails. Keeping systemd
-//     live is also what lets envd's own Restart=always fire if envd dies mid-resume.
+//   - init.scope holds systemd (PID 1). Keeping it live is what lets envd's own
+//     Restart=always fire if envd dies mid-resume, and PID 1 must never be frozen
+//     regardless. (Volume mounts now carry nolock, so mount.nfs no longer needs
+//     rpc.statd during setupNFS -- see the rpcbind note below.)
 //   - systemd-journald.service drains the socket envd logs to (its unit has
 //     Wants=systemd-journald.socket). Freeze it and once the socket buffer fills, envd's
 //     own log writes block -- turning a slow resume into a wedged one.
 //   - socats is envd's port forwarding. It is already excluded from the freeze today
 //     (ProcessTypeSocat is absent from WorkloadProcessTypes); this preserves that.
 //   - rpcbind.service holds the local portmapper, and rpcbind.socket is its activation
-//     pair. nfsvers=3 mounts carry no `nolock`, so mount.nfs starts rpc.statd, which
-//     registers with the LOCAL portmapper -- and the resume thaw is deferred inside the
-//     /init handler, so it runs after setupNFS. Measured on a dev guest: with rpcbind
-//     frozen, `rpcinfo -p 127.0.0.1` goes from answering in 0.145s to timing out, and a
-//     v3 mount attempt from a clean 3.2s error to a 25s hang. The socket unit holds no
-//     processes today, so freezing it stops nothing -- it is here because activation could
-//     later place a process into a cgroup we froze, and rpcbind is one service in practice.
+//     pair. Volume mounts now carry `nolock` (issue #3619), so mount.nfs no longer starts
+//     rpc.statd and the resume mount path no longer depends on the local portmapper.
+//     These entries are kept defensively: before nolock, a frozen rpcbind turned a v3
+//     mount from a clean 3.2s error into a 25s hang (measured on a dev guest), so keeping
+//     OUR own portmapper live across a pause is cheap insurance against any other resume
+//     path that might come to rely on it. The socket unit holds no processes today, so
+//     freezing it stops nothing; it rides along with its service for the same reason.
 //
 // Deliberately NOT here, so the list stays justified rather than merely cautious:
 // run-rpc_pipefs.mount (a mount unit, 0 processes, so freezing its cgroup stops nothing)

--- a/packages/orchestrator/pkg/nfsproxy/e2e_test.sh
+++ b/packages/orchestrator/pkg/nfsproxy/e2e_test.sh
@@ -109,4 +109,16 @@ test ! -f "${tmpdir}/dir1/subdir/b.txt"
 rm -rf "${tmpdir}/dir1"
 test ! -d "${tmpdir}/dir1"
 
+# 13) advisory locking (flock) must resolve locally and NOT hang.
+# The proxy has no lock manager, so the volume must be mounted with nolock
+# (see packages/envd/internal/api/init.go). Without it the kernel sends the
+# lock to the proxy as an NLM request, gets port 0, and a hard mount retries
+# forever -- flock wedges in uninterruptible sleep. Guard against that
+# regression: a 10s timeout turns a hang into a loud failure instead of a
+# stuck suite. See github.com/e2b-dev/infra issue #3619.
+if ! timeout 10 flock "${tmpdir}/test.txt" -c true; then
+  echo "flock did not resolve within 10s under ${test_path} (missing nolock?)" >&2
+  exit 1
+fi
+
 echo "POSIX filesystem operations OK under ${test_path}"


### PR DESCRIPTION
## Summary

`flock()` on a mounted sandbox volume hangs forever in uninterruptible sleep (state `D`), cannot be killed even with `SIGKILL`, and holds the sandbox until it is destroyed. Reads and writes are fine; only locking hangs.

Root cause: `nfsOptions` in `packages/envd/internal/api/init.go` sets neither `nolock` nor `local_lock`, so `local_lock` defaults to `none` and the kernel sends every advisory lock to the nfs proxy as an NLM request. The proxy has no lock manager and its portmap (`packages/orchestrator/pkg/portmap`) never registers NLM (`100021`), so `PMAPPROC_GETPORT` returns port `0`. Because the mount is `hard`, the client retries the bind forever.

Fix: add `nolock` to `nfsOptions`. Locks then resolve node-locally, which is the correct semantics given the proxy has no lock manager — and matches how the same server is mounted everywhere else in the repo (nfsproxy e2e `nolock`, Filestore chunk cache `nolock`).

## Changes

- `packages/envd/internal/api/init.go` — add `nolock` to `nfsOptions` (the fix).
- `packages/envd/internal/services/cgroups/hierarchy.go` — the pause/resume freeze allowlist documented its `rpcbind`/`rpc-statd` entries as justified by "mounts have no nolock, so mount.nfs starts rpc.statd". With `nolock`, `mount.nfs` no longer starts `rpc.statd`, so that justification is gone. Comment updated to reflect reality; the entries are **kept defensively** (re-justified inline) rather than pruned, to keep this PR's blast radius on freeze behavior at zero.
- `packages/orchestrator/pkg/nfsproxy/e2e_test.sh` — add an `flock` assertion (10s timeout) to the POSIX suite so a future regression that drops `nolock` fails loudly instead of hanging the suite. This closes the gap that let the bug ship: the e2e harness (`e2e_start.sh`) mounts with `nolock`, so it never exercised the production config.

## Why this is not a duplicate

Checked before opening:
- `gh issue view 3619 --repo e2b-dev/infra --comments` — no comments, no linked PR.
- `gh pr list --state open --search '3619 in:body'` — none.
- `gh pr list --state open --search 'nolock' / 'flock' / 'nfsOptions'` — no PR touching this.

## Tests run

Reproduced and verified on a dev host using the **real** proxy + portmap code (unmodified), two containers on a bridge network mirroring production topology (client with local rpcbind+statd; server = go-nfs proxy+portmap registering only NFS/mountd on 2049, never NLM):

**Before (current prod options, no `nolock`)** — mount reports `local_lock=none`; `flock` on the volume hangs, killed by timeout (exit 124). Kernel evidence matches the issue exactly:

```
state D, wchan rpc_wait_bit_killable
rpc_wait_bit_killable -> __rpc_execute -> rpc_call_sync -> nlmclnt_call ->
nlmclnt_lock -> nlmclnt_proc -> nfs3_proc_lock -> do_setlk -> nfs_flock ->
__do_sys_flock -> do_syscall_64
```

Local-disk `flock` (control) and all reads/writes succeed.

**After (with `nolock`)** — same unmodified proxy; mount reports `local_lock=all`; `flock` on the volume returns `0` (`LOCKED_OK`).

Also:
- `go build ./...` (envd) — OK.
- `go vet` on `internal/api`, `internal/services/cgroups`, `pkg/nfsproxy` — OK.
- `gofmt -l` on changed Go files — clean.
- `bash -n e2e_test.sh` — OK; ran `e2e_test.sh` standalone, new flock assertion passes.

The full `TestIntegrationTest` could not run on this shared box because the host `rpcbind` already holds `:111` (a pre-existing environment constraint, not related to this change); the flock behavior was instead proven with the isolated two-container harness above.

## Model evaluation

Not applicable — no change to model output, accuracy, or serving. This only changes NFS mount options and a test/comment.

## AI assistance

AI assistance was used to investigate, reproduce, and draft this change. A human submitter has reviewed every changed line and the reproduction.

Fixes #3619
