### PR TITLE
fix(clean-nfs-cache): install CA certificates

### DIFF
--- a/packages/orchestrator/Dockerfile.clean-nfs-cache
+++ b/packages/orchestrator/Dockerfile.clean-nfs-cache
@@ -2,6 +2,10 @@ FROM debian:bookworm-20260824-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe
 
 ARG COMMIT_SHA
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 LABEL org.opencontainers.image.title="clean-nfs-cache" \
       org.opencontainers.image.description="E2B privileged NFS cache cleanup CronJob" \
       org.opencontainers.image.source="https://github.com/e2b-dev/infra" \


### PR DESCRIPTION
## Summary

Install Debian's standard CA certificate bundle in the dedicated `clean-nfs-cache` runtime image.

## Why

The image uses Debian slim, which does not include trusted root certificates by default. The staging CronJob therefore failed while initializing its authenticated LaunchDarkly client with:

```text
x509: certificate signed by unknown authority
```

This restores normal Go system-root verification. It does not add a custom certificate, custom TLS transport, or verification bypass.

## Validation

- Built the real linux/amd64 `Dockerfile.clean-nfs-cache` image.
- Verified the final image runs standalone with its existing root user and `/clean-nfs-cache` entrypoint.
- Verified `/etc/ssl/certs/ca-certificates.crt`: 150 parsed roots and successful OpenSSL verification.
- Authenticated successfully to the real staging LaunchDarkly endpoint using the existing secret and a disposable local dry-run cache.
- Confirmed zero x509 errors, zero scanned builds, and zero deletions.
- `go test -count=1 -race -v ./cmd/clean-nfs-cache/...`
- `mise exec -- golangci-lint run ./...`
- `git diff --check origin/main...HEAD`

## Rollout notes

The Debian package is intentionally unversioned so rebuilt images receive current public roots. The base image itself remains digest-pinned.
