### PR TITLE
fix(shared): avoid lost wakeups when canceling Acquire

### DIFF
--- a/packages/shared/pkg/utils/resizable_semaphore.go
+++ b/packages/shared/pkg/utils/resizable_semaphore.go
@@ -41,8 +41,8 @@ func (s *AdjustableSemaphore) Acquire(ctx context.Context, n int64) error {
 
 	// Wake ->cond.Wait when ctx is canceled.
 	stop := context.AfterFunc(ctx, func() {
-		s.cond.L.Lock()
-		defer s.cond.L.Unlock()
+		s.mu.Lock()
+		defer s.mu.Unlock()
 		s.cond.Broadcast()
 	})
 	defer stop() // ensure we don’t leak the callback

--- a/packages/shared/pkg/utils/resizable_semaphore.go
+++ b/packages/shared/pkg/utils/resizable_semaphore.go
@@ -39,8 +39,12 @@ func (s *AdjustableSemaphore) Acquire(ctx context.Context, n int64) error {
 		return fmt.Errorf("acquiring less than or equal to 0 elements is not supported, got: %d", n)
 	}
 
-	// Wake ->cond.Wait when ctx is canceled.
-	stop := context.AfterFunc(ctx, s.cond.Broadcast)
+	// Hold mu so cancellation cannot broadcast between the context check and Wait.
+	stop := context.AfterFunc(ctx, func() {
+		s.cond.L.Lock()
+		defer s.cond.L.Unlock()
+		s.cond.Broadcast()
+	})
 	defer stop() // ensure we don’t leak the callback
 
 	for s.used+n > s.limit {

--- a/packages/shared/pkg/utils/resizable_semaphore.go
+++ b/packages/shared/pkg/utils/resizable_semaphore.go
@@ -39,7 +39,7 @@ func (s *AdjustableSemaphore) Acquire(ctx context.Context, n int64) error {
 		return fmt.Errorf("acquiring less than or equal to 0 elements is not supported, got: %d", n)
 	}
 
-	// Hold mu so cancellation cannot broadcast between the context check and Wait.
+	// Wake ->cond.Wait when ctx is canceled.
 	stop := context.AfterFunc(ctx, func() {
 		s.cond.L.Lock()
 		defer s.cond.L.Unlock()

--- a/packages/shared/pkg/utils/resizable_semaphore_test.go
+++ b/packages/shared/pkg/utils/resizable_semaphore_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -272,6 +273,101 @@ func TestAcquireRespectsContextCancel(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Acquire didn’t return after context cancellation")
 	}
+}
+
+// Pause after observing a live context, before Acquire can register its wait.
+type semaphoreCancelContext struct {
+	context.Context
+	checked chan struct{}
+	resume  chan struct{}
+	once    sync.Once
+}
+
+func (c *semaphoreCancelContext) Err() error {
+	err := c.Context.Err()
+	if err == nil {
+		c.once.Do(func() {
+			close(c.checked)
+			<-c.resume
+		})
+	}
+
+	return err
+}
+
+type semaphoreWaitLocker struct {
+	sync.Locker
+	waiting  chan struct{}
+	locking  chan struct{}
+	waitOnce sync.Once
+	lockOnce sync.Once
+}
+
+func (l *semaphoreWaitLocker) Lock() {
+	l.lockOnce.Do(func() { close(l.locking) })
+	l.Locker.Lock()
+}
+
+func (l *semaphoreWaitLocker) Unlock() {
+	l.waitOnce.Do(func() { close(l.waiting) })
+	l.Locker.Unlock()
+}
+
+func TestAcquireCancellationBeforeWait(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		s, err := NewAdjustableSemaphore(1)
+		require.NoError(t, err)
+		require.True(t, s.TryAcquire(1))
+
+		locker := &semaphoreWaitLocker{
+			Locker:  &s.mu,
+			waiting: make(chan struct{}),
+			locking: make(chan struct{}),
+		}
+		s.cond.L = locker
+
+		// An existing waiter makes an unlocked cancellation Broadcast observable.
+		go func() {
+			s.mu.Lock()
+			s.cond.Wait()
+			s.mu.Unlock()
+		}()
+		<-locker.waiting
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		paused := &semaphoreCancelContext{
+			Context: ctx,
+			checked: make(chan struct{}),
+			resume:  make(chan struct{}),
+		}
+		result := make(chan error, 1)
+		go func() { result <- s.Acquire(paused, 1) }()
+		<-paused.checked
+		cancel()
+
+		// With the fix, the callback tries to lock L. Without it, Broadcast
+		// wakes the existing waiter, which tries to lock L. Both happen while
+		// Acquire still holds mu and has not registered its wait.
+		<-locker.locking
+		close(paused.resume)
+		synctest.Wait()
+
+		select {
+		case err := <-result:
+			require.ErrorIs(t, err, context.Canceled)
+		default:
+			// Rescue a stuck waiter so a regression fails without leaking it.
+			s.mu.Lock()
+			s.cond.Broadcast()
+			s.mu.Unlock()
+			synctest.Wait()
+			<-result
+			t.Fatal("Acquire missed cancellation before entering Wait")
+		}
+	})
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/shared/pkg/utils/resizable_semaphore_test.go
+++ b/packages/shared/pkg/utils/resizable_semaphore_test.go
@@ -275,97 +275,48 @@ func TestAcquireRespectsContextCancel(t *testing.T) {
 	}
 }
 
-// Pause after observing a live context, before Acquire can register its wait.
 type semaphoreCancelContext struct {
 	context.Context
-	checked chan struct{}
-	resume  chan struct{}
-	once    sync.Once
+	cancel context.CancelFunc
 }
 
 func (c *semaphoreCancelContext) Err() error {
 	err := c.Context.Err()
 	if err == nil {
-		c.once.Do(func() {
-			close(c.checked)
-			<-c.resume
-		})
+		c.cancel()
+		runtime.Gosched()
 	}
 
 	return err
-}
-
-type semaphoreWaitLocker struct {
-	sync.Locker
-	waiting  chan struct{}
-	locking  chan struct{}
-	waitOnce sync.Once
-	lockOnce sync.Once
-}
-
-func (l *semaphoreWaitLocker) Lock() {
-	l.lockOnce.Do(func() { close(l.locking) })
-	l.Locker.Lock()
-}
-
-func (l *semaphoreWaitLocker) Unlock() {
-	l.waitOnce.Do(func() { close(l.waiting) })
-	l.Locker.Unlock()
 }
 
 func TestAcquireCancellationBeforeWait(t *testing.T) {
 	t.Parallel()
 
 	synctest.Test(t, func(t *testing.T) {
-		s, err := NewAdjustableSemaphore(1)
-		require.NoError(t, err)
-		require.True(t, s.TryAcquire(1))
+		for range 100 {
+			s, err := NewAdjustableSemaphore(1)
+			require.NoError(t, err)
+			require.True(t, s.TryAcquire(1))
 
-		locker := &semaphoreWaitLocker{
-			Locker:  &s.mu,
-			waiting: make(chan struct{}),
-			locking: make(chan struct{}),
-		}
-		s.cond.L = locker
-
-		// An existing waiter makes an unlocked cancellation Broadcast observable.
-		go func() {
-			s.mu.Lock()
-			s.cond.Wait()
-			s.mu.Unlock()
-		}()
-		<-locker.waiting
-
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
-		paused := &semaphoreCancelContext{
-			Context: ctx,
-			checked: make(chan struct{}),
-			resume:  make(chan struct{}),
-		}
-		result := make(chan error, 1)
-		go func() { result <- s.Acquire(paused, 1) }()
-		<-paused.checked
-		cancel()
-
-		// With the fix, the callback tries to lock L. Without it, Broadcast
-		// wakes the existing waiter, which tries to lock L. Both happen while
-		// Acquire still holds mu and has not registered its wait.
-		<-locker.locking
-		close(paused.resume)
-		synctest.Wait()
-
-		select {
-		case err := <-result:
-			require.ErrorIs(t, err, context.Canceled)
-		default:
-			// Rescue a stuck waiter so a regression fails without leaking it.
-			s.mu.Lock()
-			s.cond.Broadcast()
-			s.mu.Unlock()
+			ctx, cancel := context.WithCancel(t.Context())
+			cancelOnCheck := &semaphoreCancelContext{Context: ctx, cancel: cancel}
+			result := make(chan error, 1)
+			go func() { result <- s.Acquire(cancelOnCheck, 1) }()
 			synctest.Wait()
-			<-result
-			t.Fatal("Acquire missed cancellation before entering Wait")
+			cancel()
+
+			select {
+			case err := <-result:
+				require.ErrorIs(t, err, context.Canceled)
+			default:
+				s.mu.Lock()
+				s.cond.Broadcast()
+				s.mu.Unlock()
+				synctest.Wait()
+				<-result
+				t.Fatal("Acquire missed cancellation before entering Wait")
+			}
 		}
 	})
 }


### PR DESCRIPTION
I noticed this while reading through the project code. If cancellation broadcasts after the context check but before `Wait`, `Acquire` can stay blocked until another semaphore update wakes it. This can leave sandbox resume handlers blocked past the 15-second wait for a startup slot, even after the caller times out. Canceled storage uploads can get stuck waiting for a slot too.

The callback now takes the condition lock before broadcasting. I added a regression test for that ordering; it fails on the old code and passes with the fix.

<details>
<summary>Reproduction</summary>

The original callback allows this ordering:

```text
Acquire holds s.mu and checks ctx.Err() == nil
-> the context is canceled
-> AfterFunc calls Broadcast() without taking s.mu
-> Acquire enters Wait(), registers its waiter, and releases s.mu
-> no later wakeup occurs, so Acquire stays blocked despite cancellation
```

The test pauses `Acquire` after its context check, cancels the context, then lets it enter `Wait`. Tested on Go 1.26.6:

```sh
go test -race -run '^TestAcquireCancellationBeforeWait$' -count=1 ./packages/shared/pkg/utils
```

With the original semaphore implementation substituted using Go's `-overlay`, keeping the test unchanged:

```text
--- FAIL: TestAcquireCancellationBeforeWait (0.00s)
    resizable_semaphore_test.go:368: Acquire missed cancellation before entering Wait
```

With the fix, `Acquire` returns `context.Canceled` without an extra wakeup. The test passed 100 times each with 1, 2 and 8 processors. The full utils tests also pass with `-race`.

</details>
