### PR TITLE
docs: fix volume-content mermaid diagram rendering

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -385,10 +385,10 @@ sequenceDiagram
 
     U->>API: POST /volumes (create) or GET /volumes/{id}
     API->>PG: persist / load volume row
-    API->>API: mint JWT (aud = https://api.&lt;domain&gt;)<br/>resolve domain
+    API->>API: mint JWT (aud = https://api.#lt;domain#gt;)<br/>resolve domain
     API-->>U: { volumeID, name, token, domain? }
-    Note over U: domain is returned only for BYOC teams;<br/>SDK stores it and falls back to api.&lt;E2B_DOMAIN&gt; otherwise
-    U->>VC: /volumecontent/{id}/... at api.&lt;domain&gt;<br/>Authorization: Bearer token
+    Note over U: domain is returned only for BYOC teams#59;<br/>SDK stores it and falls back to api.#lt;E2B_DOMAIN#gt; otherwise
+    U->>VC: /volumecontent/{id}/... at api.#lt;domain#gt;<br/>Authorization: Bearer token
     VC->>VC: verify token (audience must match its own origin)
     VC-->>U: file content
 ```


### PR DESCRIPTION
## Problem

The Volume content sequence diagram in `docs/ARCHITECTURE.md` does not render on GitHub:

```text
Parse error on line 12:
... for BYOC teams;<br/>SDK stores it and f
-----------------------^
```

Mermaid sequence diagrams treat `;` as a statement separator (equivalent to a newline). After `BYOC teams;`, the parser starts a new statement at `<br/>` and fails. The same diagram also uses HTML `&lt;` / `&gt;` for domain placeholders; those are invalid tokens in current Mermaid.

This is a docs-only bug. CONTRIBUTING.md says documentation fixes can skip the issue-first step.

## Fix

Use [Mermaid entity codes](https://mermaid.js.org/syntax/sequenceDiagram.html#entity-codes-to-escape-characters) in that sequence diagram, which is the documented way to keep the original text:

| character | in source |
|---|---|
| `;` | `#59;` |
| `<` | `#lt;` |
| `>` | `#gt;` |

The rendered note and `api.<domain>` placeholders stay the same. Surrounding prose is unchanged.

<details>
<summary>Diagram after the change (should render below)</summary>

```mermaid
sequenceDiagram
    autonumber
    participant U as SDK
    participant API as API
    participant PG as PostgreSQL
    participant VC as volume-content API (belt)

    U->>API: POST /volumes (create) or GET /volumes/{id}
    API->>PG: persist / load volume row
    API->>API: mint JWT (aud = https://api.#lt;domain#gt;)<br/>resolve domain
    API-->>U: { volumeID, name, token, domain? }
    Note over U: domain is returned only for BYOC teams#59;<br/>SDK stores it and falls back to api.#lt;E2B_DOMAIN#gt; otherwise
    U->>VC: /volumecontent/{id}/... at api.#lt;domain#gt;<br/>Authorization: Bearer token
    VC->>VC: verify token (audience must match its own origin)
    VC-->>U: file content
```

</details>

## Validation

- Reproduced the GitHub parse error against current `main`
- Parsed all six diagrams in `docs/ARCHITECTURE.md` with Mermaid 11.12.0 after the change
- Docs-only; `make test` / `make lint` do not apply

Related: #3621 also addresses the GitHub parse error by escaping the semicolon. This change also replaces the HTML entities so the diagram parses in current Mermaid, not only GitHub's renderer.
